### PR TITLE
fix: add type for scope with time series ids

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -67,6 +67,12 @@ export interface AclScopeAssetsId {
   };
 }
 
+export interface AclScopeTimeSeriesIds {
+  idscope: {
+    ids: CogniteInternalId[];
+  };
+}
+
 export interface AclScopeCurrentUser {
   currentuserscope: {};
 }
@@ -85,7 +91,10 @@ export type AclScopeSecurityCategories = AclScopeAll;
 
 export type AclScopeSequences = AclScopeAll;
 
-export type AclScopeTimeseries = AclScopeAll | AclScopeAssetsId;
+export type AclScopeTimeseries =
+  | AclScopeAll
+  | AclScopeAssetsId
+  | AclScopeTimeSeriesIds;
 
 export type AclScopeUsers = AclScopeAll;
 


### PR DESCRIPTION
This partially solves the issue #316 I opened.

A missing scope type `AclScopeTimeSeriesIds` was created. But the scope type `AclScopeAssetsId` that, according to the API docs, is not possible to use anymore is still there. I didn't remove it because I do not have the knowledge to be sure about the implications.