### PR TITLE
fix: change from fuzzy search to using filter

### DIFF
--- a/src/__tests__/resources/assets.integration.spec.ts
+++ b/src/__tests__/resources/assets.integration.spec.ts
@@ -210,7 +210,7 @@ describe('Asset integration test', () => {
 
   test('search for root test asset', async () => {
     const result = await client.assets.search({
-      search: {
+      filter: {
         name: rootAsset.name,
       },
     });


### PR DESCRIPTION
Changing to `filter` makes sure we get the correct name instead of using fuzzy `search`. 