### PR TITLE
feat(avents-aggregate): aggregates moved to separate api

### DIFF
--- a/packages/stable/src/__tests__/api/events.int.spec.ts
+++ b/packages/stable/src/__tests__/api/events.int.spec.ts
@@ -85,7 +85,7 @@ describe('Events integration test', () => {
   });
 
   test('count aggregate', async () => {
-    const aggregates = await client.events.aggregate({
+    const aggregates = await client.events.aggregate.count({
       filter: {
         source: 'WORKMATE',
       },
@@ -95,7 +95,7 @@ describe('Events integration test', () => {
   });
 
   test('values aggregate', async () => {
-    const aggregates = await client.events.uniqueValuesAggregate({
+    const aggregates = await client.events.aggregate.uniqueValues({
       filter: {
         source: 'WORKMATE',
       },

--- a/packages/stable/src/api/events/eventsAggregateApi.ts
+++ b/packages/stable/src/api/events/eventsAggregateApi.ts
@@ -1,0 +1,40 @@
+// Copyright 2020 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import {
+  AggregateResponse,
+  EventAggregateQuery,
+  EventUniqueValuesAggregate,
+  UniqueValuesAggregateResponse,
+} from '../../types';
+
+export class EventsAggregateAPI extends BaseResourceAPI<unknown> {
+  /**
+   * [Aggregate events](https://docs.cognite.com/api/v1/#operation/aggregateEvents)
+   *
+   * ```js
+   * const aggregates = await client.events.aggregate.count({ filter: { assetIds: [1, 2, 3] } });
+   * console.log('Number of events: ', aggregates[0].count)
+   * ```
+   */
+  public count = (query: EventAggregateQuery): Promise<AggregateResponse[]> => {
+    return super.aggregateEndpoint(query);
+  };
+
+  /**
+   * [Aggregate events](https://docs.cognite.com/api/v1/#operation/aggregateEvents)
+   *
+   * ```js
+   * const uniqueValues = await client.events.aggregate.uniqueValues({ filter: { assetIds: [1, 2, 3] }, fields: ['subtype'] });
+   * console.log('Unique values: ', uniqueValues)
+   * ```
+   */
+  public uniqueValues = (
+    query: EventUniqueValuesAggregate
+  ): Promise<UniqueValuesAggregateResponse[]> => {
+    return super.aggregateEndpoint({
+      ...query,
+      aggregate: 'uniqueValues',
+    });
+  };
+}


### PR DESCRIPTION
BREAKING CHANGE!: Event aggregate methods moved to a separate api.

`client.events.aggregate(...)` -> `client.events.aggregate.count()`
`client.events.uniqueValuesAggregate(...)` -> `client.events.aggregate.uniqueValues(...)`