### PR TITLE
Expose loggedIn status from authorize

### DIFF
--- a/src/Login.ts
+++ b/src/Login.ts
@@ -297,9 +297,7 @@ export class Login {
     if (loginStatus.loggedIn) {
       return {
         ...authTokens,
-        user: loginStatus.user,
-        project: loginStatus.project,
-        projectId: loginStatus.projectId,
+        ...loginStatus,
       };
     }
     return null;


### PR DESCRIPTION
The only prop which is not exposed from `authorize` `loginStatus` is `loggedIn` which can bring a user information about the logging status