### PR TITLE
[WIP] types generation using horiuchi/dtsgenerator

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/query-string": "^6.1.0",
     "axios-debug-log": "^0.4.0",
     "axios-mock-adapter": "1.15.0",
-    "dtsgenerator": "^2.0.6",
+    "dtsgenerator": "cognitedata/dtsgenerator#feat/typeMappings",
     "es-check": "^5.0.0",
     "jest": "^23.6.0",
     "ls": "^0.2.1",

--- a/scripts/generateTypes.sh
+++ b/scripts/generateTypes.sh
@@ -21,7 +21,8 @@ cd ./../../scripts
 
 # generate types and do some post generation rain-dance
 node ../node_modules/dtsgenerator/bin/dtsgen --out ../src/types/types.ts ../v1.json  -n ""
-printf '%s\n%s\n' "// Copyright 2019 Cognite AS" "$(cat ../src/types/types.ts)" > ../src/types/types.ts
+printf '%s\n%s\n' "/* tslint:disable no-namespace no-empty-interface max-union-size use-type-alias */" "$(cat ../src/types/types.ts)" > ../src/types/types.ts
+printf '%s\n\n%s\n' "// Copyright 2019 Cognite AS" "$(cat ../src/types/types.ts)" > ../src/types/types.ts
 sed -i "" 's/declare type/export type/g' ../src/types/types.ts
 sed -i "" 's/declare interface/export interface/g' ../src/types/types.ts
 sed -i "" 's/declare namespace/export declare namespace/g' ../src/types/types.ts

--- a/scripts/generateTypes.sh
+++ b/scripts/generateTypes.sh
@@ -1,0 +1,34 @@
+yarn add --dev cognitedata/openapi-spec-merger#feat/convertInlineSchemasToExplicit
+yarn add --dev cognitedata/dtsgenerator#feat/typeMappings
+yarn add --dev cognitedata/service-contracts
+# fetch newest service-contracts
+yarn upgrade @cognite/service-contracts
+
+# unhide 3d viewer stuff from config
+node -e "const fs = require('fs');\
+const configFile = fs.readFileSync('./node_modules/@cognite/service-contracts/versions/v1/oas-config.json');\
+const configJson = JSON.parse(configFile.toString());\
+configJson.includes.push({ localPath: './threed_private.yml'});\
+fs.writeFileSync('./node_modules/@cognite/service-contracts/versions/v1/oas-config-modified.json', JSON.stringify(configJson, null, 2));"
+
+# merge service-contracts to JSON
+node ./node_modules/@cognite/oas-merger/src/cli -c ./node_modules/@cognite/service-contracts/versions/v1/oas-config-modified.json -f ./v1.json
+
+cd ./node_modules/dtsgenerator
+yarn
+yarn build
+cd ./../../scripts
+
+# generate types and do some post generation rain-dance
+node ../node_modules/dtsgenerator/bin/dtsgen --out ../src/types/types.ts ../v1.json  -n ""
+printf '%s\n%s\n' "// Copyright 2019 Cognite AS" "$(cat ../src/types/types.ts)" > ../src/types/types.ts
+sed -i "" 's/declare type/export type/g' ../src/types/types.ts
+sed -i "" 's/declare interface/export interface/g' ../src/types/types.ts
+sed -i "" 's/declare namespace/export declare namespace/g' ../src/types/types.ts
+
+rm ../v1.json
+rm ../node_modules/@cognite/service-contracts/versions/v1/oas-config-modified.json
+
+# run linter
+yarn lint --fix
+yarn remove @cognite/oas-merger @cognite/service-contracts

--- a/src/__tests__/autoPagination.spec.ts
+++ b/src/__tests__/autoPagination.spec.ts
@@ -2,7 +2,7 @@
 
 import * as sleep from 'sleep-promise';
 import { makeAutoPaginationMethods } from '../autoPagination';
-import { ListResponse } from '../types/types';
+import { ListResponse } from '../types';
 
 async function fibListResponse() {
   const generateResponse = async (

--- a/src/__tests__/resources/3d.mock.spec.ts
+++ b/src/__tests__/resources/3d.mock.spec.ts
@@ -10,7 +10,7 @@ import {
   RevealSector3D,
   Revision3D,
   UnrealRevision3D,
-} from '../../types/types';
+} from '../../types';
 import { transformDateInRequest } from '../../utils';
 import {
   randomInt,

--- a/src/__tests__/resources/apiKeys.integration.spec.ts
+++ b/src/__tests__/resources/apiKeys.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { NewApiKeyResponse, ServiceAccount } from '../../types/types';
+import { NewApiKeyResponseDTO, ServiceAccount } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('API keys integration test', () => {
@@ -18,7 +18,7 @@ describe('API keys integration test', () => {
     await client.serviceAccounts.delete([serviceAccount.id]);
   });
 
-  let apiKeys: NewApiKeyResponse[];
+  let apiKeys: NewApiKeyResponseDTO[];
 
   test('create', async () => {
     apiKeys = await client.apiKeys.create([

--- a/src/__tests__/resources/apiKeys.integration.spec.ts
+++ b/src/__tests__/resources/apiKeys.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { NewApiKeyResponseDTO, ServiceAccount } from '../../types';
+import { ApiKeyObject, ServiceAccount } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('API keys integration test', () => {
@@ -18,7 +18,7 @@ describe('API keys integration test', () => {
     await client.serviceAccounts.delete([serviceAccount.id]);
   });
 
-  let apiKeys: NewApiKeyResponseDTO[];
+  let apiKeys: ApiKeyObject[];
 
   test('create', async () => {
     apiKeys = await client.apiKeys.create([

--- a/src/__tests__/resources/assets.integration.spec.ts
+++ b/src/__tests__/resources/assets.integration.spec.ts
@@ -3,7 +3,7 @@
 import CogniteClient from '../../cogniteClient';
 import { CogniteError } from '../../error';
 import { CogniteMultiError } from '../../multiError';
-import { Asset } from '../../types/types';
+import { Asset } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Asset integration test', () => {
@@ -143,7 +143,7 @@ describe('Asset integration test', () => {
       .list({
         filter: {
           name: rootAsset.name,
-          createdTime: { min: 0, max: Date.now() },
+          createdTime: { min: new Date(0), max: new Date() },
         },
       })
       .autoPagingToArray({ limit: 100 });

--- a/src/__tests__/resources/assets.unit.spec.ts
+++ b/src/__tests__/resources/assets.unit.spec.ts
@@ -103,30 +103,49 @@ describe('Asset unit test', () => {
     );
 
     test('straight tree', () => {
-      const rootAsset = { externalId: '123', parentExternalId: 'abc' };
+      const rootAsset = {
+        name: 'x',
+        externalId: '123',
+        parentExternalId: 'abc',
+      };
       const childAsset = {
+        name: 'x',
         externalId: 'def',
         parentExternalId: rootAsset.externalId,
       };
-      const grandChildAsset = { parentExternalId: childAsset.externalId };
+      const grandChildAsset = {
+        name: 'x',
+        parentExternalId: childAsset.externalId,
+      };
       expect(assetChunker([childAsset, rootAsset, grandChildAsset], 2)).toEqual(
         [[rootAsset, childAsset], [grandChildAsset]]
       );
     });
 
     test('regular tree', () => {
-      const assetA = { externalId: 'A' };
-      const assetAA = { externalId: 'AA', parentExternalId: assetA.externalId };
-      const assetAB = { externalId: 'AB', parentExternalId: assetA.externalId };
+      const assetA = { name: 'x', externalId: 'A' };
+      const assetAA = {
+        name: 'x',
+        externalId: 'AA',
+        parentExternalId: assetA.externalId,
+      };
+      const assetAB = {
+        name: 'x',
+        externalId: 'AB',
+        parentExternalId: assetA.externalId,
+      };
       const assetAAA = {
+        name: 'x',
         externalId: 'AAA',
         parentExternalId: assetAA.externalId,
       };
       const assetAAB = {
+        name: 'x',
         externalId: 'AAB',
         parentExternalId: assetAA.externalId,
       };
       const someAsset = {
+        name: 'x',
         parentId: 123,
       };
       const inputOrder = [

--- a/src/__tests__/resources/datapoints.integration.spec.ts
+++ b/src/__tests__/resources/datapoints.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { GetTimeSeriesMetadataDTO } from '../../types/types';
+import { GetTimeSeriesMetadataDTO } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
 describe('Datapoints integration test', () => {

--- a/src/__tests__/resources/events.integration.spec.ts
+++ b/src/__tests__/resources/events.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { CogniteEvent } from '../../types/types';
+import { CogniteEvent } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
 describe('Events integration test', () => {
@@ -13,11 +13,11 @@ describe('Events integration test', () => {
   const events = [
     {
       description: 'Test event',
-      startTime: 10,
-      endTime: 100,
+      startTime: new Date(10),
+      endTime: new Date(100),
     },
     {
-      startTime: new Date('1 jan 2016').getTime(),
+      startTime: new Date('1 jan 2016'),
       source: 'WORKMATE',
       type: 'ACTION',
       subtype: 'POKE',
@@ -71,8 +71,8 @@ describe('Events integration test', () => {
       .list({
         filter: {
           startTime: {
-            min: events[0].startTime - 1,
-            max: events[0].endTime! + 1,
+            min: new Date(events[0].startTime.getTime() - 1),
+            max: new Date(events[0].endTime!.getTime() + 1),
           },
         },
         limit: 3,

--- a/src/__tests__/resources/files.integration.spec.ts
+++ b/src/__tests__/resources/files.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { FilesMetadata } from '../../types/types';
+import { FilesMetadata } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Files integration test', () => {

--- a/src/__tests__/resources/groups.integration.spec.ts
+++ b/src/__tests__/resources/groups.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { Group, GroupSpec, ServiceAccount } from '../../types/types';
+import { Group, GroupSpec, ServiceAccount } from '../../types';
 import { sleepPromise } from '../../utils';
 import { randomInt, retryInSeconds, setupLoggedInClient } from '../testUtils';
 

--- a/src/__tests__/resources/models3D.integration.spec.ts
+++ b/src/__tests__/resources/models3D.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { Model3D } from '../../types/types';
+import { Model3D } from '../../types';
 import {
   getSortedPropInArray,
   randomInt,

--- a/src/__tests__/resources/raw.integration.spec.ts
+++ b/src/__tests__/resources/raw.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { RawDB, RawDBTable } from '../../types/types';
+import { RawDB, RawDBTable } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 let index = 0;

--- a/src/__tests__/resources/revisions3D.integration.spec.ts
+++ b/src/__tests__/resources/revisions3D.integration.spec.ts
@@ -13,7 +13,7 @@ import {
   Revision3D,
   Tuple3,
   UpdateRevision3D,
-} from '../../types/types';
+} from '../../types';
 import {
   getSortedPropInArray,
   randomInt,

--- a/src/__tests__/resources/securityCategories.integration.spec.ts
+++ b/src/__tests__/resources/securityCategories.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { SecurityCategory } from '../../types/types';
+import { SecurityCategoryDTO } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Security categories integration test', () => {
@@ -9,7 +9,7 @@ describe('Security categories integration test', () => {
   beforeAll(async () => {
     client = setupLoggedInClient();
   });
-  let securityCategories: SecurityCategory[];
+  let securityCategories: SecurityCategoryDTO[];
 
   test('create', async () => {
     const securityCategoriesToCreate = [

--- a/src/__tests__/resources/securityCategories.integration.spec.ts
+++ b/src/__tests__/resources/securityCategories.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { SecurityCategoryDTO } from '../../types';
+import { SecurityCategory } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Security categories integration test', () => {
@@ -9,7 +9,7 @@ describe('Security categories integration test', () => {
   beforeAll(async () => {
     client = setupLoggedInClient();
   });
-  let securityCategories: SecurityCategoryDTO[];
+  let securityCategories: SecurityCategory[];
 
   test('create', async () => {
     const securityCategoriesToCreate = [

--- a/src/__tests__/resources/serviceaccounts.integration.spec.ts
+++ b/src/__tests__/resources/serviceaccounts.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { ServiceAccount } from '../../types/types';
+import { ServiceAccount } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Service accounts integration test', () => {

--- a/src/__tests__/resources/timeseries.integration.spec.ts
+++ b/src/__tests__/resources/timeseries.integration.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { GetTimeSeriesMetadataDTO } from '../../types/types';
+import { GetTimeSeriesMetadataDTO } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Timeseries integration test', () => {

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -1,6 +1,6 @@
 // Copyright 2019 Cognite AS
 
-import { ListResponse } from './types/types';
+import { ListResponse } from './types';
 
 // polyfill
 if (Symbol.asyncIterator === undefined) {

--- a/src/resources/3d/assetMappings3DApi.ts
+++ b/src/resources/3d/assetMappings3DApi.ts
@@ -14,7 +14,7 @@ import {
   CogniteInternalId,
   CreateAssetMapping3D,
   DeleteAssetMapping3D,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class AssetMappings3DAPI {

--- a/src/resources/3d/files3DApi.ts
+++ b/src/resources/3d/files3DApi.ts
@@ -3,7 +3,7 @@
 import { AxiosInstance } from 'axios';
 import { rawRequest } from '../../axiosWrappers';
 import { MetadataMap } from '../../metadata';
-import { CogniteInternalId } from '../../types/types';
+import { CogniteInternalId } from '../../types';
 import { projectUrl } from '../../utils';
 
 export class Files3DAPI {

--- a/src/resources/3d/models3DApi.ts
+++ b/src/resources/3d/models3DApi.ts
@@ -17,7 +17,7 @@ import {
   Model3D,
   Model3DListRequest,
   UpdateModel3D,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class Models3DAPI {

--- a/src/resources/3d/revisions3DApi.ts
+++ b/src/resources/3d/revisions3DApi.ts
@@ -20,7 +20,7 @@ import {
   Revision3D,
   Revision3DListRequest,
   UpdateRevision3D,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class Revisions3DAPI {

--- a/src/resources/3d/viewer3DApi.ts
+++ b/src/resources/3d/viewer3DApi.ts
@@ -14,7 +14,7 @@ import {
   RevealNode3D,
   RevealRevision3D,
   RevealSector3D,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class Viewer3DAPI {

--- a/src/resources/apiKeys/apiKeysApi.ts
+++ b/src/resources/apiKeys/apiKeysApi.ts
@@ -9,6 +9,7 @@ import {
 } from '../../standardMethods';
 import {
   ApiKeyListScope,
+  ApiKeyObject,
   ApiKeyRequest,
   CogniteInternalId,
   NewApiKeyResponseDTO,
@@ -58,7 +59,7 @@ export class ApiKeysAPI {
 
 export type ApiKeysListEndpoint = (
   scope?: ApiKeyListScope
-) => Promise<NewApiKeyResponseDTO[]>;
+) => Promise<ApiKeyObject[]>;
 
 export type ApiKeysCreateEndpoint = (
   items: ApiKeyRequest[]

--- a/src/resources/apiKeys/apiKeysApi.ts
+++ b/src/resources/apiKeys/apiKeysApi.ts
@@ -9,11 +9,10 @@ import {
 } from '../../standardMethods';
 import {
   ApiKeyListScope,
-  ApiKeyObject,
   ApiKeyRequest,
   CogniteInternalId,
-  NewApiKeyResponse,
-} from '../../types/types';
+  NewApiKeyResponseDTO,
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class ApiKeysAPI {
@@ -59,10 +58,10 @@ export class ApiKeysAPI {
 
 export type ApiKeysListEndpoint = (
   scope?: ApiKeyListScope
-) => Promise<ApiKeyObject[]>;
+) => Promise<NewApiKeyResponseDTO[]>;
 
 export type ApiKeysCreateEndpoint = (
   items: ApiKeyRequest[]
-) => Promise<NewApiKeyResponse[]>;
+) => Promise<NewApiKeyResponseDTO[]>;
 
 export type ApiKeysDeleteEndpoint = (items: CogniteInternalId[]) => Promise<{}>;

--- a/src/resources/assets/assetUtils.ts
+++ b/src/resources/assets/assetUtils.ts
@@ -4,19 +4,19 @@ import { chunk } from 'lodash';
 import { CogniteError } from '../../error';
 import { Node, topologicalSort } from '../../graphUtils';
 import { CogniteMultiError } from '../../multiError';
-import { ExternalAssetItem } from '../../types/types';
+import { DataExternalAssetItem } from '../../types';
 
 /** @hidden */
 export function assetChunker(
-  assets: ExternalAssetItem[],
+  assets: DataExternalAssetItem[],
   chunkSize: number = 1000
-): ExternalAssetItem[][] {
-  const nodes: Node<ExternalAssetItem>[] = assets.map(asset => {
+): DataExternalAssetItem[][] {
+  const nodes: Node<DataExternalAssetItem>[] = assets.map(asset => {
     return { data: asset };
   });
 
   // find all new exteralIds and map the new externalId to the asset
-  const externalIdMap = new Map<string, Node<ExternalAssetItem>>();
+  const externalIdMap = new Map<string, Node<DataExternalAssetItem>>();
   nodes.forEach(node => {
     const { externalId } = node.data;
     if (externalId) {

--- a/src/resources/assets/assetUtils.ts
+++ b/src/resources/assets/assetUtils.ts
@@ -4,19 +4,19 @@ import { chunk } from 'lodash';
 import { CogniteError } from '../../error';
 import { Node, topologicalSort } from '../../graphUtils';
 import { CogniteMultiError } from '../../multiError';
-import { DataExternalAssetItem } from '../../types';
+import { ExternalAssetItem } from '../../types';
 
 /** @hidden */
 export function assetChunker(
-  assets: DataExternalAssetItem[],
+  assets: ExternalAssetItem[],
   chunkSize: number = 1000
-): DataExternalAssetItem[][] {
-  const nodes: Node<DataExternalAssetItem>[] = assets.map(asset => {
+): ExternalAssetItem[][] {
+  const nodes: Node<ExternalAssetItem>[] = assets.map(asset => {
     return { data: asset };
   });
 
   // find all new exteralIds and map the new externalId to the asset
-  const externalIdMap = new Map<string, Node<DataExternalAssetItem>>();
+  const externalIdMap = new Map<string, Node<ExternalAssetItem>>();
   nodes.forEach(node => {
     const { externalId } = node.data;
     if (externalId) {

--- a/src/resources/assets/assetsApi.ts
+++ b/src/resources/assets/assetsApi.ts
@@ -17,7 +17,7 @@ import {
   AssetIdEither,
   AssetListScope,
   AssetSearchFilter,
-  DataExternalAssetItem,
+  ExternalAssetItem,
 } from '../../types';
 import { projectUrl } from '../../utils';
 import { assetChunker } from './assetUtils';
@@ -103,7 +103,7 @@ export class AssetsAPI {
 }
 
 export type AssetCreateEndpoint = (
-  items: DataExternalAssetItem[]
+  items: ExternalAssetItem[]
 ) => Promise<Asset[]>;
 
 export type AssetListEndpoint = (

--- a/src/resources/assets/assetsApi.ts
+++ b/src/resources/assets/assetsApi.ts
@@ -17,8 +17,8 @@ import {
   AssetIdEither,
   AssetListScope,
   AssetSearchFilter,
-  ExternalAssetItem,
-} from '../../types/types';
+  DataExternalAssetItem,
+} from '../../types';
 import { projectUrl } from '../../utils';
 import { assetChunker } from './assetUtils';
 
@@ -103,7 +103,7 @@ export class AssetsAPI {
 }
 
 export type AssetCreateEndpoint = (
-  items: ExternalAssetItem[]
+  items: DataExternalAssetItem[]
 ) => Promise<Asset[]>;
 
 export type AssetListEndpoint = (

--- a/src/resources/dataPoints/dataPointsApi.ts
+++ b/src/resources/dataPoints/dataPointsApi.ts
@@ -15,7 +15,7 @@ import {
   DatapointsMultiQuery,
   DatapointsPostDatapoint,
   LatestDataBeforeRequest,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class DataPointsAPI {

--- a/src/resources/events/eventsApi.ts
+++ b/src/resources/events/eventsApi.ts
@@ -18,7 +18,7 @@ import {
   EventSearchRequest,
   ExternalEvent,
   IdEither,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class EventsAPI {

--- a/src/resources/files/filesApi.ts
+++ b/src/resources/files/filesApi.ts
@@ -20,7 +20,7 @@ import {
   FilesSearchFilter,
   IdEither,
   UploadFileMetadataResponse,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 import {
   generateDownloadUrlEndpoint,

--- a/src/resources/files/filesUtils.ts
+++ b/src/resources/files/filesUtils.ts
@@ -11,7 +11,7 @@ import {
   FilesMetadata,
   ItemsResponse,
   UploadFileMetadataResponse,
-} from '../../types/types';
+} from '../../types';
 
 /** @hidden */
 export function waitUntilFileIsUploaded(

--- a/src/resources/groups/groupsApi.ts
+++ b/src/resources/groups/groupsApi.ts
@@ -12,9 +12,9 @@ import {
 import {
   CogniteInternalId,
   Group,
+  GroupServiceAccount,
   GroupSpec,
   ListGroups,
-  ServiceAccount,
 } from '../../types';
 import { projectUrl } from '../../utils';
 
@@ -76,7 +76,7 @@ export class GroupsAPI {
    * ```
    */
   public listServiceAccounts: GroupsListServiceAccountsEndpoint = groupId => {
-    return generateListNoCursorEndpoint<ServiceAccount>(
+    return generateListNoCursorEndpoint<GroupServiceAccount>(
       this.instance,
       this.serviceAccountPath(groupId),
       this.map
@@ -141,7 +141,7 @@ export type GroupsDeleteEndpoint = (ids: CogniteInternalId[]) => Promise<{}>;
 
 export type GroupsListServiceAccountsEndpoint = (
   groupId: CogniteInternalId
-) => Promise<ServiceAccount[]>;
+) => Promise<GroupServiceAccount[]>;
 
 export type GroupsAddServiceAccountsEndpoint = (
   groupId: CogniteInternalId,

--- a/src/resources/groups/groupsApi.ts
+++ b/src/resources/groups/groupsApi.ts
@@ -12,10 +12,10 @@ import {
 import {
   CogniteInternalId,
   Group,
-  GroupServiceAccount,
   GroupSpec,
   ListGroups,
-} from '../../types/types';
+  ServiceAccount,
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class GroupsAPI {
@@ -76,7 +76,7 @@ export class GroupsAPI {
    * ```
    */
   public listServiceAccounts: GroupsListServiceAccountsEndpoint = groupId => {
-    return generateListNoCursorEndpoint<GroupServiceAccount>(
+    return generateListNoCursorEndpoint<ServiceAccount>(
       this.instance,
       this.serviceAccountPath(groupId),
       this.map
@@ -141,7 +141,7 @@ export type GroupsDeleteEndpoint = (ids: CogniteInternalId[]) => Promise<{}>;
 
 export type GroupsListServiceAccountsEndpoint = (
   groupId: CogniteInternalId
-) => Promise<GroupServiceAccount[]>;
+) => Promise<ServiceAccount[]>;
 
 export type GroupsAddServiceAccountsEndpoint = (
   groupId: CogniteInternalId,

--- a/src/resources/projects/projectsApi.ts
+++ b/src/resources/projects/projectsApi.ts
@@ -6,7 +6,7 @@ import {
   generateRetrieveSingleEndpoint,
   generateSingleReplaceEndpoint,
 } from '../../standardMethods';
-import { ProjectObject, ProjectResponse } from '../../types';
+import { ProjectResponse, ProjectUpdate } from '../../types';
 import { apiUrl, projectUrl } from '../../utils';
 
 export class ProjectsAPI {
@@ -40,7 +40,7 @@ export class ProjectsAPI {
    * ```
    */
   public update: ProjectsUpdateEndpoint = (urlName, replacement) => {
-    return generateSingleReplaceEndpoint<ProjectObject, ProjectResponse>(
+    return generateSingleReplaceEndpoint<ProjectUpdate, ProjectResponse>(
       this.instance,
       projectUrl(urlName),
       this.map
@@ -54,5 +54,5 @@ export type ProjectsRetrieveEndpoint = (
 
 export type ProjectsUpdateEndpoint = (
   urlName: string,
-  replacement: ProjectObject
+  replacement: ProjectUpdate
 ) => Promise<ProjectResponse>;

--- a/src/resources/projects/projectsApi.ts
+++ b/src/resources/projects/projectsApi.ts
@@ -6,7 +6,7 @@ import {
   generateRetrieveSingleEndpoint,
   generateSingleReplaceEndpoint,
 } from '../../standardMethods';
-import { ProjectResponse, ProjectUpdate } from '../../types/types';
+import { ProjectObject, ProjectResponse } from '../../types';
 import { apiUrl, projectUrl } from '../../utils';
 
 export class ProjectsAPI {
@@ -40,7 +40,7 @@ export class ProjectsAPI {
    * ```
    */
   public update: ProjectsUpdateEndpoint = (urlName, replacement) => {
-    return generateSingleReplaceEndpoint<ProjectUpdate, ProjectResponse>(
+    return generateSingleReplaceEndpoint<ProjectObject, ProjectResponse>(
       this.instance,
       projectUrl(urlName),
       this.map
@@ -54,5 +54,5 @@ export type ProjectsRetrieveEndpoint = (
 
 export type ProjectsUpdateEndpoint = (
   urlName: string,
-  replacement: ProjectUpdate
+  replacement: ProjectObject
 ) => Promise<ProjectResponse>;

--- a/src/resources/raw/rawApi.ts
+++ b/src/resources/raw/rawApi.ts
@@ -20,7 +20,7 @@ import {
   RawDBRowInsert,
   RawDBRowKey,
   RawDBTable,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class RawAPI {

--- a/src/resources/securityCategories/securityCategoriesApi.ts
+++ b/src/resources/securityCategories/securityCategoriesApi.ts
@@ -11,9 +11,9 @@ import {
 import {
   CogniteInternalId,
   ListSecurityCategories,
-  SecurityCategory,
-  SecurityCategorySpec,
-} from '../../types/types';
+  SecurityCategoryDTO,
+  SecurityCategorySpecDTO,
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class SecurityCategoriesAPI {
@@ -59,11 +59,11 @@ export class SecurityCategoriesAPI {
 
 export type SecurityCategoriesListEndpoint = (
   query?: ListSecurityCategories
-) => CogniteAsyncIterator<SecurityCategory>;
+) => CogniteAsyncIterator<SecurityCategoryDTO>;
 
 export type SecurityCategoriesCreateEndpoint = (
-  items: SecurityCategorySpec[]
-) => Promise<SecurityCategory[]>;
+  items: SecurityCategorySpecDTO[]
+) => Promise<SecurityCategoryDTO[]>;
 
 export type SecurityCategoriesDeleteEndpoint = (
   ids: CogniteInternalId[]

--- a/src/resources/securityCategories/securityCategoriesApi.ts
+++ b/src/resources/securityCategories/securityCategoriesApi.ts
@@ -11,8 +11,8 @@ import {
 import {
   CogniteInternalId,
   ListSecurityCategories,
-  SecurityCategoryDTO,
-  SecurityCategorySpecDTO,
+  SecurityCategory,
+  SecurityCategorySpec,
 } from '../../types';
 import { projectUrl } from '../../utils';
 
@@ -59,11 +59,11 @@ export class SecurityCategoriesAPI {
 
 export type SecurityCategoriesListEndpoint = (
   query?: ListSecurityCategories
-) => CogniteAsyncIterator<SecurityCategoryDTO>;
+) => CogniteAsyncIterator<SecurityCategory>;
 
 export type SecurityCategoriesCreateEndpoint = (
-  items: SecurityCategorySpecDTO[]
-) => Promise<SecurityCategoryDTO[]>;
+  items: SecurityCategorySpec[]
+) => Promise<SecurityCategory[]>;
 
 export type SecurityCategoriesDeleteEndpoint = (
   ids: CogniteInternalId[]

--- a/src/resources/serviceAccounts/serviceAccountsApi.ts
+++ b/src/resources/serviceAccounts/serviceAccountsApi.ts
@@ -11,7 +11,7 @@ import {
   CogniteInternalId,
   ServiceAccount,
   ServiceAccountInput,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class ServiceAccountsAPI {

--- a/src/resources/timeSeries/timeSeriesApi.ts
+++ b/src/resources/timeSeries/timeSeriesApi.ts
@@ -18,7 +18,7 @@ import {
   TimeseriesIdEither,
   TimeSeriesSearchDTO,
   TimeSeriesUpdate,
-} from '../../types/types';
+} from '../../types';
 import { projectUrl } from '../../utils';
 
 export class TimeSeriesAPI {

--- a/src/standardMethods.ts
+++ b/src/standardMethods.ts
@@ -6,7 +6,7 @@ import { makeAutoPaginationMethods } from './autoPagination';
 import { rawRequest } from './axiosWrappers';
 import { MetadataMap } from './metadata';
 import { promiseAllWithData } from './resources/assets/assetUtils';
-import { CursorResponse, ItemsResponse } from './types/types';
+import { CursorResponse, ItemsResponse } from './types';
 
 type CreateEndpoint<RequestType, ResponseType> = (
   items: RequestType[]

--- a/src/types/custom.ts
+++ b/src/types/custom.ts
@@ -4,11 +4,16 @@ import {
   BoundingBox3D,
   CogniteInternalId,
   Cursor,
+  DataExternalAssetItem,
   DefaultGroupId,
   Event,
   FileFilter,
+  NewApiKeyResponseDTO,
   OutputProjectAuthentication,
   ProjectName,
+  SecurityCategoryDTO,
+  SecurityCategorySpecDTO,
+  ServiceAccount,
 } from './types';
 
 export interface FileRequestFilter extends Cursor, FileFilter {}
@@ -144,7 +149,7 @@ export interface Revision3DListRequest extends Limit {
   published?: boolean;
 }
 
-export interface ProjectObject {
+export interface ProjectUpdate {
   name?: ProjectName;
   defaultGroupId?: DefaultGroupId; // int64
   authentication?: OutputProjectAuthentication;
@@ -160,3 +165,9 @@ export interface ListGroups {
 export type CogniteEvent = Event;
 
 export type TimeseriesIdEither = IdEither;
+
+export type SecurityCategory = SecurityCategoryDTO;
+export type SecurityCategorySpec = SecurityCategorySpecDTO;
+export type ExternalAssetItem = DataExternalAssetItem;
+export type ApiKeyObject = NewApiKeyResponseDTO;
+export type GroupServiceAccount = ServiceAccount;

--- a/src/types/custom.ts
+++ b/src/types/custom.ts
@@ -1,0 +1,162 @@
+// Copyright 2019 Cognite AS
+import {
+  AssetIdEither,
+  BoundingBox3D,
+  CogniteInternalId,
+  Cursor,
+  DefaultGroupId,
+  Event,
+  FileFilter,
+  OutputProjectAuthentication,
+  ProjectName,
+} from './types';
+
+export interface FileRequestFilter extends Cursor, FileFilter {}
+
+export interface ApiKeyListScope {
+  /**
+   * Only available with users:list acl, returns all api keys for this project.
+   */
+  all?: boolean;
+  /**
+   * Get api keys for a specific service account, only available to admin users.
+   */
+  serviceAccountId?: CogniteInternalId;
+  /**
+   * Whether to include deleted api keys
+   */
+  includeDeleted?: boolean;
+}
+
+export type FileContent = ArrayBuffer | Buffer | any;
+
+export type IdEither = AssetIdEither;
+
+export interface ApiKeyListScope {
+  /**
+   * Only available with users:list acl, returns all api keys for this project.
+   */
+  all?: boolean;
+  /**
+   * Get api keys for a specific service account, only available to admin users.
+   */
+  serviceAccountId?: CogniteInternalId;
+  /**
+   * Whether to include deleted api keys
+   */
+  includeDeleted?: boolean;
+}
+
+export interface ListRevealSectors3DQuery extends Cursor, Limit {
+  /**
+   * Bounding box to restrict search to. If given, only return sectors that intersect the given bounding box. Given as a JSON-encoded object of two arrays \"min\" and \"max\" with 3 coordinates each.
+   */
+  boundingBox?: BoundingBox3D;
+}
+
+export interface List3DNodesQuery extends Cursor, Limit {
+  /**
+   * Get sub nodes up to this many levels below the specified node. Depth 0 is the root node.
+   */
+  depth?: number;
+  /**
+   * ID of a node that are the root of the subtree you request (default is the root node).
+   */
+  nodeId?: CogniteInternalId;
+}
+
+export interface Limit {
+  limit?: number;
+}
+
+export interface AssetMappings3DListFilter extends Cursor, Limit {
+  nodeId?: CogniteInternalId;
+  assetId?: CogniteInternalId;
+}
+
+export interface ItemsResponse<T> {
+  items: T[];
+}
+
+export interface CursorResponse<T> extends ItemsResponse<T> {
+  nextCursor: string;
+}
+
+export type Tuple3<T> = [T, T, T];
+
+export interface ListRawDatabases extends Cursor, Limit {}
+
+export interface ListRawTables extends Cursor, Limit {}
+
+export interface ListRawRows extends Cursor, Limit {
+  /**
+   * Set this to true if you only want to fetch row keys
+   */
+  onlyRowKeys?: boolean;
+  /**
+   * Specify this to limit columns to retrieve. Array of column keys
+   */
+  columns?: string[];
+  /**
+   * Exclusive filter for last updated time. When specified only rows updated after this time will be returned
+   */
+  minLastUpdatedTime?: Date;
+  /**
+   * Inclusive filter for last updated time. When specified only rows updated before this time will be returned
+   */
+  maxLastUpdatedTime?: Date;
+}
+
+export interface Model3DListRequest extends Limit {
+  /**
+   * Filter based on whether or not it has published revisions.
+   */
+  published?: boolean;
+}
+
+export interface ListSecurityCategories extends Cursor, Limit {
+  sort?: 'ASC' | 'DESC';
+}
+
+export interface TimeseriesFilter extends Limit {
+  /**
+   * Decide if the metadata field should be returned or not.
+   */
+  includeMetadata?: boolean;
+  /**
+   * Cursor for paging through time series.
+   */
+  cursor?: string;
+  /**
+   * Get time series related to these assets. Takes [ 1 .. 100 ] unique items.
+   */
+  assetIds?: number[];
+}
+
+export interface ListResponse<T> extends CursorResponse<T> {
+  next?: () => Promise<ListResponse<T>>;
+}
+
+export interface Revision3DListRequest extends Limit {
+  /**
+   * Filter based on whether or not it has published revisions.
+   */
+  published?: boolean;
+}
+
+export interface ProjectObject {
+  name?: ProjectName;
+  defaultGroupId?: DefaultGroupId; // int64
+  authentication?: OutputProjectAuthentication;
+}
+
+export interface ListGroups {
+  /**
+   * Whether to get all groups, only available with the groups:list acl.
+   */
+  all?: boolean;
+}
+
+export type CogniteEvent = Event;
+
+export type TimeseriesIdEither = IdEither;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2019 Cognite AS
+
+export * from './types';
+export * from './custom';
+export { Limit } from './custom';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1553,7 +1553,7 @@ export interface Filter {
    * example:
    * [object Object]
    */
-  metadata?: {};
+  metadata?: TimeSeriesMetadata;
   /**
    * Filter out time series that are not linked to any of these assets.
    * example:
@@ -1666,10 +1666,7 @@ export interface GetTimeSeriesMetadataDTO {
    * Whether the time series is string valued or not.
    */
   isString: boolean;
-  /**
-   * Additional metadata. String key -> String value.
-   */
-  metadata?: {};
+  metadata?: TimeSeriesMetadata;
   /**
    * The physical unit of the time series.
    */
@@ -2248,10 +2245,7 @@ export interface PostTimeSeriesMetadataDTO {
    * Whether the time series is string valued or not.
    */
   isString?: boolean;
-  /**
-   * Additional metadata. String key -> String value.
-   */
-  metadata?: {};
+  metadata?: TimeSeriesMetadata;
   /**
    * The physical unit of the time series.
    */
@@ -2694,6 +2688,12 @@ export interface TimeSeriesLookupById {
     | {
         externalId?: CogniteExternalId;
       })[];
+}
+/**
+ * Additional metadata. String key -> String value
+ */
+export interface TimeSeriesMetadata {
+  [name: string]: string;
 }
 /**
  * Changes will be applied to timeseries.

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,6 @@
 // Copyright 2019 Cognite AS
+
+/* tslint:disable no-namespace no-empty-interface max-union-size use-type-alias */
 export type Aggregate =
   | 'average'
   | 'max'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,105 +1,4 @@
 // Copyright 2019 Cognite AS
-
-export interface Acl<ActionsType, ScopeType> {
-  actions: ActionsType[];
-  scope: ScopeType;
-}
-
-export type Acl3D = Acl<AclAction3D, AclScope3D>;
-
-export type AclAction3D = READ | CREATE | UPDATE | DELETE;
-
-export type AclActionAnalytics = READ | EXECUTE | LIST;
-
-export type AclActionApiKeys = LIST | CREATE | DELETE;
-
-export type AclActionAssets = LIST | WRITE;
-
-export type AclActionEvents = READ | WRITE;
-
-export type AclActionFiles = READ | WRITE;
-
-export type AclActionGroups = LIST | READ | CREATE | UPDATE | DELETE;
-
-export type AclActionProjects = LIST | READ | CREATE | UPDATE;
-
-export type AclActionRaw = READ | WRITE | LIST;
-
-export type AclActionSecurityCategories = MEMBEROF | LIST | CREATE | DELETE;
-
-export type AclActionSequences = READ | WRITE;
-
-export type AclActionTimeseries = READ | WRITE;
-
-export type AclActionUsers = LIST | CREATE | DELETE;
-
-export type AclAnalytics = Acl<AclActionAnalytics, AclScopeAnalytics>;
-
-export type AclApiKeys = Acl<AclActionApiKeys, AclScopeApiKeys>;
-
-export type AclAssets = Acl<AclActionAssets, AclScopeAssets>;
-
-export type AclEvents = Acl<AclActionEvents, AclScopeEvents>;
-
-export type AclFiles = Acl<AclActionFiles, AclScopeFiles>;
-
-export type AclGroups = Acl<AclActionGroups, AclScopeGroups>;
-
-export type AclProjects = Acl<AclActionProjects, AclScopeProjects>;
-
-export type AclRaw = Acl<AclActionRaw, AclScopeRaw>;
-
-export type AclScope3D = AclScopeAll;
-
-export interface AclScopeAll {
-  all: {};
-}
-
-export type AclScopeAnalytics = AclScopeAll;
-
-export type AclScopeApiKeys = AclScopeAll | AclScopeCurrentUser;
-
-export type AclScopeAssets = AclScopeAll;
-
-export interface AclScopeAssetsId {
-  assetIdScope: {
-    subtreeIds: CogniteInternalId[];
-  };
-}
-
-export interface AclScopeCurrentUser {
-  currentuserscope: {};
-}
-
-export type AclScopeEvents = AclScopeAll;
-
-export type AclScopeFiles = AclScopeAll;
-
-export type AclScopeGroups = AclScopeAll | AclScopeCurrentUser;
-
-export type AclScopeProjects = AclScopeAll;
-
-export type AclScopeRaw = AclScopeAll;
-
-export type AclScopeSecurityCategories = AclScopeAll;
-
-export type AclScopeSequences = AclScopeAll;
-
-export type AclScopeTimeseries = AclScopeAll | AclScopeAssetsId;
-
-export type AclScopeUsers = AclScopeAll;
-
-export type AclSecurityCategories = Acl<
-  AclActionSecurityCategories,
-  AclScopeSecurityCategories
->;
-
-export type AclSequences = Acl<AclActionSequences, AclScopeSequences>;
-
-export type AclTimeseries = Acl<AclActionTimeseries, AclScopeTimeseries>;
-
-export type AclUsers = Acl<AclActionUsers, AclScopeUsers>;
-
 export type Aggregate =
   | 'average'
   | 'max'
@@ -111,130 +10,201 @@ export type Aggregate =
   | 'totalVariation'
   | 'continuousVariance'
   | 'discreteVariance';
-
-export interface ApiKeyListScope {
-  /**
-   * Only available with users:list acl, returns all api keys for this project.
-   */
-  all?: boolean;
-  /**
-   * Get api keys for a specific service account, only available to admin users.
-   */
-  serviceAccountId?: CogniteInternalId;
-  /**
-   * Whether to include deleted api keys
-   */
-  includeDeleted?: boolean;
-}
-
-export interface ApiKeyObject {
-  /**
-   * Internal id for the api key
-   */
-  id: CogniteInternalId;
-  /**
-   * Id of the service account
-   */
-  serviceAccountId: CogniteInternalId;
-  createdTime: Date;
-  /**
-   * The status of the api key
-   */
-  status: 'ACTIVE' | 'DELETED';
-}
-
 export interface ApiKeyRequest {
-  serviceAccountId: CogniteInternalId;
+  serviceAccountId: number; // int64
 }
-
-export type ArrayPatchLong =
-  | { set: number[] }
-  | { add?: number[]; remove?: number[] };
-
-export interface Asset extends ExternalAsset, AssetInternalId {
-  lastUpdatedTime: Date;
-  createdTime: Date;
+/**
+ * ApiKeyResponse
+ */
+export interface ApiKeyResponse {
+  items: {
+    /**
+     * id of the api key
+     * example:
+     * 91723917823
+     */
+    id: number; // int64
+    /**
+     * id of the service account
+     * example:
+     * 1283712837
+     */
+    serviceAccountId: number; // int64
+    /**
+     * Created time in unix milliseconds
+     * example:
+     * 1554897980221
+     */
+    createdTime: Date; // int64
+    status: 'ACTIVE' | 'DELETED';
+  }[];
+}
+/**
+ * Change that will be applied to array object.
+ */
+export type ArrayPatchLong = ArrayPatchLongSet | ArrayPatchLongAddOrRemove;
+export interface ArrayPatchLongAddOrRemove {
+  add?: number /* int64 */[];
+  remove?: number /* int64 */[];
+}
+export interface ArrayPatchLongSet {
+  set: number /* int64 */[];
+}
+/**
+ * Representation of a physical asset, e.g plant or piece of equipment
+ */
+export interface Asset {
+  externalId?: CogniteExternalId;
+  name: AssetName;
+  parentId?: CogniteInternalId; // int64
+  description?: AssetDescription;
+  metadata?: AssetMetadata;
+  source?: AssetSource;
+  id: CogniteInternalId; // int64
+  createdTime: EpochTimestamp; // int64
+  lastUpdatedTime: EpochTimestamp; // int64
   /**
    * IDs of assets on the path to the asset.
    */
-  path: number[];
+  path: number /* int64 */[];
   /**
    * Asset path depth (number of levels below root node).
    */
-  depth: number;
+  depth: number; // int32
 }
-
 export type AssetChange = AssetChangeById | AssetChangeByExternalId;
-
-export interface AssetChangeByExternalId extends AssetPatch, ExternalId {}
-
-export interface AssetChangeById extends AssetPatch, InternalId {}
-
+/**
+ * Changes applied to asset
+ */
+export interface AssetChangeByExternalId {
+  update: {
+    externalId?: SinglePatchString;
+    name?: SinglePatchRequiredString;
+    description?: SinglePatchString;
+    metadata?: ObjectPatch;
+    source?: SinglePatchString;
+  };
+  externalId: CogniteExternalId;
+}
+/**
+ * Changes applied to asset
+ */
+export interface AssetChangeById {
+  update: {
+    externalId?: SinglePatchString;
+    name?: SinglePatchRequiredString;
+    description?: SinglePatchString;
+    metadata?: ObjectPatch;
+    source?: SinglePatchString;
+  };
+  id: CogniteInternalId; // int64
+}
+export type AssetDataResponse = DataAsset;
+export type AssetDataWithCursorResponse = DataWithCursorAsset;
 /**
  * Description of asset.
  */
 export type AssetDescription = string;
-
-export type AssetExternalId = ExternalId;
-
+export interface AssetExternalId {
+  externalId: CogniteExternalId;
+}
 /**
  * Filter on assets with exact match
  */
-export interface AssetFilter extends Limit {
+export interface AssetFilter {
   filter?: {
     name?: AssetName;
-    parentIds?: CogniteInternalId[];
-    metadata?: Metadata;
+    parentIds?: CogniteInternalId /* int64 */[];
+    metadata?: AssetMetadata;
     source?: AssetSource;
-    createdTime?: DateRange;
-    lastUpdatedTime?: DateRange;
+    createdTime?: EpochTimestampRange;
+    lastUpdatedTime?: EpochTimestampRange;
     /**
-     * Filtered assets are root assets or not
+     * filtered assets are root assets or not
      */
     root?: boolean;
     externalIdPrefix?: CogniteExternalId;
   };
-}
-
-export type AssetIdEither = IdEither;
-
-export type AssetInternalId = InternalId;
-
-export interface AssetListScope extends AssetFilter, Cursor {}
-
-export interface AssetMapping3D extends AssetMapping3DBase {
   /**
-   * A number describing the position of this node in the 3D hierarchy, starting from 0.
-   * The tree is traversed in a depth-first order.
+   * <- Limits the maximum number of results to be returned by single request. In case there are more results to the request 'nextCursor' attribute will be provided as part of response. Request may contain less results than request limit.
    */
-  treeIndex: number;
-  /**
-   * The number of nodes in the subtree of this node (this number included the node itself).
-   */
-  subtreeSize: number;
+  limit?: number; // int32
 }
-
-export interface AssetMapping3DBase {
+export type AssetIdEither = AssetInternalId | AssetExternalId;
+/**
+ * Only include files that reference these specific asset IDs.
+ * example:
+ * 363848954441724,793045462540095,1261042166839739
+ */
+export type AssetIds = CogniteInternalId /* int64 */[];
+export interface AssetInternalId {
+  id: CogniteInternalId; // int64
+}
+/**
+ * Cursor for paging through results
+ */
+export interface AssetListScope {
+  filter?: {
+    name?: AssetName;
+    parentIds?: CogniteInternalId /* int64 */[];
+    metadata?: AssetMetadata;
+    source?: AssetSource;
+    createdTime?: EpochTimestampRange;
+    lastUpdatedTime?: EpochTimestampRange;
+    /**
+     * filtered assets are root assets or not
+     */
+    root?: boolean;
+    externalIdPrefix?: CogniteExternalId;
+  };
+  /**
+   * <- Limits the maximum number of results to be returned by single request. In case there are more results to the request 'nextCursor' attribute will be provided as part of response. Request may contain less results than request limit.
+   */
+  limit?: number; // int32
+  cursor?: string;
+}
+export interface AssetMapping3D {
   /**
    * The ID of the node.
+   * example:
+   * 1003
    */
-  nodeId: CogniteInternalId;
+  nodeId: number; // int64
   /**
    * The ID of the associated asset (Cognite's Assets API).
+   * example:
+   * 3001
    */
-  assetId: CogniteInternalId;
+  assetId: number; // int64
+  /**
+   * A number describing the position of this node in the 3D hierarchy, starting from 0. The tree is traversed in a depth-first order.
+   * example:
+   * 5
+   */
+  treeIndex: number; // int64
+  /**
+   * The number of nodes in the subtree of this node (this number included the node itself).
+   * example:
+   * 7
+   */
+  subtreeSize: number; // int64
 }
-
-export interface AssetMappings3DListFilter extends Cursor, Limit {
-  nodeId?: CogniteInternalId;
-  assetId?: CogniteInternalId;
+export interface AssetMapping3DList {
+  items: AssetMapping3D[];
 }
-
+/**
+ * Custom, application specific metadata. String key -> String value
+ */
+export interface AssetMetadata {
+  [name: string]: string;
+}
 /**
  * Name of asset. Often referred to as tag.
  */
 export type AssetName = string;
-
+/**
+ * Changes applied to asset
+ */
 export interface AssetPatch {
   update: {
     externalId?: SinglePatchString;
@@ -244,19 +214,43 @@ export interface AssetPatch {
     source?: SinglePatchString;
   };
 }
-
-export interface AssetSearchFilter extends AssetFilter {
+export type AssetResponse = Asset;
+export interface AssetSearch {
   search?: {
     name?: AssetName;
     description?: AssetDescription;
   };
 }
-
+/**
+ * Filter on assets with exact match
+ */
+export interface AssetSearchFilter {
+  filter?: {
+    name?: AssetName;
+    parentIds?: CogniteInternalId /* int64 */[];
+    metadata?: AssetMetadata;
+    source?: AssetSource;
+    createdTime?: EpochTimestampRange;
+    lastUpdatedTime?: EpochTimestampRange;
+    /**
+     * filtered assets are root assets or not
+     */
+    root?: boolean;
+    externalIdPrefix?: CogniteExternalId;
+  };
+  /**
+   * <- Limits the maximum number of results to be returned by single request. In case there are more results to the request 'nextCursor' attribute will be provided as part of response. Request may contain less results than request limit.
+   */
+  limit?: number; // int32
+  search?: {
+    name?: AssetName;
+    description?: AssetDescription;
+  };
+}
 /**
  * The source of this asset
  */
 export type AssetSource = string;
-
 /**
  * Data specific to Azure AD authentication
  */
@@ -278,154 +272,693 @@ export interface AzureADConfigurationDTO {
    */
   appResourceId?: string;
 }
-
 /**
- * The bounding box of the subtree with this sector as the root sector.
- * Is null if there are no geometries in the subtree.
+ * The bounding box of the subtree with this sector as the root sector. Is null if there are no geometries in the subtree.
  */
 export interface BoundingBox3D {
-  /**
-   * The minimal coordinates of the bounding box.
-   */
-  min: Tuple3<number>;
-  /**
-   * The maximal coordinates of the bounding box.
-   */
-  max: Tuple3<number>;
+  max: number /* double */[];
+  min: number /* double */[];
 }
-
-export type CREATE = 'CREATE';
-
-export type CogniteCapability = SingleCogniteCapability[];
-
-export interface CogniteEvent extends ExternalEvent, InternalId {
-  lastUpdatedTime: Date;
-  createdTime: Date;
-}
-
+/**
+ * Capability
+ */
+export type CogniteCapability = (
+  | {
+      groupsAcl?: CognitegroupsAclAcl;
+    }
+  | {
+      assetsAcl?: CogniteassetsAclAcl;
+    }
+  | {
+      eventsAcl?: CogniteeventsAclAcl;
+    }
+  | {
+      filesAcl?: CognitefilesAclAcl;
+    }
+  | {
+      usersAcl?: CogniteusersAclAcl;
+    }
+  | {
+      projectsAcl?: CogniteprojectsAclAcl;
+    }
+  | {
+      securityCategoriesAcl?: CognitesecuritycategoriesAclAcl;
+    }
+  | {
+      rawAcl?: CogniterawAclAcl;
+    }
+  | {
+      timeSeriesAcl?: CognitetimeseriesAclAcl;
+    }
+  | {
+      apikeysAcl?: CogniteapikeysAclAcl;
+    }
+  | {
+      threedAcl?: CognitethreedAclAcl;
+    }
+  | {
+      sequencesAcl?: CognitesequencesAclAcl;
+    }
+  | {
+      analyticsAcl?: CogniteanalyticsAclAcl;
+    })[];
 /**
  * External Id provided by client. Should be unique within the project.
  */
 export type CogniteExternalId = string;
-
-export type CogniteInternalId = number;
-
-export type CreateAssetMapping3D = AssetMapping3DBase;
-
+/**
+ * External Id provided by client. Should be unique within the project
+ */
+export type CogniteExternalIdType = string;
+/**
+ * Javascript friendly internal ID given to the object.
+ */
+export type CogniteInternalId = number; // int64
+export declare namespace CogniteInternalId {
+  export type Id = CogniteInternalId; // int64
+}
+/**
+ * Javascript friendly internal ID given to the object.
+ */
+export type CogniteInternalIdType = number; // int64
+/**
+ * Acl:Analytics
+ */
+export interface CogniteanalyticsAclAcl {
+  actions: CogniteanalyticsAclAction[];
+  scope: CogniteanalyticsAclScope;
+}
+/**
+ * Analytics:Action
+ */
+export type CogniteanalyticsAclAction = 'READ' | 'EXECUTE' | 'LIST';
+/**
+ * Analytics:Scope
+ */
+export interface CogniteanalyticsAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:Apikey
+ */
+export interface CogniteapikeysAclAcl {
+  actions: CogniteapikeysAclAction[];
+  scope: CogniteapikeysAclScope;
+}
+/**
+ * Apikey:Action
+ */
+export type CogniteapikeysAclAction = 'LIST' | 'CREATE' | 'DELETE';
+/**
+ * Apikey:Scope
+ */
+export type CogniteapikeysAclScope =
+  | {
+      all?: GenericAclAllScope;
+    }
+  | {
+      /**
+       * apikeys the user making the request has
+       */
+      currentuserscope?: GenericAclCurrentUserScope;
+    };
+/**
+ * Acl:Asset
+ */
+export interface CogniteassetsAclAcl {
+  actions: CogniteassetsAclAction[];
+  scope: CogniteassetsAclScope;
+}
+/**
+ * Asset:Action
+ */
+export type CogniteassetsAclAction = 'READ' | 'WRITE';
+/**
+ * Scope:AssetIdScope
+ */
+export interface CogniteassetsAclIdScope {
+  /**
+   * root asset id (subtrees)
+   */
+  subtreeIds?: string /* uint64 */[];
+}
+/**
+ * Asset:Scope
+ */
+export interface CogniteassetsAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:Event
+ */
+export interface CogniteeventsAclAcl {
+  actions: CogniteeventsAclAction[];
+  scope: CogniteeventsAclScope;
+}
+/**
+ * Event:Action
+ */
+export type CogniteeventsAclAction = 'READ' | 'WRITE';
+/**
+ * Event:Scope
+ */
+export interface CogniteeventsAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:File
+ */
+export interface CognitefilesAclAcl {
+  actions: CognitefilesAclAction[];
+  scope: CognitefilesAclScope;
+}
+/**
+ * File:Action
+ */
+export type CognitefilesAclAction = 'READ' | 'WRITE';
+/**
+ * File:Scope
+ */
+export interface CognitefilesAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:Group
+ */
+export interface CognitegroupsAclAcl {
+  actions: CognitegroupsAclAction[];
+  scope: CognitegroupsAclScope;
+}
+/**
+ * Group:Action
+ */
+export type CognitegroupsAclAction =
+  | 'LIST'
+  | 'READ'
+  | 'CREATE'
+  | 'UPDATE'
+  | 'DELETE';
+/**
+ * Group:Scope
+ */
+export type CognitegroupsAclScope =
+  | {
+      /**
+       * all groups
+       */
+      all?: GenericAclAllScope;
+    }
+  | {
+      /**
+       * groups the current user is in
+       */
+      currentuserscope?: GenericAclCurrentUserScope;
+    };
+/**
+ * Acl:Project
+ */
+export interface CogniteprojectsAclAcl {
+  actions: CogniteprojectsAclAction[];
+  scope: CogniteprojectsAclScope;
+}
+/**
+ * Project:Action
+ */
+export type CogniteprojectsAclAction = 'LIST' | 'READ' | 'CREATE' | 'UPDATE';
+/**
+ * Project:Scope
+ */
+export interface CogniteprojectsAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:Raw
+ */
+export interface CogniterawAclAcl {
+  actions: CogniterawAclAction[];
+  scope: CogniterawAclScope;
+}
+/**
+ * Raw:Action
+ */
+export type CogniterawAclAction = 'READ' | 'WRITE' | 'LIST';
+/**
+ * Raw:Scope
+ */
+export interface CogniterawAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:SecurityCategory
+ */
+export interface CognitesecuritycategoriesAclAcl {
+  actions: CognitesecuritycategoriesAclAction[];
+  scope: CognitesecuritycategoriesAclScope;
+}
+/**
+ * SecurityCategory:Action
+ */
+export type CognitesecuritycategoriesAclAction =
+  | 'MEMBEROF'
+  | 'LIST'
+  | 'CREATE'
+  | 'DELETE';
+/**
+ * SecurityCategory:Scope
+ */
+export interface CognitesecuritycategoriesAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:Sequences
+ */
+export interface CognitesequencesAclAcl {
+  actions: CognitesequencesAclAction[];
+  scope: CognitesequencesAclScope;
+}
+/**
+ * Sequences:Action
+ */
+export type CognitesequencesAclAction = 'READ' | 'WRITE';
+/**
+ * Sequences:Scope
+ */
+export interface CognitesequencesAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:Threed
+ */
+export interface CognitethreedAclAcl {
+  actions: CognitethreedAclAction[];
+  scope: CognitethreedAclScope;
+}
+/**
+ * Threed:Action
+ */
+export type CognitethreedAclAction = 'READ' | 'CREATE' | 'UPDATE' | 'DELETE';
+/**
+ * Threed:Scope
+ */
+export interface CognitethreedAclScope {
+  all?: GenericAclAllScope;
+}
+/**
+ * Acl:Timeseries
+ */
+export interface CognitetimeseriesAclAcl {
+  actions: CognitetimeseriesAclAction[];
+  scope: CognitetimeseriesAclScope;
+}
+/**
+ * Timeseries:Action
+ */
+export type CognitetimeseriesAclAction = 'READ' | 'WRITE';
+/**
+ * Timeseries:Scope
+ */
+export type CognitetimeseriesAclScope =
+  | {
+      all?: GenericAclAllScope;
+    }
+  | {
+      assetIdScope?: CogniteassetsAclIdScope;
+    };
+/**
+ * Acl:User
+ */
+export interface CogniteusersAclAcl {
+  actions: CogniteusersAclAction[];
+  scope: CogniteusersAclScope;
+}
+/**
+ * User:Action
+ */
+export type CogniteusersAclAction = 'LIST' | 'CREATE' | 'DELETE';
+/**
+ * User:Scope
+ */
+export type CogniteusersAclScope =
+  | {
+      /**
+       * all users
+       */
+      all?: GenericAclAllScope;
+    }
+  | {
+      /**
+       * the current user making the request
+       */
+      currentuserscope?: GenericAclCurrentUserScope;
+    };
+export interface CreateAssetMapping3D {
+  /**
+   * The ID of the node.
+   * example:
+   * 1003
+   */
+  nodeId: number; // int64
+  /**
+   * The ID of the associated asset (Cognite's Assets API).
+   * example:
+   * 3001
+   */
+  assetId: number; // int64
+}
 export interface CreateModel3D {
   /**
    * The name of the model.
+   * example:
+   * My Model
    */
   name: string;
+  metadata?: Metadata3D;
 }
-
 export interface CreateRevision3D {
   /**
    * True if the revision is marked as published.
    */
   published?: boolean;
-  /**
-   * Global rotation to be applied to the entire model.
-   * The rotation is expressed by Euler angles in radians and in XYZ order.
-   */
-  rotation?: [boolean, boolean, boolean];
+  rotation?: number /* double */[];
+  metadata?: Metadata3D;
   camera?: RevisionCameraProperties;
   /**
-   * The file id to a file uploaded to Cognite's Files API.
-   * Can only be set on revision creation, and can never be updated. _Only FBX files are supported_.
+   * The file id to a file uploaded to Cognite's Files API. Can only be set on revision creation, and can never be updated. _Only FBX files are supported_.
    */
-  fileId: CogniteInternalId;
+  fileId: number; // int64
 }
-
+/**
+ * The creation time of the resource, in milliseconds since January 1, 1970 at 00:00 UTC.
+ * example:
+ * 0
+ */
+export type CreatedTime = Date; // int64
 /**
  * Cursor for paging through results
  */
 export interface Cursor {
   cursor?: string;
 }
-
-export interface CursorResponse<T> extends ItemsResponse<T> {
-  nextCursor: string;
+export declare namespace Cursor {
+  export type Cursor = string;
 }
-
-export type DELETE = 'DELETE';
-
+export interface DataApiKeyRequest {
+  items: ApiKeyRequest[];
+}
+export interface DataAsset {
+  items: Asset[];
+}
+export interface DataAssetChange {
+  items: AssetChange[];
+}
+export interface DataEvent {
+  items: Event[];
+}
+export interface DataEventChange {
+  items: EventChange[];
+}
+export interface DataExternalAsset {
+  items: DataExternalAssetItem[];
+}
+/**
+ * Representation of a physical asset, e.g plant or piece of equipment
+ */
+export interface DataExternalAssetItem {
+  externalId?: CogniteExternalId;
+  name: AssetName;
+  parentId?: CogniteInternalId; // int64
+  description?: AssetDescription;
+  metadata?: AssetMetadata;
+  source?: AssetSource;
+  parentExternalId?: CogniteExternalId;
+}
+export interface DataExternalEvent {
+  items: ExternalEvent[];
+}
+export interface DataExternalFileMetadata {
+  items?: ExternalFilesMetadata[];
+}
+export interface DataFileChange {
+  items: FileChangeUpdate[];
+}
+export interface DataFileMetadata {
+  items?: FilesMetadata[];
+}
+/**
+ * List of responses. Order matches the requests order.
+ */
+export interface DataGetTimeSeriesMetadataDTO {
+  items: GetTimeSeriesMetadataDTO[];
+}
+export interface DataGroup {
+  items: Group[];
+}
+export interface DataGroupSpec {
+  items: GroupSpec[];
+}
+export interface DataIdentifier {
+  id: CogniteInternalId; // int64
+}
+export interface DataIdentifiers {
+  /**
+   * List of ID objects
+   */
+  items: DataIdentifier[];
+}
 export interface DataIds {
-  items?: AssetIdEither[];
+  items: AssetIdEither[];
 }
-
+export interface DataLong {
+  /**
+   * example:
+   * 23872937137,1238712837,128371973
+   */
+  items: number /* int64 */[];
+}
+export interface DataRawDB {
+  items?: RawDB[];
+}
+export interface DataRawDBRow {
+  items?: RawDBRowInsert[];
+}
+export interface DataRawDBRowKey {
+  items?: RawDBRowKey[];
+}
+export interface DataRawDBTable {
+  items?: RawDBTable[];
+}
+export interface DataSecurityCategorySpecDTO {
+  items: SecurityCategorySpecDTO[];
+}
+/**
+ * A list of objects along with possible cursors to get the next page of results
+ */
+export interface DataWithCursor {
+  items?: FilesMetadata[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+/**
+ * A list of objects along with possible cursors to get the next, or previous, page of results
+ */
+export interface DataWithCursorAsset {
+  items: Asset[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+/**
+ * A list of objects along with possible cursors to get the next, or previous, page of results
+ */
+export interface DataWithCursorEvent {
+  items: Event[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+/**
+ * A list of objects along with possible cursors to get the next page of result
+ */
+export interface DataWithCursorGetTimeSeriesMetadataDTO {
+  items: GetTimeSeriesMetadataDTO[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+/**
+ * A list of objects along with possible cursors to get the next, or previous, page of results
+ */
+export interface DataWithCursorRawDB {
+  items?: RawDB[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+/**
+ * A list of objects along with possible cursors to get the next, or previous, page of results
+ */
+export interface DataWithCursorRawDBRow {
+  items?: RawDBRow[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+/**
+ * A list of objects along with possible cursors to get the next, or previous, page of results
+ */
+export interface DataWithCursorRawDBTable {
+  items?: RawDBTable[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+export interface DataWithLinks {
+  items?: (FileInternalId | FileExternalId)[];
+}
+export interface DatapointsDeleteQuery {
+  /**
+   * List of delete filters
+   */
+  items: DatapointsDeleteRequest[];
+}
 export interface DatapointsDeleteRange {
   /**
    * The timestamp of first datapoint to delete
    */
-  inclusiveBegin: Timestamp;
+  inclusiveBegin: EpochTimestamp; // int64
   /**
    * If set, the timestamp of first datapoint after inclusiveBegin to not delete. If not set, only deletes the datapoint at inclusiveBegin.
    */
-  exclusiveEnd: Timestamp;
+  exclusiveEnd?: EpochTimestamp; // int64
 }
-
+/**
+ * Select timeseries and datapoints to delete.
+ */
 export type DatapointsDeleteRequest =
-  | InternalId & DatapointsDeleteRange
-  | ExternalId & DatapointsDeleteRange;
-
-export interface DatapointsGetAggregateDatapoint extends DatapointsMetadata {
+  | {
+      /**
+       * The timestamp of first datapoint to delete
+       */
+      inclusiveBegin: EpochTimestamp; // int64
+      /**
+       * If set, the timestamp of first datapoint after inclusiveBegin to not delete. If not set, only deletes the datapoint at inclusiveBegin.
+       */
+      exclusiveEnd?: EpochTimestamp; // int64
+      id: CogniteInternalId; // int64
+    }
+  | {
+      /**
+       * The timestamp of first datapoint to delete
+       */
+      inclusiveBegin: EpochTimestamp; // int64
+      /**
+       * If set, the timestamp of first datapoint after inclusiveBegin to not delete. If not set, only deletes the datapoint at inclusiveBegin.
+       */
+      exclusiveEnd?: EpochTimestamp; // int64
+      externalId: CogniteExternalId;
+    };
+export interface DatapointsGetAggregateDatapoint {
+  /**
+   * Id of the timeseries the datapoints belong to
+   */
+  id: CogniteInternalId; // int64
+  /**
+   * External id of the timeseries the datapoints belong to.
+   */
+  externalId?: string;
+  /**
+   * The list of datapoints
+   */
   datapoints: GetAggregateDatapoint[];
 }
-
 export type DatapointsGetDatapoint =
   | DatapointsGetStringDatapoint
   | DatapointsGetDoubleDatapoint;
-
-export interface DatapointsGetDoubleDatapoint extends DatapointsMetadata {
+export interface DatapointsGetDoubleDatapoint {
+  /**
+   * Id of the timeseries the datapoints belong to
+   */
+  id: CogniteInternalId; // int64
+  /**
+   * External id of the timeseries the datapoints belong to.
+   */
+  externalId?: string;
   /**
    * Whether the time series is string valued or not.
    */
-  isString: false;
+  isString: boolean;
   /**
    * The list of datapoints
    */
   datapoints: GetDoubleDatapoint[];
 }
-
-export interface DatapointsGetStringDatapoint extends DatapointsMetadata {
+export interface DatapointsGetStringDatapoint {
+  /**
+   * Id of the timeseries the datapoints belong to
+   */
+  id: CogniteInternalId; // int64
+  /**
+   * External id of the timeseries the datapoints belong to.
+   */
+  externalId?: string;
   /**
    * Whether the time series is string valued or not.
    */
-  isString: true;
+  isString: boolean;
   /**
    * The list of datapoints
    */
   datapoints: GetStringDatapoint[];
 }
-
 export interface DatapointsInsertProperties {
+  /**
+   * The list of datapoints. Total limit per request is 100000 datapoints.
+   */
   datapoints: PostDatapoint[];
 }
-
-export interface DatapointsMetadata extends InternalId {
+export interface DatapointsInsertQuery {
+  items: DatapointsPostDatapoint[];
+}
+export interface DatapointsLatestQuery {
+  /**
+   * List of latest queries
+   */
+  items: LatestDataBeforeRequest[];
+}
+export interface DatapointsMetadata {
+  /**
+   * Id of the timeseries the datapoints belong to
+   */
+  id: CogniteInternalId; // int64
   /**
    * External id of the timeseries the datapoints belong to.
    */
-  externalId?: CogniteExternalId;
+  externalId?: string;
 }
-
-export interface DatapointsMultiQuery extends Limit {
+export interface DatapointsMultiQuery {
   items: DatapointsQuery[];
+  start?: TimestampOrStringStart;
+  end?: TimestampOrStringEnd;
   /**
-   * Get datapoints after this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send in a Date object. Note that when using aggregates, the start time will be rounded down to a whole granularity unit (in UTC timezone). For granularity 2d it will be rounded to 0:00 AM on the same day, for 3h it will be rounded to the start of the hour, etc.
+   * Return up to this number of datapoints.
    */
-  start?: string | Timestamp;
-  /**
-   * Get datapoints up to this time. Same format as for start. Note that when using aggregates, the end will be rounded up such that the last aggregate represents a full aggregation interval containing the original end, where the interval is the granularity unit times the granularity multiplier. For granularity 2d, the aggregation interval is 2 days, if end was originally 3 days after the start, it will be rounded to 4 days after the start.
-   */
-  end?: string | Timestamp;
+  limit?: number; // int32
   /**
    * The aggregates to be returned. This value overrides top-level default aggregates list when set. Specify all aggregates to be retrieved here. Specify empty array if this sub-query needs to return datapoints without aggregation.
    */
   aggregates?: Aggregate[];
   /**
    * The time granularity size and unit to aggregate over.
+   * example:
+   * 1h
    */
   granularity?: string;
   /**
@@ -433,44 +966,92 @@ export interface DatapointsMultiQuery extends Limit {
    */
   includeOutsidePoints?: boolean;
 }
-
+/**
+ * List of responses. Order matches the requests order.
+ */
+export interface DatapointsOrAggregatesResponse {
+  items: (DatapointsGetAggregateDatapoint | DatapointsGetDatapoint)[];
+}
 export type DatapointsPostDatapoint =
-  | DatapointsPostDatapointId
-  | DatapointsPostDatapointExternalId;
-
-export interface DatapointsPostDatapointExternalId
-  extends DatapointsInsertProperties,
-    ExternalId {}
-
-export interface DatapointsPostDatapointId
-  extends DatapointsInsertProperties,
-    InternalId {}
-
-export type DatapointsQuery = DatapointsQueryId | DatapointsQueryExternalId;
-
-export interface DatapointsQueryExternalId
-  extends DatapointsQueryProperties,
-    ExternalId {}
-
-export interface DatapointsQueryId
-  extends DatapointsQueryProperties,
-    InternalId {}
-
-export interface DatapointsQueryProperties extends Limit {
+  | {
+      /**
+       * The list of datapoints. Total limit per request is 100000 datapoints.
+       */
+      datapoints: PostDatapoint[];
+      id: CogniteInternalId; // int64
+    }
+  | {
+      /**
+       * The list of datapoints. Total limit per request is 100000 datapoints.
+       */
+      datapoints: PostDatapoint[];
+      externalId: CogniteExternalId;
+    };
+/**
+ * Parameters describing a query for datapoints.
+ */
+export type DatapointsQuery =
+  | {
+      start?: TimestampOrStringStart;
+      end?: TimestampOrStringEnd;
+      /**
+       * Return up to this number of datapoints.
+       */
+      limit?: number; // int32
+      /**
+       * The aggregates to be returned.  Use default if null. An empty string must be sent to get raw data if the default is a set of aggregates.
+       */
+      aggregates?: Aggregate[];
+      /**
+       * The granularity size and granularity of the aggregates.
+       * example:
+       * 1h
+       */
+      granularity?: string;
+      /**
+       * Whether to include the last datapoint before the requested time period,and the first one after the requested period. This can be useful for interpolating data. Not available for aggregates.
+       */
+      includeOutsidePoints?: boolean;
+      id: CogniteInternalId; // int64
+    }
+  | {
+      start?: TimestampOrStringStart;
+      end?: TimestampOrStringEnd;
+      /**
+       * Return up to this number of datapoints.
+       */
+      limit?: number; // int32
+      /**
+       * The aggregates to be returned.  Use default if null. An empty string must be sent to get raw data if the default is a set of aggregates.
+       */
+      aggregates?: Aggregate[];
+      /**
+       * The granularity size and granularity of the aggregates.
+       * example:
+       * 1h
+       */
+      granularity?: string;
+      /**
+       * Whether to include the last datapoint before the requested time period,and the first one after the requested period. This can be useful for interpolating data. Not available for aggregates.
+       */
+      includeOutsidePoints?: boolean;
+      externalId: CogniteExternalId;
+    };
+export interface DatapointsQueryProperties {
+  start?: TimestampOrStringStart;
+  end?: TimestampOrStringEnd;
   /**
-   * Get datapoints after this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send in Date object. Note that when using aggregates, the start time will be rounded down to a whole granularity unit (in UTC timezone). For granularity 2d it will be rounded to 0:00 AM on the same day, for 3h it will be rounded to the start of the hour, etc.
+   * Return up to this number of datapoints.
    */
-  start?: string | Timestamp;
-  /**
-   * Get datapoints up to this time. Same format as for start. Note that when using aggregates, the end will be rounded up such that the last aggregate represents a full aggregation interval containing the original end, where the interval is the granularity unit times the granularity multiplier. For granularity 2d, the aggregation interval is 2 days, if end was originally 3 days after the start, it will be rounded to 4 days after the start.
-   */
-  end?: string | Timestamp;
+  limit?: number; // int32
   /**
    * The aggregates to be returned.  Use default if null. An empty string must be sent to get raw data if the default is a set of aggregates.
    */
   aggregates?: Aggregate[];
   /**
-   * The granularity size and granularity of the aggregates (2h)
+   * The granularity size and granularity of the aggregates.
+   * example:
+   * 1h
    */
   granularity?: string;
   /**
@@ -478,103 +1059,338 @@ export interface DatapointsQueryProperties extends Limit {
    */
   includeOutsidePoints?: boolean;
 }
-
-export type DateRange = Range<Timestamp>;
-
 /**
- * A default group for all project users. Can be used to establish default capabilities. WARNING: this group may be logically deleted
+ * List of responses. Order matches the requests order.
  */
-export type DefaultGroupId = number;
-
-export type DeleteAssetMapping3D = AssetMapping3DBase;
-
-export type EXECUTE = 'EXECUTE';
-
-export type EventChange = EventChangeById | EventChangeByExternalId;
-
-export interface EventChangeByExternalId extends EventPatch, ExternalId {}
-
-export interface EventChangeById extends EventPatch, InternalId {}
-
-export interface EventFilter {
-  startTime?: DateRange;
-  endTime?: DateRange;
-  metadata?: Metadata;
+export interface DatapointsResponse {
+  items: DatapointsGetDatapoint[];
+}
+/**
+ * A default group for all project users. Can be used to establish default capabilities.WARNING: this group may be logically deleted
+ * example:
+ * 123871937
+ */
+export type DefaultGroupId = number; // int64
+export interface DeleteAssetMapping3D {
+  /**
+   * The ID of the node.
+   * example:
+   * 1003
+   */
+  nodeId: number; // int64
+  /**
+   * The ID of the associated asset (Cognite's Assets API).
+   * example:
+   * 3001
+   */
+  assetId: number; // int64
+}
+export interface DuplicatedIdsInRequestResponse {
+  /**
+   * Error details
+   */
+  error: {
+    /**
+     * HTTP status code
+     * example:
+     * 422
+     */
+    code: number; // int32
+    /**
+     * Error message
+     */
+    message: string;
+    /**
+     * Items which are duplicated
+     */
+    duplicated: (
+      | {
+          id: CogniteInternalId; // int64
+        }
+      | {
+          externalId: CogniteExternalId;
+        })[];
+  };
+}
+export type EitherId = InternalId | ExternalId;
+export interface EmptyResponse {}
+/**
+ * It is the number of milliseconds that have elapsed since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+ */
+export type EpochTimestamp = Date; // int64
+/**
+ * Range between two timestamps
+ */
+export interface EpochTimestampRange {
+  max?: EpochTimestamp; // int64
+  min?: EpochTimestamp; // int64
+}
+/**
+ * Cognite API error
+ */
+export interface Error {
+  /**
+   * HTTP status code
+   * example:
+   * 401
+   */
+  code: number; // int32
+  /**
+   * Error message
+   * example:
+   * Could not authenticate.
+   */
+  message: string;
+  /**
+   * List of lookup objects that have not matched any results.
+   */
+  missing?: {
+    [name: string]: any;
+  }[];
+  /**
+   * List of objects that violate the uniqueness constraint.
+   */
+  duplicated?: {
+    [name: string]: any;
+  }[];
+}
+export interface ErrorResponse {
+  error: Error;
+}
+/**
+ * An event represents something that happened at a given interval in time, e.g a failure, a work order etc.
+ */
+export interface Event {
+  externalId?: CogniteExternalIdType;
+  startTime?: EpochTimestamp; // int64
+  endTime?: EpochTimestamp; // int64
+  /**
+   * Type of the event, e.g 'failure'.
+   */
+  type?: string;
+  /**
+   * Subtype of the event, e.g 'electrical'.
+   */
+  subtype?: string;
+  /**
+   * Textual description of the event.
+   */
+  description?: string;
+  metadata?: EventMetadata;
   /**
    * Asset IDs of related equipment that this event relates to.
    */
-  assetIds?: CogniteInternalId[];
+  assetIds?: CogniteInternalIdType /* int64 */[];
+  /**
+   * The source of this event.
+   */
+  source?: string;
+  id: CogniteInternalIdType; // int64
+  lastUpdatedTime: EpochTimestamp; // int64
+  createdTime: EpochTimestamp; // int64
 }
-
-export interface EventFilterRequest extends Cursor, Limit {
-  filter?: EventFilter;
-}
-
-export interface EventPatch {
+export type EventChange = EventChangeById | EventChangeByExternalId;
+/**
+ * Changes will be applied to event.
+ */
+export interface EventChangeByExternalId {
   update: {
     externalId?: SinglePatchString;
-    startTime?: SinglePatchDate;
-    endTime?: SinglePatchDate;
+    startTime?: SinglePatchLong;
+    endTime?: SinglePatchLong;
     description?: SinglePatchString;
     metadata?: ObjectPatch;
     assetIds?: ArrayPatchLong;
     source?: SinglePatchString;
+    type?: SinglePatchString;
+    subtype?: SinglePatchString;
+  };
+  externalId: CogniteExternalIdType;
+}
+/**
+ * Changes will be applied to event.
+ */
+export interface EventChangeById {
+  update: {
+    externalId?: SinglePatchString;
+    startTime?: SinglePatchLong;
+    endTime?: SinglePatchLong;
+    description?: SinglePatchString;
+    metadata?: ObjectPatch;
+    assetIds?: ArrayPatchLong;
+    source?: SinglePatchString;
+    type?: SinglePatchString;
+    subtype?: SinglePatchString;
+  };
+  id: CogniteInternalIdType; // int64
+}
+export type EventDataResponse = EventResponse;
+export type EventDataWithCursorResponse = EventWithCursorResponse;
+/**
+ * Filter on events filter with exact match
+ */
+export interface EventFilter {
+  startTime?: EpochTimestampRange;
+  endTime?: EpochTimestampRange;
+  metadata?: EventMetadata;
+  /**
+   * Asset IDs of related equipment that this event relates to.
+   */
+  assetIds?: CogniteInternalIdType /* int64 */[];
+  /**
+   * The source of this event.
+   */
+  source?: string;
+  /**
+   * The event type
+   */
+  type?: string;
+  /**
+   * The event subtype
+   */
+  subtype?: string;
+  createdTime?: EpochTimestampRange;
+  lastUpdatedTime?: EpochTimestampRange;
+  externalIdPrefix?: CogniteExternalIdType;
+}
+/**
+ * Cursor for paging through results
+ */
+export interface EventFilterRequest {
+  filter?: EventFilter;
+  /**
+   * <- Limits the maximum number of results to be returned by single request. In case there are more results to the request 'nextCursor' attribute will be provided as part of response. Request may contain less results than request limit.
+   */
+  limit?: number; // int32
+  cursor?: string;
+}
+/**
+ * Custom, application specific metadata. String key -> String value
+ */
+export interface EventMetadata {
+  [name: string]: string;
+}
+/**
+ * Changes will be applied to event.
+ */
+export interface EventPatch {
+  update: {
+    externalId?: SinglePatchString;
+    startTime?: SinglePatchLong;
+    endTime?: SinglePatchLong;
+    description?: SinglePatchString;
+    metadata?: ObjectPatch;
+    assetIds?: ArrayPatchLong;
+    source?: SinglePatchString;
+    type?: SinglePatchString;
+    subtype?: SinglePatchString;
   };
 }
-
+export type EventResponse = Event;
 export interface EventSearch {
+  /**
+   * text to search in description field across events
+   */
   description?: string;
 }
-
-export interface EventSearchRequest extends Limit {
+/**
+ * Filter on events filter with exact match
+ */
+export interface EventSearchRequest {
   filter?: EventFilter;
   search?: EventSearch;
+  /**
+   * <- Limits the maximum number of results to be returned by single request. In case there are more results to the request 'nextCursor' attribute will be provided as part of response. Request may contain less results than request limit.
+   */
+  limit?: number; // int32
 }
-
+/**
+ * A list of objects along with possible cursors to get the next, or previous, page of results
+ */
+export interface EventWithCursorResponse {
+  items: Event[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
+/**
+ * Representation of a physical asset, e.g plant or piece of equipment
+ */
 export interface ExternalAsset {
   externalId?: CogniteExternalId;
-  name?: AssetName;
-  parentId?: CogniteInternalId;
+  name: AssetName;
+  parentId?: CogniteInternalId; // int64
   description?: AssetDescription;
-  metadata?: Metadata;
+  metadata?: AssetMetadata;
   source?: AssetSource;
 }
-
-export interface ExternalAssetItem extends ExternalAsset {
-  /**
-   * External id to the parent asset
-   */
-  parentExternalId?: CogniteExternalId;
-}
-
 /**
  * An event represents something that happened at a given interval in time, e.g a failure, a work order etc.
  */
 export interface ExternalEvent {
-  externalId?: CogniteExternalId;
-  startTime?: Timestamp;
-  endTime?: Timestamp;
+  externalId?: CogniteExternalIdType;
+  startTime?: EpochTimestamp; // int64
+  endTime?: EpochTimestamp; // int64
+  /**
+   * Type of the event, e.g 'failure'.
+   */
   type?: string;
+  /**
+   * Subtype of the event, e.g 'electrical'.
+   */
   subtype?: string;
+  /**
+   * Textual description of the event.
+   */
   description?: string;
-  metadata?: Metadata;
-  assetIds?: CogniteInternalId[];
+  metadata?: EventMetadata;
+  /**
+   * Asset IDs of related equipment that this event relates to.
+   */
+  assetIds?: CogniteInternalIdType /* int64 */[];
+  /**
+   * The source of this event.
+   */
   source?: string;
 }
-
 export interface ExternalFilesMetadata {
   externalId?: CogniteExternalId;
   name: FileName;
-  source?: string;
-  mimeType?: FileMimeType;
-  metadata?: Metadata;
-  assetIds?: CogniteInternalId[];
+  source?: FileSource;
+  mimeType?: MimeType;
+  metadata?: FilesMetadataField;
+  assetIds?: CogniteInternalId /* int64 */[];
 }
-
 export interface ExternalId {
-  externalId: CogniteExternalId;
+  externalId: CogniteExternalIdType;
 }
-
+export interface ExternalIdsAlreadyExistResponse {
+  /**
+   * Error details
+   */
+  error: {
+    /**
+     * HTTP status code
+     * example:
+     * 409
+     */
+    code: number; // int32
+    /**
+     * Error message
+     */
+    message: string;
+    /**
+     * Items which are duplicated
+     */
+    duplicated: {
+      externalId: CogniteExternalId;
+    }[];
+  };
+}
+/**
+ * Changes will be applied to file.
+ */
 export interface FileChange {
   update: {
     externalId?: SinglePatchString;
@@ -583,68 +1399,142 @@ export interface FileChange {
     assetIds?: ArrayPatchLong;
   };
 }
-
 export type FileChangeUpdate =
   | FileChangeUpdateById
   | FileChangeUpdateByExternalId;
-
-export interface FileChangeUpdateByExternalId extends ExternalId, FileChange {}
-
-export interface FileChangeUpdateById extends InternalId, FileChange {}
-
-export type FileContent = ArrayBuffer | Buffer | any;
-
-export interface FileFilter extends Limit {
-  filter?: {
-    name?: FileName;
-    mimeType?: FileMimeType;
-    metadata?: Metadata;
-    /**
-     * Only include files that reference these specific asset IDs.
-     */
-    assetIds?: CogniteInternalId[];
-    source?: string;
-    createdTime?: DateRange;
-    lastUpdatedTime?: DateRange;
-    uploadedTime?: DateRange;
-    externalIdPrefix?: CogniteExternalId;
-    uploaded?: boolean;
+/**
+ * Changes will be applied to file.
+ */
+export interface FileChangeUpdateByExternalId {
+  externalId: CogniteExternalId;
+  update: {
+    externalId?: SinglePatchString;
+    source?: SinglePatchString;
+    metadata?: ObjectPatch;
+    assetIds?: ArrayPatchLong;
   };
 }
-
-export interface FileLink {
-  downloadUrl: string;
-}
-
 /**
- * File type. E.g. text/plain, application/pdf, ...
+ * Changes will be applied to file.
  */
-export type FileMimeType = string;
-
+export interface FileChangeUpdateById {
+  id: CogniteInternalId; // int64
+  update: {
+    externalId?: SinglePatchString;
+    source?: SinglePatchString;
+    metadata?: ObjectPatch;
+    assetIds?: ArrayPatchLong;
+  };
+}
+export interface FileExternalId {
+  externalId?: CogniteExternalId;
+}
+/**
+ * Filter on files with exact match
+ */
+export interface FileFilter {
+  filter?: {
+    name?: FileName;
+    mimeType?: MimeType;
+    metadata?: FilesMetadataField;
+    assetIds?: AssetIds;
+    /**
+     * The source of this event.
+     */
+    source?: string;
+    createdTime?: EpochTimestampRange;
+    lastUpdatedTime?: EpochTimestampRange;
+    uploadedTime?: EpochTimestampRange;
+    externalIdPrefix?: CogniteExternalId;
+    /**
+     * Whether or not the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
+     * example:
+     * true
+     */
+    uploaded?: boolean;
+  };
+  /**
+   * <- Maximum number of items that the client want to get back.
+   */
+  limit?: number; // int32
+}
+export type FileIdEither = FileInternalId | FileExternalId;
+export interface FileInternalId {
+  id?: CogniteInternalId; // int64
+}
+export interface FileLink {
+  downloadUrl?: string;
+}
+export interface FileLinkIds {
+  items?: FileIdEither[];
+}
+export type FileMetadataResponse = FilesMetadata;
+export type FileMetadataWithCursorResponse = DataWithCursor;
 /**
  * Name of the file.
  */
 export type FileName = string;
-
-export interface FileRequestFilter extends Cursor, FileFilter {}
-
-export interface FilesMetadata extends ExternalFilesMetadata {
-  id: CogniteInternalId;
+export type FileResponse = DataFileMetadata;
+/**
+ * The source of the file.
+ */
+export type FileSource = string;
+export interface FilesMetadata {
+  externalId?: CogniteExternalId;
+  name: FileName;
+  source?: FileSource;
+  mimeType?: MimeType;
+  metadata?: FilesMetadataField;
+  assetIds?: CogniteInternalId /* int64 */[];
+  id: CogniteInternalId; // int64
   /**
-   * Whether or not the actual file is uploaded
+   * Whether or not the actual file is uploaded.  This field is returned only by the API, it has no effect in a post body.
+   * example:
+   * true
    */
   uploaded: boolean;
-  uploadedTime?: Date;
-  createdTime: Date;
-  lastUpdatedTime: Date;
+  uploadedTime?: EpochTimestamp; // int64
+  createdTime: EpochTimestamp; // int64
+  lastUpdatedTime: EpochTimestamp; // int64
 }
-
-export interface FilesSearchFilter extends FileFilter {
+/**
+ * Custom, application specific metadata. String key -> String value
+ */
+export interface FilesMetadataField {
+  [name: string]: string;
+}
+/**
+ * Filter on files with exact match
+ */
+export interface FilesSearchFilter {
+  filter?: {
+    name?: FileName;
+    mimeType?: MimeType;
+    metadata?: FilesMetadataField;
+    assetIds?: AssetIds;
+    /**
+     * The source of this event.
+     */
+    source?: string;
+    createdTime?: EpochTimestampRange;
+    lastUpdatedTime?: EpochTimestampRange;
+    uploadedTime?: EpochTimestampRange;
+    externalIdPrefix?: CogniteExternalId;
+    /**
+     * Whether or not the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
+     * example:
+     * true
+     */
+    uploaded?: boolean;
+  };
+  /**
+   * <- Maximum number of items that the client want to get back.
+   */
+  limit?: number; // int32
   search?: {
     name?: FileName;
   };
 }
-
 export interface Filter {
   /**
    * Filter on unit (case-sensitive).
@@ -659,47 +1549,115 @@ export interface Filter {
    */
   isStep?: boolean;
   /**
-   * Filter out timeseries that do not match these metadata fields and values (case-sensitive)
+   * Filter out timeseries that do not match these metadata fields and values (case-sensitive). Format is {"key1":"value1","key2":"value2"}.
+   * example:
+   * [object Object]
    */
-  metadata?: Metadata;
+  metadata?: {};
   /**
    * Filter out time series that are not linked to any of these assets.
+   * example:
+   * 363848954441724,793045462540095,1261042166839739
    */
-  assetIds?: CogniteInternalId[];
-  createdTime?: Date;
-  lastUpdatedTime?: Date;
+  assetIds?: CogniteInternalId /* int64 */[];
+  /**
+   * Filter out time series with createdTime outside this range.
+   */
+  createdTime?: EpochTimestampRange;
+  /**
+   * Filter out time series with lastUpdatedTime outside this range.
+   */
+  lastUpdatedTime?: EpochTimestampRange;
 }
-
-export interface GetAggregateDatapoint extends GetDatapointMetadata {
-  average?: number;
-  max?: number;
-  min?: number;
-  count?: number;
-  sum?: number;
-  interpolation?: number;
-  stepInterpolation?: number;
-  continuousVariance?: number;
-  discreteVariance?: number;
-  totalVariation?: number;
+/**
+ * Scope:All
+ */
+export interface GenericAclAllScope {}
+/**
+ * Scope:CurrentUser
+ */
+export interface GenericAclCurrentUserScope {}
+export interface GetAggregateDatapoint {
+  /**
+   * The data timestamp in milliseconds since the epoch (Jan 1, 1970).
+   */
+  timestamp: EpochTimestamp; // int64
+  /**
+   * The integral average value in the aggregate period
+   */
+  average?: number; // double
+  /**
+   * The maximum value in the aggregate period
+   */
+  max?: number; // double
+  /**
+   * The minimum value in the aggregate period
+   */
+  min?: number; // double
+  /**
+   * The number of datapoints in the aggregate period
+   */
+  count?: number; // int32
+  /**
+   * The sum of the datapoints in the aggregate period
+   */
+  sum?: number; // double
+  /**
+   * The interpolated value of the series in the beginning of the aggregate
+   */
+  interpolation?: number; // double
+  /**
+   * The last value before or at the beginning of the aggregate.
+   */
+  stepInterpolation?: number; // double
+  /**
+   * The variance of the interpolated underlying function.
+   */
+  continuousVariance?: number; // double
+  /**
+   * The variance of the datapoint values.
+   */
+  discreteVariance?: number; // double
+  /**
+   * The total variation of the interpolated underlying function.
+   */
+  totalVariation?: number; // double
 }
-
 export interface GetDatapointMetadata {
-  timestamp: Date;
+  /**
+   * The data timestamp in milliseconds since the epoch (Jan 1, 1970).
+   */
+  timestamp: EpochTimestamp; // int64
 }
-
-export interface GetDoubleDatapoint extends GetDatapointMetadata {
+export interface GetDoubleDatapoint {
+  /**
+   * The data timestamp in milliseconds since the epoch (Jan 1, 1970).
+   */
+  timestamp: EpochTimestamp; // int64
+  /**
+   * The data value.
+   */
   value: number;
 }
-
-export interface GetStringDatapoint extends GetDatapointMetadata {
+export interface GetStringDatapoint {
+  /**
+   * The data timestamp in milliseconds since the epoch (Jan 1, 1970).
+   */
+  timestamp: EpochTimestamp; // int64
+  /**
+   * The data value.
+   */
   value: string;
 }
-
-export interface GetTimeSeriesMetadataDTO extends InternalId {
+export interface GetTimeSeriesMetadataDTO {
+  /**
+   * Generated id of the time series
+   */
+  id: CogniteInternalId; // int64
   /**
    * Externally supplied id of the time series
    */
-  externalId?: CogniteExternalId;
+  externalId?: string;
   /**
    * Name of time series
    */
@@ -711,7 +1669,7 @@ export interface GetTimeSeriesMetadataDTO extends InternalId {
   /**
    * Additional metadata. String key -> String value.
    */
-  metadata?: Metadata;
+  metadata?: {};
   /**
    * The physical unit of the time series.
    */
@@ -719,7 +1677,7 @@ export interface GetTimeSeriesMetadataDTO extends InternalId {
   /**
    * Asset that this time series belongs to.
    */
-  assetId?: CogniteInternalId;
+  assetId?: CogniteInternalId; // int64
   /**
    * Whether the time series is a step series or not.
    */
@@ -727,67 +1685,93 @@ export interface GetTimeSeriesMetadataDTO extends InternalId {
   /**
    * Description of the time series.
    */
-  description: string;
+  description?: string;
   /**
    * Security categories required in order to access this time series.
    */
-  securityCategories?: number[];
-  createdTime: Date;
-  lastUpdatedTime: Date;
+  securityCategories?: number /* int64 */[];
+  /**
+   * Time when this time-series is created in CDF in milliseconds since Jan 1, 1970.
+   */
+  createdTime: EpochTimestamp; // int64
+  /**
+   * The latest time when this time-series is updated in CDF in milliseconds since Jan 1, 1970.
+   */
+  lastUpdatedTime: EpochTimestamp; // int64
 }
-
 export interface Group {
   name: GroupName;
   sourceId?: GroupSourceId;
   capabilities?: CogniteCapability;
-  id: number;
+  id: number; // int64
   isDeleted: boolean;
-  deletedTime?: Date;
+  deletedTime?: Date; // int64
 }
-
 /**
  * Name of the group
- * @example Production Engineers
+ * example:
+ * Production Engineers
  */
 export type GroupName = string;
-
-export interface GroupServiceAccount {
-  /**
-   * Unique name of the service account
-   * @example some-internal-service@apple.com
-   */
-  name: string;
-  id: CogniteInternalId;
-  /**
-   * List of group ids
-   */
-  groups: CogniteInternalId[];
-  /**
-   * If this service account has been logically deleted
-   */
-  isDeleted: boolean;
-  /**
-   * Time of deletion
-   */
-  deletedTime?: Date;
-}
-
+export type GroupResponse = DataGroup;
 /**
  * ID of the group in the source. If this is the same ID as a group in the IDP, a user in that group will implicitly be a part of this group as well.
- * @example b7c9a5a4-99c2-4785-bed3-5e6ad9a78603
+ * example:
+ * b7c9a5a4-99c2-4785-bed3-5e6ad9a78603
  */
 export type GroupSourceId = string;
-
+/**
+ * A specification for creating a new group
+ */
 export interface GroupSpec {
   name: GroupName;
   sourceId?: GroupSourceId;
   capabilities?: CogniteCapability;
 }
-
-export type Groups = CogniteInternalId[];
-
-export type IdEither = InternalId | ExternalId;
-
+/**
+ * List of group ids
+ * example:
+ * 238712387,1283712837,1238712387
+ */
+export type Groups = number /* int64 */[];
+export interface HeaderParameters {
+  Origin?: Parameters.Origin;
+}
+/**
+ * An ID JWT token
+ */
+export interface IdToken {
+  /**
+   * The subject of the token
+   * example:
+   * tim@apple.com
+   */
+  sub: string;
+  /**
+   * Which CDF project the subject is in
+   * example:
+   * apple
+   */
+  project_name: string;
+  /**
+   * Which groups (by id) the subject is in
+   * example:
+   * 123982398,123981283723,7283273927
+   */
+  groups: number /* int64 */[];
+  /**
+   * The signing key id
+   * example:
+   * a769f8ef-d5e3-4cf7-b914-2a6de189d942
+   */
+  signing_key: string;
+  /**
+   * The expiration time of the token in seconds (unix)
+   * example:
+   * 1554897484
+   */
+  exp: number; // int64
+}
 /**
  * Data about how to authenticate and authorize users
  */
@@ -796,167 +1780,318 @@ export interface InputProjectAuthentication {
   validDomains?: ValidDomains;
   oAuth2Configuration?: OAuth2ConfigurationDTO;
 }
-
 /**
- * Range between two integers
+ * An event represents something that happened at a given interval in time, e.g a failure, a work order etc.
  */
-export type IntegerRange = Range<number>;
-
+export interface InternalEvent {
+  externalId?: CogniteExternalIdType;
+  startTime?: EpochTimestamp; // int64
+  endTime?: EpochTimestamp; // int64
+  /**
+   * Type of the event, e.g 'failure'.
+   */
+  type?: string;
+  /**
+   * Subtype of the event, e.g 'electrical'.
+   */
+  subtype?: string;
+  /**
+   * Textual description of the event.
+   */
+  description?: string;
+  metadata?: EventMetadata;
+  /**
+   * Asset IDs of related equipment that this event relates to.
+   */
+  assetIds?: CogniteInternalIdType /* int64 */[];
+  /**
+   * The source of this event.
+   */
+  source?: string;
+}
 export interface InternalId {
-  id: CogniteInternalId;
+  id: CogniteInternalIdType; // int64
 }
-
-export interface ItemsResponse<T> {
-  items: T[];
-}
-
-export type LIST = 'LIST';
-
+export type JsonArrayInt64 = string; // jsonArray(int64)
+/**
+ * Describes latest query
+ */
 export type LatestDataBeforeRequest =
-  | InternalId & LatestDataPropertyFilter
-  | ExternalId & LatestDataPropertyFilter;
-
+  | {
+      /**
+       * Get first datapoint before this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time in ms since epoch.
+       */
+      before?: Date | string;
+      id: CogniteInternalId; // int64
+    }
+  | {
+      /**
+       * Get first datapoint before this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time in ms since epoch.
+       */
+      before?: Date | string;
+      externalId: CogniteExternalId;
+    };
 export interface LatestDataPropertyFilter {
   /**
-   * Get first datapoint before this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time as a Date object.
+   * Get first datapoint before this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time in ms since epoch.
    */
-  before: string | Date;
+  before?: Date | string;
 }
-
-export interface Limit {
-  limit?: number;
+export declare namespace Limit {
+  export type Limit = number;
 }
-
-export interface List3DNodesQuery extends Cursor, Limit {
+/**
+ * Represents the current authentication status of the request
+ */
+export interface LoginStatusDTO {
   /**
-   * Get sub nodes up to this many levels below the specified node. Depth 0 is the root node.
+   * The user principal, e.g john.doe@corporation.com.
+   * example:
+   * tim@apple.com
    */
-  depth?: number;
+  user: string;
   /**
-   * ID of a node that are the root of the subtree you request (default is the root node).
+   * Whether the user is logged in or not.
+   * example:
+   * true
    */
-  nodeId?: CogniteInternalId;
+  loggedIn: boolean;
+  /**
+   * Name of project user belongs to
+   * example:
+   * tesla
+   */
+  project: string;
+  /**
+   * Internal project id of the project
+   * example:
+   * 137238723719
+   */
+  projectId: number; // int64
+  /**
+   * ID of the api key making the request. This is optional and only present if an api key is used as authentication.
+   */
+  apiKeyId?: number; // int64
 }
-
-export interface ListGroups {
-  /**
-   * Whether to get all groups, only available with the groups:list acl.
-   */
-  all?: boolean;
+/**
+ * LoginStatusResponse
+ */
+export interface LoginStatusResponse {
+  data: LoginStatusDTO;
 }
-
-export interface ListRawDatabases extends Cursor, Limit {}
-
-export interface ListRawRows extends Cursor, Limit {
+/**
+ * Represents an url where the user can be redirected to sign in.
+ */
+export interface LoginUrlDTO {
   /**
-   * Set this to true if you only want to fetch row keys
+   * The url where the user can be redirected to sign in.
    */
-  onlyRowKeys?: boolean;
-  /**
-   * Specify this to limit columns to retrieve. Array of column keys
-   */
-  columns?: string[];
-  /**
-   * Exclusive filter for last updated time. When specified only rows updated after this time will be returned
-   */
-  minLastUpdatedTime?: Date;
-  /**
-   * Inclusive filter for last updated time. When specified only rows updated before this time will be returned
-   */
-  maxLastUpdatedTime?: Date;
+  url?: string;
 }
-
-export interface ListRawTables extends Cursor, Limit {}
-
-export interface ListResponse<T> extends CursorResponse<T> {
-  next?: () => Promise<ListResponse<T>>;
+export interface LoginUrlResponse {
+  data?: LoginUrlDTO;
 }
-
-export interface ListReveal3DNodeAncestors extends Cursor, Limit {}
-
-export interface ListRevealSectors3DQuery extends Cursor, Limit {
-  /**
-   * Bounding box to restrict search to. If given, only return sectors that intersect the given bounding box. Given as a JSON-encoded object of two arrays \"min\" and \"max\" with 3 coordinates each.
-   */
-  boundingBox?: BoundingBox3D;
-}
-
-export interface ListSecurityCategories extends Cursor, Limit {
-  sort?: 'ASC' | 'DESC';
-}
-
-export type MEMBEROF = 'MEMBEROF';
-
 /**
  * Custom, application specific metadata. String key -> String value
  */
-export interface Metadata {
-  [key: string]: string;
+export interface Metadata3D {
+  [name: string]: string;
 }
-
+/**
+ * File type. E.g. text/plain, application/pdf, ..
+ * example:
+ * image/jpeg
+ */
+export type MimeType = string;
+/**
+ * Some required fields are missing
+ */
+export interface MissingField {
+  /**
+   * HTTP status code
+   * example:
+   * 400
+   */
+  code: number; // int32
+  /**
+   * Error message
+   */
+  message: string;
+  /**
+   * Additional data
+   */
+  extra?: {};
+  /**
+   * Fields that are missing.
+   */
+  missingFields: {}[];
+}
+export interface MissingFieldError {
+  error: {
+    /**
+     * HTTP status code
+     * example:
+     * 400
+     */
+    code: number; // int32
+    /**
+     * Error message
+     */
+    message: string;
+    /**
+     * Fields that are missing.
+     */
+    missingFields: {}[];
+  };
+}
 export interface Model3D {
   /**
    * The name of the model.
+   * example:
+   * My Model
    */
   name: string;
   /**
    * The ID of the model.
+   * example:
+   * 1000
    */
-  id: CogniteInternalId;
-  createdTime: Date;
+  id: number; // int64
+  createdTime: CreatedTime; // int64
+  metadata?: Metadata3D;
 }
-
-export interface Model3DListRequest extends Limit {
+export interface Model3DList {
+  items: Model3D[];
+}
+export declare namespace ModelId {
+  export type ModelId = number; // int64
+}
+export declare namespace Name {
+  export type Name = FileName;
+}
+export interface NewApiKeyResponse {
+  items: NewApiKeyResponseDTO[];
+}
+export interface NewApiKeyResponseDTO {
   /**
-   * Filter based on whether or not it has published revisions.
+   * Internal id for the api key
    */
-  published?: boolean;
-}
-
-export interface NewApiKeyResponse extends ApiKeyObject {
+  id: number; // int64
+  /**
+   * id of the service account
+   */
+  serviceAccountId: number; // int64
+  /**
+   * Time of creating in unix ms
+   */
+  createdTime: Date; // int64
+  /**
+   * The status of the api key.
+   */
+  status: 'ACTIVE' | 'DELETED';
   /**
    * The api key to be used against the API
+   * example:
+   * MQ23y87QSDKIJSd87287sdJkjsd
    */
   value: string;
 }
-
+/**
+ * Cursor to get the next page of results (if available).
+ */
+export type NextCursor = string;
+export interface NextCursorData {
+  nextCursor?: NextCursor;
+}
 export interface Node3D {
   /**
    * The ID of the node.
+   * example:
+   * 1000
    */
-  id: CogniteInternalId;
+  id: number; // int64
   /**
-   * The index of the node in the 3D model hierarchy, starting from 0.
-   * The tree is traversed in a depth-first order.
+   * The index of the node in the 3D model hierarchy, starting from 0. The tree is traversed in a depth-first order.
+   * example:
+   * 3
    */
-  treeIndex: number;
+  treeIndex: number; // int64
   /**
    * The parent of the node, null if it is the root node.
+   * example:
+   * 2
    */
-  parentId: CogniteInternalId;
+  parentId: null | number; // int64
   /**
    * The depth of the node in the tree, starting from 0 at the root node.
+   * example:
+   * 2
    */
-  depth: number;
+  depth: number; // int64
   /**
    * The name of the node.
+   * example:
+   * Node name
    */
   name: string;
   /**
    * The number of descendants of the node, plus one (counting itself).
+   * example:
+   * 4
    */
-  subtreeSize: number;
-  /**
-   *  The bounding box of the subtree with this sector as the root sector.
-   *  Is null if there are no geometries in the subtree.
-   */
+  subtreeSize: number; // int64
   boundingBox: BoundingBox3D;
 }
-
-export type NullableSinglePatchLong = { set: number } | { setNull: true };
-
-export type NullableSinglePatchString = { set: string } | { setNull: true };
-
+export interface Node3DList {
+  items: Node3D[];
+}
+export interface NotFoundResponse {
+  /**
+   * Error details
+   */
+  error: {
+    /**
+     * HTTP status code
+     * example:
+     * 400
+     */
+    code: number; // int32
+    /**
+     * Error message
+     */
+    message: string;
+    /**
+     * Items which are not found
+     */
+    missing: (
+      | {
+          id: CogniteInternalId; // int64
+        }
+      | {
+          externalId: CogniteExternalId;
+        })[];
+  };
+}
+/**
+ * Change that will be applied to assetId.
+ */
+export type NullableSinglePatchLong =
+  | {
+      set: number; // int64
+    }
+  | {
+      setNull: 'true';
+    };
+/**
+ * Change that will be applied to description.
+ */
+export type NullableSinglePatchString =
+  | {
+      set: string;
+    }
+  | {
+      setNull: 'true';
+    };
 /**
  * Data related to generic OAuth2 authentication. Not used for Azure AD
  */
@@ -982,42 +2117,129 @@ export interface OAuth2ConfigurationDTO {
    */
   clientSecret?: string;
 }
-
-export type ObjectPatch =
-  | {
-      /**
-       * Set the key-value pairs. All existing key-value pairs will be removed.
-       */
-      set: { [key: string]: string };
-    }
-  | {
-      /**
-       * Add the key-value pairs. Values for existing keys will be overwritten.
-       */
-      add: { [key: string]: string };
-      /**
-       * Remove the key-value pairs with given keys.
-       */
-      remove: string[];
-    };
-
+/**
+ * Object change
+ */
+export type ObjectPatch = ObjectPatchSet | ObjectPatchAddRemove;
+export interface ObjectPatchAddRemove {
+  /**
+   * Add the key-value pairs. Values for existing keys will be overwritten.
+   * example:
+   * [object Object]
+   */
+  add?: {
+    [name: string]: string;
+  };
+  /**
+   * Remove the key-value pairs with given keys.
+   * example:
+   * value1,value2
+   */
+  remove?: string[];
+}
+export interface ObjectPatchSet {
+  /**
+   * Set the key-value pairs. All existing key-value pairs will be removed.
+   * example:
+   * [object Object]
+   */
+  set: {
+    [name: string]: string;
+  };
+}
+export declare namespace Offset {
+  export type Offset = number;
+}
 /**
  * Data about how to authenticate and authorize users. The authentication configuration is hidden.
  */
 export interface OutputProjectAuthentication {
   validDomains?: ValidDomains;
 }
-
-export interface PostDatapoint {
-  timestamp: Timestamp;
-  value: number | string;
+export declare namespace Parameters {
+  export type All = boolean;
+  export type AssetId = number; // int64
+  export type AssetIds = JsonArrayInt64; // jsonArray(int64)
+  export type Columns = string;
+  export type Cursor = string;
+  export type DbName = string;
+  export type Depth = number; // int32
+  export type EnsureParent = boolean;
+  export type ErrorRedirectUrl = string;
+  export type ExternalIdPrefix = CogniteExternalId;
+  export type GroupId = number; // int64
+  export type Id = CogniteInternalId; // int64
+  export type IncludeDeleted = boolean;
+  export type IncludeMetadata = boolean;
+  export type Limit = number; // int32
+  export type MaxCreatedTime = EpochTimestamp; // int64
+  export type MaxEndTime = EpochTimestamp; // int64
+  export type MaxLastUpdatedTime = EpochTimestamp; // int64
+  export type MaxStartTime = EpochTimestamp; // int64
+  export type MaxUploadedTime = EpochTimestamp; // int64
+  export type MinCreatedTime = EpochTimestamp; // int64
+  export type MinEndTime = EpochTimestamp; // int64
+  export type MinLastUpdatedTime = EpochTimestamp; // int64
+  export type MinStartTime = EpochTimestamp; // int64
+  export type MinUploadedTime = EpochTimestamp; // int64
+  export type Name = AssetName;
+  export type NodeId = number; // int64
+  export type Origin = string;
+  export type Overwrite = boolean;
+  export type ParentIds = JsonArrayInt64; // jsonArray(int64)
+  export type Project = string;
+  export type Published = boolean;
+  export type RedirectUrl = string;
+  /**
+   * filtered assets are root assets or not
+   */
+  export type Root = boolean;
+  export type RowKey = string;
+  export type ServiceAccountId = number; // int64
+  export type Sort = 'ASC' | 'DESC';
+  export type Source = FileSource;
+  /**
+   * The event subtype
+   */
+  export type Subtype = string;
+  export type TableName = string;
+  export type ThreedFileId = number; // int64
+  export type Token = string;
+  /**
+   * The event type
+   */
+  export type Type = string;
+  export type Uploaded = boolean;
 }
-
+export interface PathParameters {
+  project: Parameters.Project;
+}
+export type PostDatapoint =
+  | {
+      /**
+       * The data timestamp in milliseconds since the epoch (Jan 1, 1970).
+       */
+      timestamp: EpochTimestamp; // int64
+      /**
+       * The numerical data value of a numerical metric
+       */
+      value: number;
+    }
+  | {
+      /**
+       * The data timestamp in milliseconds since the epoch (Jan 1, 1970).
+       */
+      timestamp: EpochTimestamp; // int64
+      /**
+       * The string data value of a string metric
+       */
+      value: string;
+    };
 export interface PostTimeSeriesMetadataDTO {
   /**
    * Externally provided id for the time series (optional but recommended)
    */
-  externalId?: CogniteExternalId;
+  externalId?: string;
   /**
    * Human readable name of time series
    */
@@ -1029,7 +2251,7 @@ export interface PostTimeSeriesMetadataDTO {
   /**
    * Additional metadata. String key -> String value.
    */
-  metadata?: Metadata;
+  metadata?: {};
   /**
    * The physical unit of the time series.
    */
@@ -1037,7 +2259,7 @@ export interface PostTimeSeriesMetadataDTO {
   /**
    * Asset that this time series belongs to.
    */
-  assetId?: CogniteInternalId;
+  assetId?: CogniteInternalId; // int64
   /**
    * Whether the time series is a step series or not.
    */
@@ -1047,40 +2269,37 @@ export interface PostTimeSeriesMetadataDTO {
    */
   description?: string;
   /**
-   * Security categories required in order to access this time series."
+   * Security categories required in order to access this time series.
    */
-  securityCategories?: number[];
+  securityCategories?: number /* int64 */[];
 }
-
+export declare namespace Project {
+  /**
+   * example:
+   * publicdata
+   */
+  export type Project = string;
+}
 /**
  * The display name of the project.
- * @example Open Industrial Data
+ * example:
+ * Open Industrial Data
  */
 export type ProjectName = string;
-
-/**
- * Information about the project
- */
+export declare namespace ProjectName {
+  export type Project = string;
+}
 export interface ProjectResponse {
   name: ProjectName;
   urlName: UrlName;
-  defaultGroupId?: DefaultGroupId;
+  defaultGroupId?: DefaultGroupId; // int64
   authentication?: OutputProjectAuthentication;
 }
-
-export interface ProjectUpdate {
-  name?: ProjectName;
-  defaultGroupId?: DefaultGroupId;
-  authentication?: InputProjectAuthentication;
+export interface QueryParameters {
+  sort?: Parameters.Sort;
+  cursor?: Parameters.Cursor;
+  limit?: Parameters.Limit; // int32
 }
-
-export type READ = 'READ';
-
-export interface Range<T> {
-  min?: T;
-  max?: T;
-}
-
 /**
  * A NoSQL database to store customer data.
  */
@@ -1090,139 +2309,267 @@ export interface RawDB {
    */
   name: string;
 }
-
-export interface RawDBRow extends RawDBRowInsert {
+export interface RawDBRow {
   /**
-   * Time when the row was last updated
+   * Unique row key
    */
-  lastUpdatedTime: Date;
-}
-
-export interface RawDBRowInsert extends RawDBRowKey {
+  key: string;
   /**
    * Row data stored as a JSON object.
    */
-  columns: { [key: string]: string };
+  columns: any;
+  lastUpdatedTime: EpochTimestamp; // int64
 }
-
+export interface RawDBRowInsert {
+  /**
+   * Unique row key
+   */
+  key: string;
+  /**
+   * Row data stored as a JSON object.
+   */
+  columns: any;
+}
+/**
+ * A row key
+ */
 export interface RawDBRowKey {
   /**
    * Unique row key
    */
   key: string;
 }
-
+/**
+ * A NoSQL database table to store customer data
+ */
 export interface RawDBTable {
   /**
    * Unique name of the table
    */
   name: string;
 }
-
+/**
+ * Raw row result written in CSV format, with column columnHeaders.
+ */
+export interface RawRowCSV {
+  /**
+   * Headers for the different columns in the response.
+   */
+  columnHeaders?: string[];
+  /**
+   * Rows of column values, in same order as columnHeaders.
+   */
+  rows?: {}[][];
+}
 export interface RemoveField {
+  /**
+   * example:
+   * true
+   */
   setNull: boolean;
 }
-
-export interface RevealNode3D extends Node3D {
+export type RequestBody = DataLong;
+export declare namespace Responses {
+  export type $200 = EmptyResponse;
+  export type $201 = SecurityCategoryResponse;
+  export type $400 = ErrorResponse;
+  export type $409 = ExternalIdsAlreadyExistResponse;
+  export type $422 = DuplicatedIdsInRequestResponse;
+}
+export interface RevealNode3D {
+  /**
+   * The ID of the node.
+   * example:
+   * 1000
+   */
+  id: number; // int64
+  /**
+   * The index of the node in the 3D model hierarchy, starting from 0. The tree is traversed in a depth-first order.
+   * example:
+   * 3
+   */
+  treeIndex: number; // int64
+  /**
+   * The parent of the node, null if it is the root node.
+   * example:
+   * 2
+   */
+  parentId: null | number; // int64
+  /**
+   * The depth of the node in the tree, starting from 0 at the root node.
+   * example:
+   * 2
+   */
+  depth: number; // int64
+  /**
+   * The name of the node.
+   * example:
+   * Node name
+   */
+  name: string;
+  /**
+   * The number of descendants of the node, plus one (counting itself).
+   * example:
+   * 4
+   */
+  subtreeSize: number; // int64
+  boundingBox: BoundingBox3D;
   /**
    * The sector the node is contained in.
+   * example:
+   * 1000
    */
-  sectorId: CogniteInternalId;
+  sectorId?: number; // int64
 }
-
-export interface RevealRevision3D extends Revision3D {
+export interface RevealNode3DList {
+  items: RevealNode3D[];
+}
+export interface RevealRevision3D {
+  /**
+   * The ID of the revision.
+   * example:
+   * 1000
+   */
+  id: number; // int64
+  /**
+   * The file id.
+   * example:
+   * 1000
+   */
+  fileId: number; // int64
+  /**
+   * True if the revision is marked as published.
+   */
+  published: boolean;
+  rotation?: number /* double */[];
+  camera?: RevisionCameraProperties;
+  /**
+   * The status of the revision.
+   * example:
+   * Done
+   */
+  status: 'Queued' | 'Processing' | 'Done' | 'Failed';
+  metadata?: Metadata3D;
+  /**
+   * The threed file ID of a thumbnail for the revision. Use /3d/files/{id} to retrieve the file.
+   * example:
+   * 1000
+   */
+  thumbnailThreedFileId?: number; // int64
+  /**
+   * The URL of a thumbnail for the revision.
+   * example:
+   * https://api.cognitedata.com/api/v1/project/myproject/3d/files/1000
+   */
+  thumbnailURL?: string;
+  /**
+   * The number of asset mappings for this revision.
+   * example:
+   * 0
+   */
+  assetMappingCount: number; // int64
+  createdTime: CreatedTime; // int64
   sceneThreedFiles: Versioned3DFile[];
 }
-
 export interface RevealSector3D {
   /**
    * The id of the sector.
+   * example:
+   * 1000
    */
-  id: CogniteInternalId;
+  id: number; // int64
   /**
    * The parent of the sector, null if it is the root sector.
+   * example:
+   * 900
    */
-  parentId: CogniteInternalId;
+  parentId: null | number; // int64
   /**
    * String representing the path to the sector: 0/2/6/ etc.
+   * example:
+   * 0/100/500/900/1000
    */
   path: string;
   /**
    * The depth of the sector in the sector tree, starting from 0 at the root sector.
+   * example:
+   * 4
    */
-  depth: number;
-  /**
-   * The bounding box of the subtree with this sector as the root sector. Is null if there are no geometries in the subtree.
-   */
+  depth: number; // int64
   boundingBox: BoundingBox3D;
   /**
    * The file ID of the data file for this sector, with multiple versions supported. Use /3d/files/{id} to retrieve the file.
    */
   threedFiles: Versioned3DFile[];
 }
-
+export interface RevealSector3DList {
+  items: RevealSector3D[];
+}
 export interface Revision3D {
   /**
    * The ID of the revision.
+   * example:
+   * 1000
    */
-  id: CogniteInternalId;
+  id: number; // int64
   /**
    * The file id.
+   * example:
+   * 1000
    */
-  fileId: CogniteInternalId;
+  fileId: number; // int64
   /**
    * True if the revision is marked as published.
    */
   published: boolean;
-  /**
-   * Global rotation to be applied to the entire model.
-   * The rotation is expressed by Euler angles in radians and in XYZ order.
-   */
-  rotation?: [number, number, number];
+  rotation?: number /* double */[];
   camera?: RevisionCameraProperties;
   /**
    * The status of the revision.
+   * example:
+   * Done
    */
-  status: Revision3DStatus;
+  status: 'Queued' | 'Processing' | 'Done' | 'Failed';
+  metadata?: Metadata3D;
   /**
-   * The threed file ID of a thumbnail for the revision.
-   * Use /3d/files/{id} to retrieve the file.
+   * The threed file ID of a thumbnail for the revision. Use /3d/files/{id} to retrieve the file.
+   * example:
+   * 1000
    */
-  thumbnailThreedFileId?: number;
+  thumbnailThreedFileId?: number; // int64
   /**
    * The URL of a thumbnail for the revision.
+   * example:
+   * https://api.cognitedata.com/api/v1/project/myproject/3d/files/1000
    */
   thumbnailURL?: string;
   /**
    * The number of asset mappings for this revision.
+   * example:
+   * 0
    */
-  assetMappingCount: number;
-  /**
-   *
-   */
-  createdTime: Date;
+  assetMappingCount: number; // int64
+  createdTime: CreatedTime; // int64
 }
-
-export interface Revision3DListRequest extends Limit {
-  /**
-   * Filter based on whether or not it has published revisions.
-   */
-  published?: boolean;
+export interface Revision3DList {
+  items: Revision3D[];
 }
-
-type Revision3DStatus = 'Queued' | 'Processing' | 'Done' | 'Failed';
-
+/**
+ * Initial camera position and target.
+ */
 export interface RevisionCameraProperties {
   /**
    * Initial camera target.
    */
-  target?: Tuple3<number>;
+  target?: number /* double */[];
   /**
    * Initial camera position.
    */
-  position?: Tuple3<number>;
+  position?: number /* double */[];
 }
-
+export declare namespace RevisionId {
+  export type RevisionId = number; // int64
+}
 export interface Search {
   /**
    * Prefix and fuzzy search on name.
@@ -1237,79 +2584,120 @@ export interface Search {
    */
   query?: string;
 }
-
-export interface SecurityCategory {
+export interface SecurityCategoryDTO {
   /**
    * Name of the security category
+   * example:
+   * Guarded by vendor x
    */
   name: string;
   /**
    * Id of the security category
    */
-  id: number;
+  id: number; // int64
 }
-
-export interface SecurityCategorySpec {
+export interface SecurityCategoryResponse {
+  items?: SecurityCategoryDTO[];
+}
+export interface SecurityCategorySpecDTO {
   /**
    * Name of the security category
+   * example:
+   * Guarded by vendor x
    */
   name: string;
 }
-
+/**
+ * A list of objects along with possible cursors to get the next page of results
+ */
+export interface SecurityCategoryWithCursorResponse {
+  items: SecurityCategoryDTO[];
+  /**
+   * Cursor to get the next page of results (if available).
+   */
+  nextCursor?: string;
+}
 export interface ServiceAccount {
   name: ServiceAccountName;
-  groups?: Groups;
-  id: CogniteInternalId;
+  groups: Groups;
+  id: number; // int64
   /**
    * If this service account has been logically deleted
+   * example:
+   * false
    */
-  isDeleted?: boolean;
+  isDeleted: boolean;
   /**
    * Time of deletion
    */
-  deletedTime?: Date;
+  deletedTime?: Date; // int64
 }
-
 export interface ServiceAccountInput {
   name: ServiceAccountName;
   groups?: Groups;
 }
-
 /**
+ * name
  * Unique name of the service account
+ * example:
+ * some-internal-service@apple.com
  */
 export type ServiceAccountName = string;
-
-export interface SetField<T> {
-  set: T;
+export interface ServiceAccountResponse {
+  /**
+   * List of service accounts
+   */
+  items: ServiceAccount[];
 }
-
-export type SingleCogniteCapability =
-  | { groupsAcl: AclGroups }
-  | { assetsAcl: AclAssets }
-  | { eventsAcl: AclEvents }
-  | { filesAcl: AclFiles }
-  | { usersAcl: AclUsers }
-  | { projectsAcl: AclProjects }
-  | { securityCategoriesAcl: AclSecurityCategories }
-  | { rawAcl: AclRaw }
-  | { timeSeriesAcl: AclTimeseries }
-  | { apikeysAcl: AclApiKeys }
-  | { threedAcl: Acl3D }
-  | { sequencesAcl: AclSequences }
-  | { analyticsAcl: AclAnalytics };
-
-export type SinglePatchDate = { set: Timestamp } | { setNull: boolean };
-
+export interface SetLongField {
+  set: number; // int64
+}
+export interface SetModelNameField {
+  set?: string;
+}
+export interface SetRevisionCameraProperties {
+  set?: RevisionCameraProperties;
+}
+export interface SetRevisionRotation {
+  set?: number /* double */[];
+}
+export interface SetStringField {
+  set: string;
+}
+export type SinglePatchLong = SetLongField | RemoveField;
 /**
  * Non removable string change.
  */
 export interface SinglePatchRequiredString {
   set: string;
 }
-
-export type SinglePatchString = SetField<string> | RemoveField;
-
+/**
+ * Removable string change.
+ */
+export type SinglePatchString = SetStringField | RemoveField;
+export interface SingleTokenStatusDTOResponse {
+  data: TokenStatusDTO;
+}
+export type StringOrNumber = string | number;
+export interface TimeSeriesCreateRequest {
+  items: PostTimeSeriesMetadataDTO[];
+}
+export type TimeSeriesCursorResponse = DataWithCursorGetTimeSeriesMetadataDTO;
+export interface TimeSeriesLookupById {
+  /**
+   * List of ID objects
+   */
+  items: (
+    | {
+        id?: CogniteInternalId; // int64
+      }
+    | {
+        externalId?: CogniteExternalId;
+      })[];
+}
+/**
+ * Changes will be applied to timeseries.
+ */
 export interface TimeSeriesPatch {
   update: {
     externalId?: NullableSinglePatchString;
@@ -1321,107 +2709,206 @@ export interface TimeSeriesPatch {
     securityCategories?: ArrayPatchLong;
   };
 }
-
-export interface TimeSeriesSearchDTO extends Limit {
+export type TimeSeriesResponse = DataGetTimeSeriesMetadataDTO;
+export interface TimeSeriesSearchDTO {
+  /**
+   * Filtering parameters
+   */
   filter?: Filter;
+  /**
+   * Search parameters
+   */
   search?: Search;
   /**
    * Return up to this many results.
    */
+  limit?: number; // int32
 }
-
 export type TimeSeriesUpdate =
   | TimeSeriesUpdateById
   | TimeSeriesUpdateByExternalId;
-
-export interface TimeSeriesUpdateByExternalId
-  extends TimeSeriesPatch,
-    ExternalId {}
-
-export interface TimeSeriesUpdateById extends TimeSeriesPatch, InternalId {}
-
-export interface TimeseriesFilter extends Limit {
-  /**
-   * Decide if the metadata field should be returned or not.
-   */
-  includeMetadata?: boolean;
-  /**
-   * Cursor for paging through time series.
-   */
-  cursor?: string;
-  /**
-   * Get time series related to these assets. Takes [ 1 .. 100 ] unique items.
-   */
-  assetIds?: number[];
+/**
+ * Changes will be applied to timeseries.
+ */
+export interface TimeSeriesUpdateByExternalId {
+  update: {
+    externalId?: NullableSinglePatchString;
+    name?: NullableSinglePatchString;
+    metadata?: ObjectPatch;
+    unit?: NullableSinglePatchString;
+    assetId?: NullableSinglePatchLong;
+    description?: NullableSinglePatchString;
+    securityCategories?: ArrayPatchLong;
+  };
+  externalId: CogniteExternalId;
 }
-
-export type TimeseriesIdEither = InternalId | ExternalId;
-
-export type Timestamp = number | Date;
-
-export type Tuple3<T> = [T, T, T];
-
-export type UPDATE = 'UPDATE';
-
-export interface UnrealRevision3D extends Revision3D {
+/**
+ * Changes will be applied to timeseries.
+ */
+export interface TimeSeriesUpdateById {
+  update: {
+    externalId?: NullableSinglePatchString;
+    name?: NullableSinglePatchString;
+    metadata?: ObjectPatch;
+    unit?: NullableSinglePatchString;
+    assetId?: NullableSinglePatchLong;
+    description?: NullableSinglePatchString;
+    securityCategories?: ArrayPatchLong;
+  };
+  id: CogniteInternalId; // int64
+}
+export interface TimeSeriesUpdateRequest {
+  items: TimeSeriesUpdate[];
+}
+/**
+ * Get datapoints up to this time. Same format as for start. Note that when using aggregates, the end will be rounded up such that the last aggregate represents a full aggregation interval containing the original end, where the interval is the granularity unit times the granularity multiplier. For granularity 2d, the aggregation interval is 2 days, if end was originally 3 days after the start, it will be rounded to 4 days after the start.
+ */
+export type TimestampOrStringEnd = Date | string;
+/**
+ * Get datapoints after this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time in ms since epoch. Note that when using aggregates, the start time will be rounded down to a whole granularity unit (in UTC timezone). For granularity 2d it will be rounded to 0:00 AM on the same day, for 3h it will be rounded to the start of the hour, etc.
+ */
+export type TimestampOrStringStart = Date | string;
+export interface TokenStatusDTO {
+  /**
+   * The token that was sent for validation
+   * example:
+   * ewogICJhbGciOiAiUlMyNTYiLAogICJ0eXAiOiAiSldUIgp9.ewogICJhY2NvdW50X3R5cGUiOiAidXNlcl9hY2NvdW50IiwKICAicHJvamVjdF9pZCI6IDI5MzgyOTU3MjA2NzUzNTMsCiAgInVuaXF1ZV9uYW1lIjogIm1hcnRpbi5yb2VkQGNvZ25pdGUuY29tIiwKICAic2Vzc2lvblRpY2tldCI6ICJDQUlTSkdKa04yUmxZMkUyTFRkbFltSXROR1E1TlMxaU16QmtMVFF4T1dRMFlUSTVaRGRqTkJvRFFWQkpJa01hRjIxaGNuUnBiaTV5YjJWa1FHTnZaMjVwZEdVdVkyOXRJSm1RdE1YVWk1d0ZLaC9vbjQ3QzE5Uld0TXZQMkpYTGd3YTVrNm0wbHMvS0NMVHB5SWFDcEpBTEtnTkJVRWtxREVGVlZFZ3RVMFZTVmtsRFJUSU1DTnlkdCtVRkVNQ2c0ck1CT2d3STZMSzM1UVVRd0tEaXN3RkNEQWpjbmJmbEJSREFvT0t6QVVvTUlnb0lBUklDQUFFYUFnb0FTZzhxRFFnQkVnVUFBUUlEQkJvQ0dnQktDeW9KQ0FFU0FRQWFBaW9BU2d3eUNnZ0JFZ0lBQVJvQ0NnQktERG9LQ0FFU0FnQUJHZ0lLQUVvTVFnb0lBUklDQUFFYUFnb0FTZzlLRFFnQkVnVUFBUUlFQXhvQ0dnQktERklLQ0FFU0FnRURHZ0lhQUVvT1dnd0lBUklFQVFRQ0FCb0NDZ0JLRFdJTENBRVNBd0lCQUJvQ0NnQktER29LQ0FFU0FnQUJHZ0lLQUVvTGNna0lBUklCQUJvQ0tnQktEM0lOQ0FFU0JRQUJBZ01FR2dJYUFFb09lZ3dJQVJJRUFBRUNBeG9DR2dCS0RZSUJDZ2dCRWdJQUFSb0NDZ0JLRFlvQkNnZ0JFZ0lBQVJvQ0NnQktEcElCQ3dnQkVnTUFBZ0VhQWdvQVNncWFBUWNTQVFBYUFob0EiLAogICJzaWduaW5nX2tleSI6ICIyZTAyMGM3NS1kODcwLTQxNWItYTY2Ny02OGZiODk0MTgwZjEiLAogICJleHBpcmVfdGltZSI6IDE1NTQ4OTcyNTYKfQ==.WNTT7qvdj4KUbIwo8x4Upq3Ki/X9rd0lqMbcIlLCDwjqrH2OH4jc/CgE/Uk9z9HeCCSWDDwJYGXOiIc+bZGQdzuYDPd5LYN8SaT1bDfa5mkAaPpk7f0KSBqp5FceNWSqjh1/mevX0OhNMbB6z5KXU9t7EDgNFWgMT2zUpfll0nNYhAgJBU1MeGtxVZcRLIP2iAEmFR4XlLlxc+bi0SxGGUZHPn2AQq5jitbJAdjnwf5KCr+2HH1Dww75q7qiGZ7NsO7ipTGdO/KaaTvlLp90k5jT4a7fPqCuMWS25NgJK4dQIEqtCvHaqnMV1Q+G6WtdEy+Qcx581H8J3A2LV1pQYA==
+   */
+  token: string;
+  /**
+   * Whether this token is valid
+   */
+  valid: boolean;
+  /**
+   * Whether this token has expired
+   */
+  expired: boolean;
+}
+export interface UnrealRevision3D {
+  /**
+   * The ID of the revision.
+   * example:
+   * 1000
+   */
+  id: number; // int64
+  /**
+   * The file id.
+   * example:
+   * 1000
+   */
+  fileId: number; // int64
+  /**
+   * True if the revision is marked as published.
+   */
+  published: boolean;
+  rotation?: number /* double */[];
+  camera?: RevisionCameraProperties;
+  /**
+   * The status of the revision.
+   * example:
+   * Done
+   */
+  status: 'Queued' | 'Processing' | 'Done' | 'Failed';
+  metadata?: Metadata3D;
+  /**
+   * The threed file ID of a thumbnail for the revision. Use /3d/files/{id} to retrieve the file.
+   * example:
+   * 1000
+   */
+  thumbnailThreedFileId?: number; // int64
+  /**
+   * The URL of a thumbnail for the revision.
+   * example:
+   * https://api.cognitedata.com/api/v1/project/myproject/3d/files/1000
+   */
+  thumbnailURL?: string;
+  /**
+   * The number of asset mappings for this revision.
+   * example:
+   * 0
+   */
+  assetMappingCount: number; // int64
+  createdTime: CreatedTime; // int64
   sceneThreedFiles: Versioned3DFile[];
 }
-
-export interface UpdateModel3D extends UpdateModelNameField, InternalId {}
-
-export interface UpdateModelNameField {
-  update: {
-    name: SetField<string>;
+export interface UpdateModel3D {
+  id: CogniteInternalId; // int64
+  update?: {
+    name?: SetModelNameField;
+    metadata?: ObjectPatch;
   };
 }
-
 export interface UpdateRevision3D {
-  id: CogniteInternalId;
-  update: {
-    /**
-     * True if the revision is marked as published.
-     */
-    published?: SetField<boolean>;
-    /**
-     * Global rotation to be applied to the entire model.
-     * The rotation is expressed by Euler angles in radians and in XYZ order.
-     */
-    rotation?: SetField<Tuple3<number>>;
-    /**
-     * Initial camera target.
-     */
-    camera?: SetField<RevisionCameraProperties>;
+  id: CogniteInternalId; // int64
+  update?: {
+    published?: {
+      /**
+       * True if the revision is marked as published.
+       */
+      set?: boolean;
+    };
+    rotation?: SetRevisionRotation;
+    camera?: SetRevisionCameraProperties;
+    metadata?: ObjectPatch;
   };
 }
-
-export interface UploadFileMetadataResponse extends FilesMetadata {
+/**
+ * Request body for the updateModelRevisionThumbnail endpoint.
+ */
+export interface UpdateRevision3DThumbnail {
+  /**
+   * File ID of thumbnail file in Files API. _Only JPEG and PNG files are supported_.
+   */
+  fileId: number; // int64
+}
+export interface UploadFileMetadataResponse {
+  externalId?: CogniteExternalId;
+  name: FileName;
+  source?: FileSource;
+  mimeType?: MimeType;
+  metadata?: FilesMetadataField;
+  assetIds?: CogniteInternalId /* int64 */[];
+  id: CogniteInternalId; // int64
+  /**
+   * Whether or not the actual file is uploaded.  This field is returned only by the API, it has no effect in a post body.
+   * example:
+   * true
+   */
+  uploaded: boolean;
+  uploadedTime?: EpochTimestamp; // int64
+  createdTime: EpochTimestamp; // int64
+  lastUpdatedTime: EpochTimestamp; // int64
+  /**
+   * The URL where the file contents should be uploaded.
+   */
   uploadUrl: string;
 }
-
 /**
  * The url name of the project. This is used as part of API calls. It should only contain letters, digits and hyphens, as long as the hyphens are not at the start or end.
- * @example publicdata
+ * example:
+ * publicdata
  */
 export type UrlName = string;
-
 /**
  * List of valid domains. If left empty, any user registered with the OAuth2 provider will get access.
+ * example:
+ * apple.com,google.com
  */
 export type ValidDomains = string[];
-
 /**
- * The file ID of the data file for this resource, with multiple versions supported.
- * Use /3d/files/{id} to retrieve the file.
+ * The file ID of the data file for this resource, with multiple versions supported. Use /3d/files/{id} to retrieve the file.
  */
 export interface Versioned3DFile {
   /**
    * Version of the file format.
+   * example:
+   * 1
    */
-  version: number;
+  version: number; // int64
   /**
    * File ID. Use /3d/files/{id} to retrieve the file.
+   * example:
+   * 1000
    */
-  fileId: CogniteInternalId;
+  fileId: number; // int64
 }
-
-export type WRITE = 'WRITE';

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,11 @@
     "array-type": [true, "array"],
     "no-reference": false,
     "no-return-await": true,
-    "file-header": [true, "Copyright \\d{4} Cognite AS"]
+    "file-header": [true, "Copyright \\d{4} Cognite AS"],
+    "no-namespace": [false, "allow-declarations"],
+    "no-empty-interface": false,
+    "max-union-size": false,
+    "use-type-alias": false
   },
   "rulesDirectory": ["tslint-plugin-prettier"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -9,11 +9,7 @@
     "array-type": [true, "array"],
     "no-reference": false,
     "no-return-await": true,
-    "file-header": [true, "Copyright \\d{4} Cognite AS"],
-    "no-namespace": [false, "allow-declarations"],
-    "no-empty-interface": false,
-    "max-union-size": false,
-    "use-type-alias": false
+    "file-header": [true, "Copyright \\d{4} Cognite AS"]
   },
   "rulesDirectory": ["tslint-plugin-prettier"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,7 @@
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
   dependencies:
     "@babel/highlight" "^7.0.0"
 
@@ -918,9 +919,14 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@^2.16.0, commander@^2.19.0, commander@^2.7.1:
+commander@^2.12.1, commander@^2.16.0, commander@^2.7.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+
+commander@^2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -971,12 +977,12 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-fetch@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.1.tgz#3f207bbd829a76e9aa2a953348bd1f2a3cf388a7"
-  integrity sha512-qWtpgBAF8ioqBOddRD+pHhrdzm/UWOArkrlIU7c08DlNbOxo5GfUbSY2vr90ZypWf0raW+HNN1F38pi5CEOjiQ==
+cross-fetch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
   dependencies:
-    node-fetch "2.3.0"
+    node-fetch "2.6.0"
     whatwg-fetch "3.0.0"
 
 cross-spawn@^5.0.1:
@@ -1044,6 +1050,7 @@ debug@^4.1.1:
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -1124,18 +1131,17 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-dtsgenerator@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/dtsgenerator/-/dtsgenerator-2.0.6.tgz#776ca06757774686ce66a0ca6613e1457a7ce3e5"
-  integrity sha512-vLTiJpLfV6zrngD9CoVc8nrn/Veg/92acerp17iTDyqTkLLAjj4B2LmwhJPbIwq7nbTEFE3f2bm4kehuXvCPoQ==
+dtsgenerator@cognitedata/dtsgenerator#feat/typeMappings:
+  version "2.0.8"
+  resolved "https://codeload.github.com/cognitedata/dtsgenerator/tar.gz/e0ced2785b875d096505e6c18ad830eeb3a7202d"
   dependencies:
-    commander "^2.19.0"
-    cross-fetch "^3.0.1"
+    commander "^2.20.0"
+    cross-fetch "^3.0.4"
     debug "^4.1.1"
-    glob "^7.1.3"
-    js-yaml "^3.12.1"
+    glob "^7.1.4"
+    js-yaml "^3.13.1"
     mkdirp "^0.5.1"
-    tslib "^1.9.3"
+    tslib "^1.10.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -1592,9 +1598,21 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2408,7 +2426,7 @@ js-yaml@^3.12.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.7.0:
+js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -2954,10 +2972,10 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-node-fetch@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3517,6 +3535,7 @@ request-promise-native@^1.0.5:
 request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -4146,6 +4165,11 @@ ts-jest@^23.10.4:
 tslib@1.9.3, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tslib@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslint-config-prettier@^1.18.0:
   version "1.18.0"


### PR DESCRIPTION
To run the generation script: 
`sh scripts/generateTypes.sh`
That generates latest service contracts into `types/types.ts` interfaces

Known or possible issues:

1) [Object object] in generated examples https://github.com/horiuchi/dtsgenerator/issues/348
2) We renamed some interfaces, so they are different from the spec. So we either need to change the spec, or to fix the generator to support name mappings, or just manually make synonyms for them (fastest I guess). I did it manually for the ones that were breaking tests.
3) dtsgenerator makes a lot of nested namespaces. But you can choose "no namespace" option which generates file with no exports. So I workaround that by just find&replace (there is also a feature request about it on repo but it most likely won't be done soon)
4) Not able to check if interfaces are correct because our tests don't cover 100% of schemas (I think we need some automatic tester for that, which says if `schema==interface`).  Tests in dtsgenerator itself is not complete either, so we can't rely on them. 
5) We use our own branch of generator on `cognitedata/dtsgenerator#feat/typeMappings` which uses a few hacks like:
  - replace `number` with `Date` in specific places etc. (this one should be easy to refactor and make as a feature)
  - skip 1 particular broken schema. (this one is a totally silly hack)

We need to either upgrade them to features and suggest as a PR to dtsgenerator or use another way of doing it.
6) dtsgenerator produces some weird response interfaces which we don't use but they are still in the file (maybe filter them out?)
7) If we use this script we might want to move it somewhere else and have it in CI?
8) It does not generate an SDK completely as OpenAPITools/openapi-generator does. But then again openapi-generator doesn't work at all.