### PR TITLE
feat: add HTTP patch method to httpClient

### DIFF
--- a/src/cogniteClient.ts
+++ b/src/cogniteClient.ts
@@ -386,6 +386,18 @@ export default class CogniteClient {
   public delete = <T = any>(path: string, options?: HttpRequestOptions) =>
     this.httpClient.delete<T>(path, options);
 
+  /**
+   * Basic HTTP method for PATCH
+   *
+   * @param path The URL path
+   * @param options Request options, optional
+   * ```js
+   * const response = await client.patch('someUrl');
+   * ```
+   */
+  public patch = <T = any>(path: string, options?: HttpRequestOptions) =>
+    this.httpClient.patch<T>(path, options);
+
   public setOneTimeSdkHeader(value: string) {
     this.httpClient.addOneTimeHeader(X_CDF_SDK_HEADER, value);
   }

--- a/src/utils/http/basicHttpClient.ts
+++ b/src/utils/http/basicHttpClient.ts
@@ -120,6 +120,14 @@ export class BasicHttpClient {
     });
   }
 
+  public patch<ResponseType>(path: string, options: HttpRequestOptions = {}) {
+    return this.request<ResponseType>({
+      ...options,
+      path,
+      method: HttpMethod.Patch,
+    });
+  }
+
   protected async preRequest(request: HttpRequest): Promise<HttpRequest> {
     const populatedHeaders = this.populateDefaultHeaders(request.headers);
     return {
@@ -222,6 +230,7 @@ export enum HttpMethod {
   Post = 'post',
   Put = 'put',
   Delete = 'delete',
+  Patch = 'patch',
 }
 
 export type HttpResponseType = 'json' | 'arraybuffer' | 'text';


### PR DESCRIPTION
Support HTTP patch method for completeness.

We are using this in some of the Applications APIs and we are using SDK to get authentication for free.