### PR TITLE
chore(travis): fix semantic-release config to work with their v16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ deploy:
       branch: v1
     skip_cleanup: true
     script:
-      - npx semantic-release
+      - node_version=$(node -v); if [ ${node_version:1:2} = 10 ]; then npx semantic-release; else echo "node_version != 10. skip"; fi
   - provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     }
   },
   "release": {
-    "branch": "v1",
+    "branches": ["v1"],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
semantic-release v16 works only with node 10. And since we spawn v8,9,10 instances on travis we can deploy only using one of them (and we should, the rest would fail anyway)

Also they changed the config syntax a bit, so I updated that