### PR TITLE
docs(labels): fix code snippet api url

### DIFF
--- a/src/resources/labels/labelsApi.ts
+++ b/src/resources/labels/labelsApi.ts
@@ -11,7 +11,7 @@ import { BaseResourceAPI } from '../baseResourceApi';
 
 export class LabelsAPI extends BaseResourceAPI<LabelDefinition> {
   /**
-   * [Create labels](https://docs.cognite.com/api/v1/#operation/createLabelDefinitions)
+   * [Create labels](https://docs.cognite.com/api/v1/#operation/createDefinitions)
    *
    * ```js
    * const labels = [


### PR DESCRIPTION
fyi @fredrik955 I agree that `createLabelDefinitions` is better, however it is not like that in api reference :(