### PR TITLE
v1.4.3 - Made metadata optional in ThreeD.listNodes, removed docs step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,11 @@ We use `jest` to run tests, see [their documentation](https://github.com/faceboo
 How to release a new version:
 
 1. Create a new branch
-2. Run `yarn docs` to update the documentation
-3. Commit changes (if any)
-4. Run
+2. Commit changes (if any)
+3. Run
     ```bash
     $ npm version [patch/minor/major]
     ```
-5. Push branch and push tags (`git push --tags`)
-6. Create a new pull requests
-7. A new version will be published when PR is merged
+4. Push branch and push tags (`git push --tags`)
+5. Create a new pull requests
+6. A new version will be published when PR is merged

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Javascript client library for Cognite SDK",
   "contributors": [
     "Fredrik Anfinsen <fredrik.anfinsen@cognite.com>",

--- a/src/ThreeD.ts
+++ b/src/ThreeD.ts
@@ -111,7 +111,7 @@ export interface ThreeDListNodesParams {
   depth?: number;
   nodeId?: number;
   includeAncestors?: boolean;
-  metadata: NodeMetadata;
+  metadata?: NodeMetadata;
 }
 
 export interface ThreeDListRevisionsParams {


### PR DESCRIPTION
The `/3d/nodes` API endpoint has an optional `metadata` key (see https://doc.cognitedata.com/api/0.6/#operation/getNodes), but the SDK required them. This is fixed in this PR.

The `yarn docs` is no longer needed as Travis does it for us, so I removed that from the readme.