### PR TITLE
fix: ts errors during yarn docs

### DIFF
--- a/src/__tests__/resources/assets.unit.spec.ts
+++ b/src/__tests__/resources/assets.unit.spec.ts
@@ -79,6 +79,18 @@ describe('Asset unit test', () => {
         errors: ['x'],
         responses: [1],
       });
+
+      await expect(
+        promiseEachInSequence(
+          [1, 2, 0, 3, 0],
+          input => (input ? Promise.resolve(input + 'r') : Promise.reject('x'))
+        )
+      ).rejects.toEqual({
+        failed: [0, 3, 0],
+        succeded: [1, 2],
+        errors: ['x'],
+        responses: ['1r', '2r'],
+      });
     });
   });
 

--- a/src/resources/assets/assetUtils.ts
+++ b/src/resources/assets/assetUtils.ts
@@ -103,18 +103,17 @@ export async function promiseEachInSequence<RequestType, ResponseType>(
   inputs: RequestType[],
   promiser: (input: RequestType) => Promise<ResponseType>
 ) {
-  return inputs.reduce((previousPromise, input, index) => {
-    return previousPromise.then(result => {
-      return promiser(input)
-        .catch(err => {
-          return Promise.reject({
-            errors: [err],
-            failed: inputs.slice(index),
-            succeded: inputs.slice(0, index),
-            responses: result,
-          });
-        })
-        .then(Array.prototype.concat.bind(result));
-    });
-  }, Promise.resolve(new Array()));
+  return inputs.reduce(async (previousPromise, input, index) => {
+    const prevResult = await previousPromise;
+    try {
+      return prevResult.concat(await promiser(input));
+    } catch (err) {
+      throw {
+        errors: [err],
+        failed: inputs.slice(index),
+        succeded: inputs.slice(0, index),
+        responses: prevResult,
+      };
+    }
+  }, Promise.resolve(new Array<ResponseType>()));
 }


### PR DESCRIPTION
typeScript freaks out during `yarn docs` for some reason
It sounds like a good reason to refactor it as well (and some tests of course)