### PR TITLE
WIP: Feat/timeseries datapoint pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/jest": "^23.3.7",
     "@types/nock": "^10.0.3",
     "@types/node": "^10.12.0",
+    "@types/ms": "^0.7.31",
     "@types/query-string": "^6.1.0",
     "es-check": "^5.0.0",
     "husky": "^3.0.2",
@@ -71,6 +72,7 @@
   "dependencies": {
     "cross-fetch": "^3.0.4",
     "lodash": "^4.17.11",
+    "ms": "^2.1.2",
     "query-string": "^5.1.1",
     "url": "^0.11.0"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,5 @@ export const X_CDF_APP_HEADER = 'x-cdp-app';
 export const X_CDF_SDK_HEADER = 'x-cdp-sdk';
 /** @hidden */
 export const X_REQUEST_ID = 'X-Request-Id';
+
+export const API_MAX_DATAPOINTS_PER_REQUEST = 10000;

--- a/src/resources/dataPoints/multiQueryFetchHelpers.ts
+++ b/src/resources/dataPoints/multiQueryFetchHelpers.ts
@@ -1,0 +1,31 @@
+// Copyright 2019 Cognite AS
+
+import ms from 'ms';
+import { DatapointsMultiQuery } from '../..';
+import { PotentiallyUndefinedQueryValues } from './types';
+
+function cleanQueryInput(
+  q: DatapointsMultiQuery
+): PotentiallyUndefinedQueryValues {
+  function alwaysReturnNumber(value: string | number | Date): number {
+    if (typeof value === 'string') {
+      return ms(value);
+    }
+    if (value instanceof Date) {
+      return value.getMilliseconds();
+    }
+    return value;
+  }
+  function numberOrUndefined(
+    // tslint:disable-next-line:max-union-size
+    value: number | string | Date | undefined
+  ): number | undefined {
+    return typeof value === 'undefined' ? value : alwaysReturnNumber(value);
+  }
+  const start = numberOrUndefined(q.start);
+  const end = numberOrUndefined(q.end);
+  const limit = numberOrUndefined(q.limit);
+  const granularity: undefined | number = numberOrUndefined(q.granularity);
+
+  return { start, end, limit, granularity };
+}

--- a/src/resources/dataPoints/multiQueryFetchHelpers.ts
+++ b/src/resources/dataPoints/multiQueryFetchHelpers.ts
@@ -1,5 +1,6 @@
 // Copyright 2019 Cognite AS
 
+import _ from 'lodash';
 import ms from 'ms';
 import {
   DatapointsGetAggregateDatapoint,
@@ -12,6 +13,7 @@ import { CDFHttpClient } from '../../utils/http/cdfHttpClient';
 import {
   ConsolidatedQueryValues,
   PotentiallyUndefinedQueryValues,
+  QueryResponse,
 } from './types';
 
 function cleanQueryInput(
@@ -115,4 +117,26 @@ export function createRequests(
     newStart = newEnd;
   }
   return requests;
+}
+
+export function mergeResponses(acc: QueryResponse, cur: QueryResponse) {
+  // Override 'mergeWith' default behaviour for the datapoint array
+  const concatAndSortDatapoints = (
+    objValue: any,
+    srcValue: any,
+    key: string
+  ) => {
+    if (key === 'datapoints') {
+      return (
+        objValue
+          .concat(srcValue)
+          // Sorting has significant performance impact on larger data sets
+          .sort(
+            (a: { timestamp: Date }, b: { timestamp: Date }) =>
+              a.timestamp.getTime() - b.timestamp.getTime()
+          )
+      );
+    }
+  };
+  return _.mergeWith(cur, acc, concatAndSortDatapoints);
 }

--- a/src/resources/dataPoints/types.ts
+++ b/src/resources/dataPoints/types.ts
@@ -6,3 +6,10 @@ export interface PotentiallyUndefinedQueryValues {
   limit?: number;
   granularity?: number;
 }
+
+export interface ConsolidatedQueryValues {
+  start: number;
+  end: number;
+  limit: number;
+  granularity: number;
+}

--- a/src/resources/dataPoints/types.ts
+++ b/src/resources/dataPoints/types.ts
@@ -1,5 +1,12 @@
 // Copyright 2019 Cognite AS
 
+import {
+  DatapointsGetAggregateDatapoint,
+  DatapointsGetDatapoint,
+  ItemsWrapper,
+} from '../..';
+import { HttpResponse } from '../../utils/http/basicHttpClient';
+
 export interface PotentiallyUndefinedQueryValues {
   start?: number;
   end?: number;
@@ -13,3 +20,7 @@ export interface ConsolidatedQueryValues {
   limit: number;
   granularity: number;
 }
+
+export type QueryResponse = HttpResponse<
+  ItemsWrapper<(DatapointsGetAggregateDatapoint | DatapointsGetDatapoint)[]>
+>;

--- a/src/resources/dataPoints/types.ts
+++ b/src/resources/dataPoints/types.ts
@@ -1,0 +1,8 @@
+// Copyright 2019 Cognite AS
+
+export interface PotentiallyUndefinedQueryValues {
+  start?: number;
+  end?: number;
+  limit?: number;
+  granularity?: number;
+}


### PR DESCRIPTION
This feature should allow for requesting more than 10000 datapoints through the sdk. 
See the commit logs for details as they should be somewhat detailed. 

This is a WIP because it currently only supports one item per query. This will be fixed, but the PR is opened anyway as I would like input on a few different points: 

- This feature highjacks and manipulates response data. The rationale is that this makes the feature invisible to the user, but a downside can be that it can confuse a user looking at the network activity tab of their browser. 
- I'd like to make test cases for this code, but I'm not sure how well the test framework would handle throwing more than 10000 datapoints in the loop. 
- What is our stance on throwing exceptions? 
  - Spesifically should we allow queries that are seemingly allowed by the API but that logically does not hold up? Like a query where `{ start, end, limit, granularity }` are all provided but with conflicting valyues. 
- Sorting done in 64281a5 can add some overhead with larger sets of datapoints (about five seconds for ~1 million datapoints in my very basic testing). Should we be concerned or is this fine? 

So in summary, there's still quite fundamental functionality missing but I'd appriciacte any input on the progress so far! 😄 