### PR TITLE
feat: add isString to DatapointsGetAggregateDatapoint

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -533,6 +533,8 @@ export type DatapointsDeleteRequest =
 
 export interface DatapointsGetAggregateDatapoint extends DatapointsMetadata {
   datapoints: GetAggregateDatapoint[];
+  /** Aggregates cannot be strings, as this is unsupported by CDF. */
+  isString: false;
 }
 
 export type DatapointsGetDatapoint =


### PR DESCRIPTION
Aggregates can never be string values, so define `isString: false` on
the DatapointsGetAggregateDatapoint type. This makes it easier to work
with the DatapointsGetDatapoint union type in applications because
they will have a consistent shape.