### PR TITLE
feat: add getDefaultRequestHeaders() to get headers required by the API

### DIFF
--- a/src/__tests__/cogniteClient.spec.ts
+++ b/src/__tests__/cogniteClient.spec.ts
@@ -134,6 +134,13 @@ describe('CogniteClient', () => {
       .reply(200, {});
   });
 
+  test('getBaseUrl() returns set value', () => {
+    const baseUrl = 'https://example.com';
+    const client = setupMockableClient();
+    client.setBaseUrl(baseUrl);
+    expect(client.getBaseUrl()).toEqual(baseUrl);
+  });
+
   describe('http requests', () => {
     let client: CogniteClient;
 

--- a/src/__tests__/cogniteClient.spec.ts
+++ b/src/__tests__/cogniteClient.spec.ts
@@ -105,6 +105,9 @@ describe('CogniteClient', () => {
         .get('/test')
         .reply(200, {});
       await client.get('/test');
+      expect(client.getDefaultRequestHeaders()).toMatchObject({
+        [API_KEY_HEADER]: apiKey,
+      });
     });
 
     test('set correct project', async () => {
@@ -115,6 +118,20 @@ describe('CogniteClient', () => {
       });
       expect(client.project).toBe(project);
     });
+  });
+
+  test('getDefaultRequestHeaders() returns clone', () => {
+    const client = setupMockableClient();
+    client.loginWithApiKey({
+      project,
+      apiKey,
+    });
+    const headers = client.getDefaultRequestHeaders();
+    headers[API_KEY_HEADER] = 'overriden';
+    const expectedHeaders = { [API_KEY_HEADER]: apiKey };
+    nock(mockBaseUrl, { reqheaders: expectedHeaders })
+      .get('/')
+      .reply(200, {});
   });
 
   describe('http requests', () => {

--- a/src/__tests__/utils/http/basicHttpClient.spec.ts
+++ b/src/__tests__/utils/http/basicHttpClient.spec.ts
@@ -21,6 +21,9 @@ describe('BasicHttpClient', () => {
         .post('/')
         .reply(200, {});
       await client.post('/');
+      expect(client.getDefaultHeaders()).toMatchObject({
+        [header.name]: header.value,
+      });
     });
 
     test('override default header', async () => {
@@ -30,6 +33,9 @@ describe('BasicHttpClient', () => {
         .post('/')
         .reply(200, {});
       await client.post('/');
+      expect(client.getDefaultHeaders()).toMatchObject({
+        [header.name]: header.value,
+      });
     });
   });
 

--- a/src/cogniteClient.ts
+++ b/src/cogniteClient.ts
@@ -34,7 +34,11 @@ import { SequencesAPI } from './resources/sequences/sequencesApi';
 import { ServiceAccountsAPI } from './resources/serviceAccounts/serviceAccountsApi';
 import { TimeSeriesAPI } from './resources/timeSeries/timeSeriesApi';
 import { apiUrl, getBaseUrl, isUsingSSL, projectUrl } from './utils';
-import { HttpRequestOptions, HttpResponse } from './utils/http/basicHttpClient';
+import {
+  HttpHeaders,
+  HttpRequestOptions,
+  HttpResponse,
+} from './utils/http/basicHttpClient';
 import { CDFHttpClient } from './utils/http/cdfHttpClient';
 
 export interface ClientOptions {
@@ -323,6 +327,29 @@ export default class CogniteClient {
   public setBaseUrl = (baseUrl: string) => {
     this.httpClient.setBaseUrl(baseUrl);
   };
+
+  /**
+   * Returns the base-url used for all requests.
+   */
+  public getBaseUrl(): string {
+    return this.httpClient.getBaseUrl();
+  }
+
+  /**
+   * Returns the default HTTP request headers, including e.g. authentication
+   * headers that is included in all requests. Headers provided per-requests is not
+   * included in this list. This function is useful when constructing API requests
+   * outside the SDK.
+   *
+   * ```js
+   * const customUrl = [...];
+   * const headers = client.getDefaultRequestHeaders();
+   * const result = await fetch(customUrl, { headers: new Headers(headers) });
+   * ```
+   */
+  public getDefaultRequestHeaders(): HttpHeaders {
+    return Object.assign({}, this.httpClient.getDefaultHeaders());
+  }
 
   /**
    * Lookup response metadata from an request using the response as the parameter

--- a/src/cogniteClient.ts
+++ b/src/cogniteClient.ts
@@ -342,13 +342,13 @@ export default class CogniteClient {
    * outside the SDK.
    *
    * ```js
-   * const customUrl = [...];
+   * const customUrl = '...';
    * const headers = client.getDefaultRequestHeaders();
-   * const result = await fetch(customUrl, { headers: new Headers(headers) });
+   * const result = await fetch(customUrl, { headers });
    * ```
    */
   public getDefaultRequestHeaders(): HttpHeaders {
-    return Object.assign({}, this.httpClient.getDefaultHeaders());
+    return { ...this.httpClient.getDefaultHeaders() };
   }
 
   /**

--- a/src/utils/http/basicHttpClient.ts
+++ b/src/utils/http/basicHttpClient.ts
@@ -80,7 +80,7 @@ export class BasicHttpClient {
   }
 
   public getDefaultHeaders(): HttpHeaders {
-    return this.defaultHeaders;
+    return { ...this.defaultHeaders };
   }
 
   public setBaseUrl(baseUrl: string) {

--- a/src/utils/http/basicHttpClient.ts
+++ b/src/utils/http/basicHttpClient.ts
@@ -79,6 +79,10 @@ export class BasicHttpClient {
     return this;
   }
 
+  public getDefaultHeaders(): HttpHeaders {
+    return this.defaultHeaders;
+  }
+
   public setBaseUrl(baseUrl: string) {
     this.baseUrl = baseUrl;
   }


### PR DESCRIPTION
Add functionality to retrieve headers used for HTTP requests. This is useful to use CDF with libraries that doesn't alllow fetching data through the API and therefor require raw headers, e.g. Cesium.