### PR TITLE
feat: throw multiError on create assets

### DIFF
--- a/src/__tests__/resources/assets.integration.spec.ts
+++ b/src/__tests__/resources/assets.integration.spec.ts
@@ -1,6 +1,8 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
+import { CogniteError } from '../../error';
+import { CogniteMultiError } from '../../multiError';
 import { Asset } from '../../types/types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
@@ -35,11 +37,82 @@ describe('Asset integration test', () => {
   });
 
   test('create empty asset array', async () => {
-    await expect(
-      client.assets.create([])
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"createAssets.arg0.items: size must be between 1 and 1000 | code: 400"`
+    const err = new CogniteMultiError({
+      succeded: [],
+      failed: [[]],
+      errors: [
+        new CogniteError(
+          'createAssets.arg0.items: size must be between 1 and 1000',
+          400,
+        ),
+      ],
+      responses: [],
+    });
+    await client.assets.create([]).catch(e => {
+      expect(e.missing).toEqual(err.missing);
+      expect(e.failed).toEqual(err.failed);
+      expect(e.succeded).toEqual(err.succeded);
+      expect(e.status).toEqual(err.status);
+      expect(e.errors[0]).toEqual(err.errors[0]);
+      expect(e.responses).toEqual(err.responses);
+    });
+  });
+
+  test('create 1001 assets (1 corrupted): error handling', async () => {
+    const newRootAsset = {
+      ...rootAsset,
+      externalId: 'test-root' + randomInt(),
+    };
+    const corruptedChild = {
+      ...childAsset,
+      extraProp: 'corrupted',
+      parentExternalId: newRootAsset.externalId,
+    };
+    const newChildAsset = {
+      ...childAsset,
+      parentExternalId: newRootAsset.externalId,
+    };
+    const childArr = new Array(999).fill(newChildAsset);
+    try {
+      expect(
+        await client.assets.create([newRootAsset, ...childArr, corruptedChild])
+      ).rejects.toBeTruthy();
+    } catch (e) {
+      expect(e).toBeInstanceOf(CogniteMultiError);
+      if (e instanceof CogniteMultiError) {
+        expect(e.status).toEqual(400);
+        expect(e.failed).toEqual([corruptedChild]);
+        expect(e.succeded).toEqual([newRootAsset, ...childArr]);
+        expect(e.responses[0].items.length).toBe(1000);
+        expect((e.errors[0] as CogniteError).status).toBe(400);
+        expect(e.errors.length).toBe(1);
+        expect(e.responses.length).toBe(1);
+        await client.assets.delete(
+          e.responses[0].items.map((asset: any) => ({ id: asset.id }))
+        );
+      }
+    }
+  });
+
+  test('create 1001 assets sequencially', async () => {
+    const newRootAsset = {
+      ...rootAsset,
+      externalId: 'test-root' + randomInt(),
+    };
+    const newChildAsset = {
+      ...childAsset,
+      parentExternalId: newRootAsset.externalId,
+    };
+    const childArr = new Array(1000).fill(newChildAsset);
+    const createdAssets = await client.assets.create([
+      newRootAsset,
+      ...childArr,
+    ]);
+    expect(createdAssets.length).toBe(1001);
+    await client.assets.delete(
+      createdAssets.slice(1).map(asset => ({ id: asset.id }))
     );
+    await client.assets.delete([{ id: createdAssets[0].id }]);
   });
 
   test('retrieve', async () => {

--- a/src/__tests__/resources/assets.integration.spec.ts
+++ b/src/__tests__/resources/assets.integration.spec.ts
@@ -43,7 +43,7 @@ describe('Asset integration test', () => {
       errors: [
         new CogniteError(
           'createAssets.arg0.items: size must be between 1 and 1000',
-          400,
+          400
         ),
       ],
       responses: [],

--- a/src/__tests__/resources/assets.unit.spec.ts
+++ b/src/__tests__/resources/assets.unit.spec.ts
@@ -1,8 +1,83 @@
 // Copyright 2019 Cognite AS
 
-import { assetChunker } from '../../resources/assets/assetUtils';
+import {
+  assetChunker,
+  promiseAllAtOnce,
+  promiseEachInSequence,
+} from '../../resources/assets/assetUtils';
 
 describe('Asset unit test', () => {
+  describe('multi promise resolution', () => {
+    test('promiseAllAtOnce: fail', async () => {
+      const data = ['x', 'a', 'b', 'c'];
+      await expect(
+        promiseAllAtOnce(
+          data,
+          input =>
+            input === 'x'
+              ? Promise.reject(input + 'x')
+              : Promise.resolve(input + 'r')
+        )
+      ).rejects.toEqual({
+        failed: ['x'],
+        succeded: ['a', 'b', 'c'],
+        errors: ['xx'],
+        responses: ['ar', 'br', 'cr'],
+      });
+    });
+
+    test('promiseAllAtOnce: one element', async () => {
+      const fail = () =>
+        new Promise(() => {
+          throw new Error('y');
+        });
+      await expect(promiseAllAtOnce(['x'], fail)).rejects.toEqual({
+        failed: ['x'],
+        succeded: [],
+        errors: [new Error('y')],
+        responses: [],
+      });
+    });
+
+    test('promiseAllAtOnce: success', async () => {
+      const data = ['a', 'b', 'c'];
+      await expect(
+        promiseAllAtOnce(data, input => Promise.resolve(input))
+      ).resolves.toEqual(['a', 'b', 'c']);
+    });
+
+    test('promiseEachInSequence', async () => {
+      expect(
+        await promiseEachInSequence([], input => Promise.resolve(input))
+      ).toEqual([]);
+      expect(
+        await promiseEachInSequence([1], input => Promise.resolve(input))
+      ).toEqual([1]);
+      expect(
+        await promiseEachInSequence([1, 2, 3], input => Promise.resolve(input))
+      ).toEqual([1, 2, 3]);
+      await expect(
+        promiseEachInSequence([1, 2], () => Promise.reject('reject'))
+      ).rejects.toEqual({
+        failed: [1, 2],
+        succeded: [],
+        errors: ['reject'],
+        responses: [],
+      });
+      await expect(
+        promiseEachInSequence(
+          [1, 0, 2, 3],
+          input => (input ? Promise.resolve(input) : Promise.reject('x'))
+        )
+      ).rejects.toEqual({
+        failed: [0, 2, 3],
+        succeded: [1],
+        errors: ['x'],
+        responses: [1],
+      });
+    });
+  });
+
   describe('assetChunker', () => {
     test.each([{ parentId: 123 }, { parentExternalId: 'abc' }, {}])(
       'single asset',

--- a/src/error.ts
+++ b/src/error.ts
@@ -23,6 +23,7 @@ export class CogniteError extends Error {
       message += `\n${JSON.stringify(extra, null, 2)}`;
     }
     super(message);
+    Object.setPrototypeOf(this, CogniteError.prototype);
     this.status = status;
     this.requestId = requestId;
     this.missing = missing;

--- a/src/multiError.ts
+++ b/src/multiError.ts
@@ -1,0 +1,65 @@
+// Copyright 2019 Cognite AS
+
+import { AxiosResponse } from 'axios';
+import { CogniteError } from './error';
+
+/** @hidden */
+export interface MultiErrorRawSummary<RequestType, ResponseType> {
+  succeded: RequestType[][];
+  responses: AxiosResponse<ResponseType>[];
+  failed: RequestType[][];
+  errors: (Error | CogniteError)[];
+}
+
+export class CogniteMultiError<RequestType, ResponseType> extends Error {
+  public failed: RequestType[];
+  public succeded: RequestType[];
+
+  public status?: number;
+  public requestId?: string;
+  public missing: object[] = [];
+  public duplicated: any[] = [];
+  public statuses: number[] = [];
+  public requestIds: string[] = [];
+  public responses: ResponseType[] = [];
+  public errors: (Error | CogniteError)[];
+
+  constructor({
+    succeded,
+    responses,
+    failed,
+    errors,
+  }: MultiErrorRawSummary<RequestType, ResponseType>) {
+    
+    super('The API Failed to process some items.');
+    Object.setPrototypeOf(this, CogniteMultiError.prototype);
+
+    this.responses = responses.map(response => response.data);
+    this.errors = errors;
+    this.succeded = succeded.reduce((all, current) => all.concat(current), []);
+    this.failed = failed.reduce((all, current) => all.concat(current), []);
+    this.status = (errors[0] as CogniteError).status;
+    this.requestId = (errors[0] as CogniteError).requestId;
+
+    for (const err of errors) {
+      if (err instanceof CogniteError) {
+        if (err.missing) {
+          this.missing = this.missing.concat(err.missing);
+        }
+        if (err.duplicated) {
+          this.duplicated = this.duplicated.concat(err.duplicated);
+        }
+        if (err.requestId) {
+          this.requestIds.push(err.requestId);
+        }
+        this.statuses.push(err.status);
+      }
+    }
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      this.stack = new Error(this.message).stack;
+    }
+  }
+}

--- a/src/multiError.ts
+++ b/src/multiError.ts
@@ -30,7 +30,6 @@ export class CogniteMultiError<RequestType, ResponseType> extends Error {
     failed,
     errors,
   }: MultiErrorRawSummary<RequestType, ResponseType>) {
-    
     super('The API Failed to process some items.');
     Object.setPrototypeOf(this, CogniteMultiError.prototype);
 

--- a/src/resources/assets/assetUtils.ts
+++ b/src/resources/assets/assetUtils.ts
@@ -1,7 +1,9 @@
 // Copyright 2019 Cognite AS
 
 import { chunk } from 'lodash';
+import { CogniteError } from '../../error';
 import { Node, topologicalSort } from '../../graphUtils';
+import { CogniteMultiError } from '../../multiError';
 import { ExternalAssetItem } from '../../types/types';
 
 /** @hidden */
@@ -33,4 +35,86 @@ export function assetChunker(
 
   const sortedNodes = topologicalSort(nodes);
   return chunk(sortedNodes.map(node => node.data), chunkSize);
+}
+
+/**
+ * Resolves all Promises at once, even if some of them fail
+ */
+/** @hidden */
+export async function promiseAllAtOnce<RequestType, ResponseType>(
+  inputs: RequestType[],
+  promiser: (input: RequestType) => Promise<ResponseType>
+) {
+  const failed: RequestType[] = [];
+  const succeded: RequestType[] = [];
+  const responses: ResponseType[] = [];
+  const errors: (Error | CogniteError)[] = [];
+
+  const promises = inputs.map(input => promiser(input));
+
+  const wrappedPromises = promises.map((promise, index) =>
+    promise
+      .then(result => {
+        succeded.push(inputs[index]);
+        responses.push(result);
+      })
+      .catch(error => {
+        failed.push(inputs[index]);
+        errors.push(error);
+      })
+  );
+
+  await Promise.all(wrappedPromises);
+
+  if (failed.length) {
+    throw {
+      succeded,
+      responses,
+      failed,
+      errors,
+    };
+  }
+
+  return responses;
+}
+
+/** @hidden */
+export async function promiseAllWithData<RequestType, ResponseType>(
+  inputs: RequestType[],
+  promiser: (input: RequestType) => Promise<ResponseType>,
+  runSequentially: boolean
+) {
+  try {
+    if (runSequentially) {
+      return await promiseEachInSequence(inputs, promiser);
+    } else {
+      return await promiseAllAtOnce(inputs, promiser);
+    }
+  } catch (err) {
+    throw new CogniteMultiError(err);
+  }
+}
+
+/**
+ * Resolves Promises sequentially
+ */
+/** @hidden */
+export async function promiseEachInSequence<RequestType, ResponseType>(
+  inputs: RequestType[],
+  promiser: (input: RequestType) => Promise<ResponseType>
+) {
+  return inputs.reduce((previousPromise, input, index) => {
+    return previousPromise.then(result => {
+      return promiser(input)
+        .catch(err => {
+          return Promise.reject({
+            errors: [err],
+            failed: inputs.slice(index),
+            succeded: inputs.slice(0, index),
+            responses: result,
+          });
+        })
+        .then(Array.prototype.concat.bind(result));
+    });
+  }, Promise.resolve(new Array()));
 }

--- a/src/standardMethods.ts
+++ b/src/standardMethods.ts
@@ -5,6 +5,7 @@ import { chunk, concat } from 'lodash';
 import { makeAutoPaginationMethods } from './autoPagination';
 import { rawRequest } from './axiosWrappers';
 import { MetadataMap } from './metadata';
+import { promiseAllWithData } from './resources/assets/assetUtils';
 import { CursorResponse, ItemsResponse } from './types/types';
 
 type CreateEndpoint<RequestType, ResponseType> = (
@@ -24,14 +25,15 @@ export function generateCreateEndpoint<RequestType, ResponseType>(
     if (items.length) {
       chunks = chunkFunction ? chunkFunction(items) : chunk(items, 1000);
     }
-    const responses = await Promise.all(
-      chunks.map(singleChunk =>
+    const responses = await promiseAllWithData(
+      chunks,
+      input =>
         rawRequest<Response>(axiosInstance, {
           method: 'post',
           url: resourcePath,
-          data: { items: singleChunk },
-        })
-      )
+          data: { items: input },
+        }),
+      true
     );
     const mergedResponses = concat(
       [],


### PR DESCRIPTION
Solves #117 and #157 

So basically we chunk up `assets.create()` request if it has more than 1000 items.
(later we'll chunk other requests as well, but with different logic)
The error used to say only about the first error happened during those multiple requests.
Now we introduced `CogniteMultiError` which will contain data about all requests (again for this specific case it's always single one).
Although the first error still takes precedence, it will also contain information about what has been created and what has failed.




`PS. need to rebase when base branch is merged`