### PR TITLE
fix: Uppercase Patch HTTP Method

### DIFF
--- a/src/utils/http/basicHttpClient.ts
+++ b/src/utils/http/basicHttpClient.ts
@@ -230,7 +230,7 @@ export enum HttpMethod {
   Post = 'post',
   Put = 'put',
   Delete = 'delete',
-  Patch = 'patch',
+  Patch = 'PATCH',
 }
 
 export type HttpResponseType = 'json' | 'arraybuffer' | 'text';


### PR DESCRIPTION
The patch method is being used in some of the applications API (see here for more context https://github.com/cognitedata/cognite-sdk-js/pull/323)

We're currently running into CORS issues with the `PATCH` method - by default the `OPTIONS` request grants us with permission to use `"GET,HEAD,PUT,POST,DELETE,PATCH"` methods. Historically, the values in this enum being lowercase haven't been a problem, since the fetch spec only requires [normalization of DELETE, GET, HEAD, OPTIONS, POST, and PUT methods](https://fetch.spec.whatwg.org/#concept-method). In server contexts this isn't a problem, since `node-fetch` uppercases all methods (https://github.com/node-fetch/node-fetch/blob/master/src/request.js#L73). But, for the notification requests that we're making through the browser, the `whatwg-fetch` polyfill only uppercases the methods explicitly defined in the spec (https://github.com/github/fetch/blob/master/fetch.js#L302). Therefore, when we attempt to make a `patch` request rather than a `PATCH` request, we get denied as this doesn't exactly match the value provided in the `Access-Control-Allow-Methods` header.

If it makes sense, I'd be happy to add another commit to capitalize all the method verbs for the sake of consistency.
