### PR TITLE
fix: uppercase patch HTTP method

### DIFF
--- a/src/__tests__/resources/sequences.integration.spec.ts
+++ b/src/__tests__/resources/sequences.integration.spec.ts
@@ -155,12 +155,14 @@ describe('Sequences integration test', () => {
   });
 
   test('search', async () => {
-    const result = await client.sequences.search({
-      search: {
-        query: 'n*m* des*tion',
-      },
+    runTestWithRetryWhenFailing(async () => {
+      const result = await client.sequences.search({
+        search: {
+          query: 'n*m* des*tion',
+        },
+      });
+      expect(result.length).toBeGreaterThan(0);
     });
-    expect(result.length).toBeGreaterThan(0);
   });
 
   test('insert rows', async () => {

--- a/src/utils/http/basicHttpClient.ts
+++ b/src/utils/http/basicHttpClient.ts
@@ -230,7 +230,7 @@ export enum HttpMethod {
   Post = 'post',
   Put = 'put',
   Delete = 'delete',
-  Patch = 'patch',
+  Patch = 'PATCH',
 }
 
 export type HttpResponseType = 'json' | 'arraybuffer' | 'text';

--- a/src/utils/http/basicHttpClient.ts
+++ b/src/utils/http/basicHttpClient.ts
@@ -226,10 +226,10 @@ export interface HttpResponse<T> {
 }
 
 export enum HttpMethod {
-  Get = 'get',
-  Post = 'post',
-  Put = 'put',
-  Delete = 'delete',
+  Get = 'GET',
+  Post = 'POST',
+  Put = 'PUT',
+  Delete = 'DELETE',
   Patch = 'PATCH',
 }
 


### PR DESCRIPTION
The patch method is being used in some of the applications API (see here for more context https://github.com/cognitedata/cognite-sdk-js/pull/323)

We're currently running into CORS issues with the `PATCH` method - by default the `OPTIONS` request grants us with permission to use `"GET,HEAD,PUT,POST,DELETE,PATCH"` methods. Historically, the values in this enum being lowercase haven't been a problem, since the fetch spec only requires [normalization of DELETE, GET, HEAD, OPTIONS, POST, and PUT methods](https://fetch.spec.whatwg.org/#concept-method). In server contexts this isn't a problem, since `node-fetch` uppercases all methods (https://github.com/node-fetch/node-fetch/blob/master/src/request.js#L73). But, for the notification requests that we're making through the browser, the `whatwg-fetch` polyfill only uppercases the methods explicitly defined in the spec (https://github.com/github/fetch/blob/master/fetch.js#L302). Therefore, when we attempt to make a `patch` request rather than a `PATCH` request, we get denied as this doesn't exactly match the value provided in the `Access-Control-Allow-Methods` header.

If it makes sense, I'd be happy to add another commit to capitalize all the method verbs for the sake of consistency.

Also - CI seems to be failing but I believe this is for an unrelated reason. All tests pass apart from the search test in `sequences.integration.spec.ts`. Since the search request is a POST request and  other POST requests seem to be unaffected, I don't think changing the capitalisation of patch should be causing the test to fail. Any help with getting this test to pass would be much appreciated!