### PR TITLE
feat(synthetic time series): add synthetic time series query api call

### DIFF
--- a/src/__tests__/resources/timeseries.integration.spec.ts
+++ b/src/__tests__/resources/timeseries.integration.spec.ts
@@ -155,6 +155,15 @@ describe('Timeseries integration test', () => {
     expect(result[0].name).toBe(name);
   });
 
+  test('synthetic query', async () => {
+    const [ts1] = createdTimeseries;
+    const result = await client.timeseries.syntheticQuery([
+      { expression: `24 * TS{id:${ts1.id}}`, start: 0, end: 100, limit: 100 },
+    ]);
+    expect(result.length).toBe(1);
+    expect(result[0].datapoints.length).toBeLessThanOrEqual(100);
+  });
+
   test('delete', async () => {
     await client.timeseries.delete(createdTimeseries.map(({ id }) => ({ id })));
   });

--- a/src/__tests__/resources/timeseries.integration.spec.ts
+++ b/src/__tests__/resources/timeseries.integration.spec.ts
@@ -158,8 +158,20 @@ describe('Timeseries integration test', () => {
   test('synthetic query', async () => {
     const [ts1, ts2] = createdTimeseries;
     const result = await client.timeseries.syntheticQuery([
-      { expression: `24 * TS{externalId='${ts1.externalId}', aggregate='average', granularity='1h'}`, start: 0, end: 100, limit: 100 },
-      { expression: `map(TS{id=${ts2.id}}, ['A', 'B'], [1, 2], 0)`, start: "2d-ago", end: "0h-ago", limit: 4 }
+      {
+        expression: `24 * TS{externalId='${
+          ts1.externalId
+        }', aggregate='average', granularity='1h'}`,
+        start: 0,
+        end: 100,
+        limit: 100,
+      },
+      {
+        expression: `map(TS{id=${ts2.id}}, ['A', 'B'], [1, 2], 0)`,
+        start: '2d-ago',
+        end: '0h-ago',
+        limit: 4,
+      },
     ]);
     expect(result.length).toBe(2);
     expect(result[0].datapoints.length).toBeLessThanOrEqual(100);

--- a/src/__tests__/resources/timeseries.integration.spec.ts
+++ b/src/__tests__/resources/timeseries.integration.spec.ts
@@ -156,12 +156,15 @@ describe('Timeseries integration test', () => {
   });
 
   test('synthetic query', async () => {
-    const [ts1] = createdTimeseries;
+    const [ts1, ts2] = createdTimeseries;
     const result = await client.timeseries.syntheticQuery([
-      { expression: `24 * TS{id:${ts1.id}}`, start: 0, end: 100, limit: 100 },
+      { expression: `24 * TS{externalId='${ts1.externalId}', aggregate='average', granularity='1h'}`, start: 0, end: 100, limit: 100 },
+      { expression: `map(TS{id=${ts2.id}}, ['A', 'B'], [1, 2], 0)`, start: "2d-ago", end: "0h-ago", limit: 4 }
     ]);
-    expect(result.length).toBe(1);
+    expect(result.length).toBe(2);
     expect(result[0].datapoints.length).toBeLessThanOrEqual(100);
+    expect(result[1].datapoints.length).toBeLessThanOrEqual(4);
+    expect(result[1].isString).toBe(false);
   });
 
   test('delete', async () => {

--- a/src/__tests__/resources/timeseries.integration.spec.ts
+++ b/src/__tests__/resources/timeseries.integration.spec.ts
@@ -163,7 +163,7 @@ describe('Timeseries integration test', () => {
           ts1.externalId
         }', aggregate='average', granularity='1h'}`,
         start: '48h-ago',
-        end: '0h-ago',
+        end: 'now',
         limit: 100,
       },
     ]);

--- a/src/__tests__/resources/timeseries.integration.spec.ts
+++ b/src/__tests__/resources/timeseries.integration.spec.ts
@@ -156,27 +156,18 @@ describe('Timeseries integration test', () => {
   });
 
   test('synthetic query', async () => {
-    const [ts1, ts2] = createdTimeseries;
+    const [ts1] = createdTimeseries;
     const result = await client.timeseries.syntheticQuery([
       {
         expression: `24 * TS{externalId='${
           ts1.externalId
         }', aggregate='average', granularity='1h'}`,
-        start: 0,
-        end: 100,
+        start: '48h-ago',
+        end: '0h-ago',
         limit: 100,
       },
-      {
-        expression: `map(TS{id=${ts2.id}}, ['A', 'B'], [1, 2], 0)`,
-        start: '2d-ago',
-        end: '0h-ago',
-        limit: 4,
-      },
     ]);
-    expect(result.length).toBe(2);
-    expect(result[0].datapoints.length).toBeLessThanOrEqual(100);
-    expect(result[1].datapoints.length).toBeLessThanOrEqual(4);
-    expect(result[1].isString).toBe(false);
+    expect(result.length).toBe(1);
   });
 
   test('delete', async () => {

--- a/src/resources/timeSeries/syntheticTimeSeriesApi.ts
+++ b/src/resources/timeSeries/syntheticTimeSeriesApi.ts
@@ -12,12 +12,8 @@ export class SyntheticTimeSeriesAPI extends BaseResourceAPI<
     return this.querySyntheticEndpoint(items);
   };
 
-  private get queryUrl() {
-    return this.url('query');
-  }
-
   private async querySyntheticEndpoint(items: SyntheticQuery[]) {
-    const path = this.queryUrl;
+    const path = this.url('query');
     return this.callEndpointWithMergeAndTransform(items, data =>
       this.postInParallelWithAutomaticChunking({
         path,

--- a/src/resources/timeSeries/syntheticTimeSeriesApi.ts
+++ b/src/resources/timeSeries/syntheticTimeSeriesApi.ts
@@ -1,0 +1,29 @@
+// Copyright 2020 Cognite AS
+
+import { BaseResourceAPI } from '../../resources/baseResourceApi';
+import { SyntheticQuery, SyntheticQueryResponse } from '../../types/types';
+
+export class SyntheticTimeSeriesAPI extends BaseResourceAPI<
+  SyntheticQueryResponse
+> {
+  public query = (
+    items: SyntheticQuery[]
+  ): Promise<SyntheticQueryResponse[]> => {
+    return this.querySyntheticEndpoint(items);
+  };
+
+  private get queryUrl() {
+    return this.url('query');
+  }
+
+  private async querySyntheticEndpoint(items: SyntheticQuery[]) {
+    const path = this.queryUrl;
+    return this.callEndpointWithMergeAndTransform(items, data =>
+      this.postInParallelWithAutomaticChunking({
+        path,
+        items: data,
+        chunkSize: 10,
+      })
+    );
+  }
+}

--- a/src/resources/timeSeries/timeSeriesApi.ts
+++ b/src/resources/timeSeries/timeSeriesApi.ts
@@ -161,9 +161,6 @@ export class TimeSeriesAPI extends BaseResourceAPI<
   /**
    * [Synthetic Query](https://docs.cognite.com/api/v1/#operation/querySyntheticTimeseries)
    *
-   * @param {SyntheticQuery[]} items - the queries made, will be chunked if over api limit
-   * Note the limit on sum of datapoints per api request, which will not be chunked automatically
-   *
    * ```js
    * await client.timeseries.syntheticQuery([
    *   {

--- a/src/resources/timeSeries/timeSeriesApi.ts
+++ b/src/resources/timeSeries/timeSeriesApi.ts
@@ -165,8 +165,8 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    * await client.timeseries.syntheticQuery([
    *   {
    *     expression: "24 * TS{externalId='production/hour', aggregate='average', granularity='1d'}",
-   *     start: 0,
-   *     end: 0,
+   *     start: '48h-ago',
+   *     end: '0h-ago',
    *     limit: 100
    *   }
    * ]);

--- a/src/resources/timeSeries/timeSeriesApi.ts
+++ b/src/resources/timeSeries/timeSeriesApi.ts
@@ -8,7 +8,10 @@ import {
   GetTimeSeriesMetadataDTO,
   IdEither,
   IgnoreUnknownIds,
+  ItemsWrapper,
   PostTimeSeriesMetadataDTO,
+  SyntheticQuery,
+  SyntheticQueryResponse,
   TimeseriesAggregate,
   TimeseriesAggregateQuery,
   TimeseriesFilter,
@@ -148,6 +151,38 @@ export class TimeSeriesAPI extends BaseResourceAPI<
   public delete = (ids: IdEither[]) => {
     return super.deleteEndpoint(ids);
   };
+
+  /**
+   * [Synthetic Query](https://docs.cognite.com/api/v1/#operation/querySyntheticTimeseries)
+   *
+   * ```js
+   * await client.timeseries.syntheticQuery([
+   *   {
+   *     expression: "24 * TS{externalId='production/hour'}",
+   *     start: 0,
+   *     end: 0,
+   *     limit: 100
+   *   }
+   * ]);
+   * ```
+   */
+  public syntheticQuery(items: SyntheticQuery[]) {
+    return this.querySyntheticEndpoint(items);
+  };
+
+  private syntheticQueryUrl() {
+    return this.url('synthetic/query');
+  }
+
+  private async querySyntheticEndpoint(items: SyntheticQuery[]) {
+    const path = this.syntheticQueryUrl();
+    const response = await this.httpClient.post<
+      ItemsWrapper<SyntheticQueryResponse[]>
+    >(path, {
+      data: {items}
+    });
+    return this.addToMapAndReturn(response.data.items, response);
+  }
 
   protected transformToList(timeSeries: GetTimeSeriesMetadataDTO[]) {
     return timeSeries.map(timeSerie => new TimeSeries(this.client, timeSerie));

--- a/src/resources/timeSeries/timeSeriesApi.ts
+++ b/src/resources/timeSeries/timeSeriesApi.ts
@@ -170,20 +170,6 @@ export class TimeSeriesAPI extends BaseResourceAPI<
     return this.querySyntheticEndpoint(items);
   };
 
-  private syntheticQueryUrl() {
-    return this.url('synthetic/query');
-  }
-
-  private async querySyntheticEndpoint(items: SyntheticQuery[]) {
-    const path = this.syntheticQueryUrl();
-    const response = await this.httpClient.post<
-      ItemsWrapper<SyntheticQueryResponse[]>
-    >(path, {
-      data: {items}
-    });
-    return this.addToMapAndReturn(response.data.items, response);
-  }
-
   protected transformToList(timeSeries: GetTimeSeriesMetadataDTO[]) {
     return timeSeries.map(timeSerie => new TimeSeries(this.client, timeSerie));
   }
@@ -191,6 +177,21 @@ export class TimeSeriesAPI extends BaseResourceAPI<
   protected transformToClass(timeSeries: GetTimeSeriesMetadataDTO[]) {
     const timeseriesArray = this.transformToList(timeSeries);
     return new TimeSeriesList(this.client, timeseriesArray);
+  }
+
+  private syntheticQueryUrl() {
+    return this.url('synthetic/query');
+  }
+
+  private async querySyntheticEndpoint(items: SyntheticQuery[]) {
+    const path = this.syntheticQueryUrl();
+
+    const response = await this.httpClient.post<
+      ItemsWrapper<SyntheticQueryResponse[]>
+    >(path, {
+      data: { items },
+    });
+    return this.addToMapAndReturn(response.data.items, response);
   }
 }
 

--- a/src/resources/timeSeries/timeSeriesApi.ts
+++ b/src/resources/timeSeries/timeSeriesApi.ts
@@ -166,7 +166,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    * ]);
    * ```
    */
-  public syntheticQuery(items: SyntheticQuery[]) {
+  public syntheticQuery = (items: SyntheticQuery[]) => {
     return this.querySyntheticEndpoint(items);
   };
 

--- a/src/resources/timeSeries/timeSeriesApi.ts
+++ b/src/resources/timeSeries/timeSeriesApi.ts
@@ -166,7 +166,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    *   {
    *     expression: "24 * TS{externalId='production/hour', aggregate='average', granularity='1d'}",
    *     start: '48h-ago',
-   *     end: '0h-ago',
+   *     end: 'now',
    *     limit: 100
    *   }
    * ]);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1940,7 +1940,7 @@ export interface SyntheticDataValue extends SyntheticDateBase {
  * A query for a synthetic time series
  */
 export interface SyntheticQuery {
-  expression?: string;
+  expression: string;
   start?: string | Timestamp;
   end?: string | Timestamp;
   limit: number;
@@ -1951,7 +1951,7 @@ export interface SyntheticQuery {
  */
 export interface SyntheticQueryResponse {
   isString?: TimeseriesIsString;
-  datapoints?: SyntheticDataPoint[];
+  datapoints: SyntheticDataPoint[];
 }
 
 export interface TimeSeriesPatch {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1922,17 +1922,13 @@ export const SortOrder = {
  */
 export type SortOrder = 'asc' | 'desc';
 
-export interface SyntheticDateBase {
-  timestamp?: Date;
-}
-
-export interface SyntheticDataError extends SyntheticDateBase {
+export interface SyntheticDataError extends GetDatapointMetadata {
   error: string;
 }
 
-export type SyntheticDataPoint = SyntheticDataValue | SyntheticDataError;
+export type SyntheticDatapoint = SyntheticDataValue | SyntheticDataError;
 
-export interface SyntheticDataValue extends SyntheticDateBase {
+export interface SyntheticDataValue extends GetDatapointMetadata {
   value: number;
 }
 
@@ -1950,7 +1946,7 @@ export interface SyntheticQuery extends Limit {
  */
 export interface SyntheticQueryResponse {
   isString?: TimeseriesIsString;
-  datapoints: SyntheticDataPoint[];
+  datapoints: SyntheticDatapoint[];
 }
 
 export interface TimeSeriesPatch {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1939,11 +1939,10 @@ export interface SyntheticDataValue extends SyntheticDateBase {
 /**
  * A query for a synthetic time series
  */
-export interface SyntheticQuery {
+export interface SyntheticQuery extends Limit {
   expression: string;
   start?: string | Timestamp;
   end?: string | Timestamp;
-  limit: number;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1922,6 +1922,38 @@ export const SortOrder = {
  */
 export type SortOrder = 'asc' | 'desc';
 
+export interface SyntheticDateBase {
+  timestamp?: Date;
+}
+
+export interface SyntheticDataError extends SyntheticDateBase {
+  error: string;
+}
+
+export type SyntheticDataPoint = SyntheticDataValue | SyntheticDataError;
+
+export interface SyntheticDataValue extends SyntheticDateBase {
+  value: number;
+}
+
+/**
+ * A query for a synthetic time series
+ */
+export interface SyntheticQuery {
+  expression?: string;
+  start?: string | Timestamp;
+  end?: string | Timestamp;
+  limit: number;
+}
+
+/**
+ * Response of a synthetic time series query
+ */
+export interface SyntheticQueryResponse {
+  isString?: TimeseriesIsString;
+  datapoints?: SyntheticDataPoint[];
+}
+
 export interface TimeSeriesPatch {
   update: {
     externalId?: NullableSinglePatchString;
@@ -2016,6 +2048,10 @@ export type TimeseriesName = string;
  */
 export type TimeseriesUnit = string;
 
+/**
+ * A point in time, either a number or a Date object.
+ * The Date is converted to a number when api calls are made.
+ */
 export type Timestamp = number | Date;
 
 export type Tuple3<T> = T[];


### PR DESCRIPTION
Adds a new class for the synthetic time series api with one public method, accessed through the regular time series api class. Adds tests and a snippet for the docs.