### PR TITLE
Fixed references to @cognite/cognitesdk -> @cognite/sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ The SDK supports authentication through api-keys (_for server-side applications_
 
 Install the package with yarn:
 
-    yarn add @cognite/cognitesdk
+    yarn add @cognite/sdk
 
 or npm
 
-    npm install @cognite/cognitesdk --save
+    npm install @cognite/sdk --save
 
 ## Usage
 
 ```js
-const sdk = require('@cognite/cognitesdk');
+const sdk = require('@cognite/sdk');
 
 sdk.configure({
   project,
@@ -36,7 +36,7 @@ sdk.configure({
 ### Using ES modules
 
 ```js
-import * as sdk from '@cognite/cognitesdk';
+import * as sdk from '@cognite/sdk';
 ```
 
 ### Using typescript
@@ -50,7 +50,7 @@ The SDK is written in native typescript, so no extra types needs to be defined.
 Authenticating with an api key should only happen when building server-side applications.
 
 ```js
-const sdk = require('@cognite/cognitesdk');
+const sdk = require('@cognite/sdk');
 sdk.configure({
   project: 'yourProject',
   apiKey: 'yourApiKey',

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -1,4 +1,4 @@
-This project is an example application with `@cognite/cognitesdk` in plain nodejs.
+This project is an example application with `@cognite/sdk` in plain nodejs.
 
 ## Available Scripts
 

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -1,4 +1,4 @@
-const sdk = require('@cognite/cognitesdk');
+const sdk = require('@cognite/sdk');
 
 sdk.configure({
   project: process.env.COGNITE_PROJECT || 'publicdata',

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -1,4 +1,4 @@
-This project is an example application for authentication with `@cognite/cognitesdk` written in React.
+This project is an example application for authentication with `@cognite/sdk` written in React.
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 

--- a/examples/react/src/App.js
+++ b/examples/react/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as sdk from '@cognite/cognitesdk';
+import * as sdk from '@cognite/sdk';
 import qs from 'query-string';
 import './App.css';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Javascript client library for Cognite SDK",
   "contributors": [
     "Fredrik Anfinsen <fredrik.anfinsen@cognite.com>",


### PR DESCRIPTION
In the docs and examples we refer to `@cognite/cognitesdk` which is the old SDK I assume? In this PR, all references are now `@cognite/sdk`.