### PR TITLE
chore(travis): fix deploy not running on node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ deploy:
     node_js: lts/*
     on:
       branch: v1
-      node_js: '0.10'
+      node_js: "10"
     skip_cleanup: true
     script:
       - npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ deploy:
     node_js: lts/*
     on:
       branch: v1
+      node_js: '0.10'
     skip_cleanup: true
     script:
-      - node_version=$(node -v); if [ ${node_version:1:2} = 10 ]; then npx semantic-release; else echo "node_version != 10. skip"; fi
+      - npx semantic-release
   - provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN


### PR DESCRIPTION
Although the previous commit got a green check mark, the Travis job running Node 10 didn't actually deploy. The output of the deploy step is
```
sh: 1: [: =: unexpected operator
node_version != 10. skip
```
(lines 824-825 here): https://travis-ci.org/cognitedata/cognite-sdk-js/jobs/637917621#L824

Travis has conditional deployment for node built in (https://docs.travis-ci.com/user/deployment#examples-of-conditional-deployment) so hopefully this will fix that CI step.