### PR TITLE
feat: add another field in CogniteError called "extra"

### DIFF
--- a/src/__tests__/__snapshots__/error.spec.ts.snap
+++ b/src/__tests__/__snapshots__/error.spec.ts.snap
@@ -58,21 +58,14 @@ exports[`CogniteError extra field 1`] = `
       \\"description\\": \\"string\\",
       \\"source\\": \\"string\\"
     }
-  ]
+  ],
+  \\"extra\\": \\"Extra log information\\"
 }"
 `;
 
 exports[`handleErrorResponse extra fields 1`] = `
 "abc | code: 500 | X-Request-ID: def
 {
-  \\"missing\\": [
-    {
-      \\"id\\": 4190022127342195
-    },
-    {
-      \\"externalId\\": \\"abc\\"
-    }
-  ],
   \\"duplicated\\": [
     {
       \\"externalId\\": \\"string\\",
@@ -80,6 +73,17 @@ exports[`handleErrorResponse extra fields 1`] = `
       \\"endTime\\": 0,
       \\"description\\": \\"string\\",
       \\"source\\": \\"string\\"
+    }
+  ],
+  \\"extra\\": {
+    \\"extraErrorInformation\\": \\"test\\"
+  },
+  \\"missing\\": [
+    {
+      \\"id\\": 4190022127342195
+    },
+    {
+      \\"externalId\\": \\"abc\\"
     }
   ]
 }"

--- a/src/__tests__/error.spec.ts
+++ b/src/__tests__/error.spec.ts
@@ -48,6 +48,7 @@ describe('CogniteError', () => {
     const error = new CogniteError(errorMessage, status, undefined, {
       missing: [internalIdObject, externalIdObject],
       duplicated: [event],
+      extra: 'Extra log information',
     });
     expect(() => {
       throw error;
@@ -83,6 +84,7 @@ describe('handleErrorResponse', () => {
       createErrorReponse(status, message, {
         missing: [internalIdObject, externalIdObject],
         duplicated: [event],
+        extra: { extraErrorInformation: 'test' },
       }),
       { [X_REQUEST_ID]: xRequestId }
     );
@@ -96,8 +98,9 @@ describe('handleErrorResponse', () => {
     } catch (e) {
       expect(e.status).toBe(status);
       expect(e.requestId).toBe(xRequestId);
-      expect(e.missing).toEqual([internalIdObject, externalIdObject]);
       expect(e.duplicated).toEqual([event]);
+      expect(e.extra.extraErrorInformation).toBe('test');
+      expect(e.missing).toEqual([internalIdObject, externalIdObject]);
     }
   });
 });


### PR DESCRIPTION
Reference: https://github.com/cognitedata/service-contracts/blob/master/design_guide/API_design_guide.md#error-messages

> Keep the error message brief. If needed, provide more information in the `extra` field.