### PR TITLE
feat: renamed interfaces

### DIFF
--- a/packages/stable/src/__tests__/api/asset.int.spec.ts
+++ b/packages/stable/src/__tests__/api/asset.int.spec.ts
@@ -4,7 +4,7 @@ import { AssetImpl } from '../../api/classes/asset';
 import { EventsAPI } from '../../api/events/eventsApi';
 import { TimeSeriesAPI } from '../../api/timeSeries/timeSeriesApi';
 import CogniteClient from '../../cogniteClient';
-import { CogniteEvent, TimeSeries } from '../../types';
+import { CogniteEvent, Timeseries } from '../../types';
 import {
   randomInt,
   runTestWithRetryWhenFailing,
@@ -127,7 +127,7 @@ describe('Asset', () => {
         : { assetIds: [createdAssets[0].id] };
     const resourceList = new Array(5).fill(content);
     const resources = await api.create(resourceList);
-    let fetchedResource: (TimeSeries | CogniteEvent)[];
+    let fetchedResource: (Timeseries | CogniteEvent)[];
     await runTestWithRetryWhenFailing(async () => {
       if (api instanceof TimeSeriesAPI) {
         fetchedResource = await createdAssets[0].timeSeries();

--- a/packages/stable/src/__tests__/api/asset.int.spec.ts
+++ b/packages/stable/src/__tests__/api/asset.int.spec.ts
@@ -1,10 +1,10 @@
 // Copyright 2020 Cognite AS
 
-import { Asset } from '../../api/classes/asset';
+import { AssetImpl } from '../../api/classes/asset';
 import { EventsAPI } from '../../api/events/eventsApi';
 import { TimeSeriesAPI } from '../../api/timeSeries/timeSeriesApi';
 import CogniteClient from '../../cogniteClient';
-import { CogniteEvent, GetTimeSeriesMetadataDTO } from '../../types';
+import { CogniteEvent, TimeSeries } from '../../types';
 import {
   randomInt,
   runTestWithRetryWhenFailing,
@@ -37,7 +37,7 @@ describe('Asset', () => {
         parentExternalId: newRoot.externalId,
       };
       const createdAssets = await client.assets.create([newRoot, newChild]);
-      expect(await createdAssets[1].parent()).toBeInstanceOf(Asset);
+      expect(await createdAssets[1].parent()).toBeInstanceOf(AssetImpl);
       expect(await createdAssets[0].parent()).toBe(null);
       await client.assets.delete([{ id: createdAssets[0].id }], {
         recursive: true,
@@ -127,7 +127,7 @@ describe('Asset', () => {
         : { assetIds: [createdAssets[0].id] };
     const resourceList = new Array(5).fill(content);
     const resources = await api.create(resourceList);
-    let fetchedResource: (GetTimeSeriesMetadataDTO | CogniteEvent)[];
+    let fetchedResource: (TimeSeries | CogniteEvent)[];
     await runTestWithRetryWhenFailing(async () => {
       if (api instanceof TimeSeriesAPI) {
         fetchedResource = await createdAssets[0].timeSeries();

--- a/packages/stable/src/__tests__/api/asset.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/asset.unit.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Cognite AS
 import * as nock from 'nock';
-import { Asset } from '../../api/classes/asset';
+import { AssetImpl } from '../../api/classes/asset';
 import CogniteClient from '../../cogniteClient';
 import { mockBaseUrl, randomInt, setupMockableClient } from '../testUtils';
 
@@ -48,7 +48,7 @@ describe('Asset class unit test', () => {
     const createdAssets = await client.assets.create([newRoot, ...childArray]);
     const children = await createdAssets[0].children();
     expect(children.length).toBe(102);
-    expect(children[0]).toBeInstanceOf(Asset);
+    expect(children[0]).toBeInstanceOf(AssetImpl);
     expect(children[0].name).toEqual(childArray[0].name);
   });
 });

--- a/packages/stable/src/__tests__/api/assets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/assets.int.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 
 import { CogniteError, CogniteMultiError } from '@cognite/sdk-core';
-import { Asset as AssetClass } from '../../api/classes/asset';
+import { AssetImpl } from '../../api/classes/asset';
 import CogniteClient from '../../cogniteClient';
 import { Asset } from '../../types';
 import {
@@ -205,18 +205,22 @@ describe('Asset integration test', () => {
   });
 
   test('list', async () => {
-    const response = await client.assets.list({ limit: 1 });
-    expect(response.nextCursor).toBeDefined();
-    expect(response.items).toBeDefined();
-    expect(response.items[0].id).toBeDefined();
-    expect(response.items[0]).toBeInstanceOf(AssetClass);
+    const { nextCursor, items } = await client.assets.list({
+      limit: 1,
+      partition: '1/10',
+    });
+    expect(nextCursor).toBeDefined();
+    expect(items).toBeDefined();
+    expect(items[0].id).toBeDefined();
+    expect(items[0]).toBeInstanceOf(AssetImpl);
+    expect(items.length).toBe(1);
   });
 
   test('list.next', async () => {
     const response = await client.assets.list({ limit: 1 });
     expect(response.next).toBeDefined();
     const nextPage = await response.next!();
-    expect(nextPage.items[0]).toBeInstanceOf(AssetClass);
+    expect(nextPage.items[0]).toBeInstanceOf(AssetImpl);
   });
 
   test('list with autoPaging', async () => {
@@ -320,12 +324,6 @@ describe('Asset integration test', () => {
       .list({ limit: 1 })
       .autoPagingToArray({ limit });
     expect(result.length).toBe(limit);
-  });
-
-  test('list partition', async () => {
-    const limit = 5;
-    const result = await client.assets.list({ partition: '1/10', limit });
-    expect(result.items.length).toBe(limit);
   });
 
   test('delete', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -1,13 +1,13 @@
 // Copyright 2020 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { TimeSeries } from '../../types';
+import { Timeseries } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
 describe('Datapoints integration test', () => {
   let client: CogniteClient;
-  let timeserie: TimeSeries;
-  let testTimeserieWithDatapoints: TimeSeries;
+  let timeserie: Timeseries;
+  let testTimeserieWithDatapoints: Timeseries;
   beforeAll(async () => {
     client = setupLoggedInClient();
     [timeserie] = await client.timeseries.create([{ name: 'tmp' }]);

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -1,13 +1,13 @@
 // Copyright 2020 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { GetTimeSeriesMetadataDTO } from '../../types';
+import { TimeSeries } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
 describe('Datapoints integration test', () => {
   let client: CogniteClient;
-  let timeserie: GetTimeSeriesMetadataDTO;
-  let testTimeserieWithDatapoints: GetTimeSeriesMetadataDTO;
+  let timeserie: TimeSeries;
+  let testTimeserieWithDatapoints: TimeSeries;
   beforeAll(async () => {
     client = setupLoggedInClient();
     [timeserie] = await client.timeseries.create([{ name: 'tmp' }]);

--- a/packages/stable/src/__tests__/api/datasets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datasets.int.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Cognite AS
 
-import { TimeSeries } from '../../api/classes/timeSeries';
+import { TimeSeriesImpl } from '../../api/classes/timeSeries';
 import CogniteClient from '../../cogniteClient';
 import {
   Asset,
@@ -8,7 +8,7 @@ import {
   CogniteInternalId,
   DataSet,
   DataSetFilterRequest,
-  FilesMetadata,
+  FileInfo,
   NullableSinglePatchLong,
   Sequence,
 } from '../../types';
@@ -81,7 +81,7 @@ describe('data sets integration test', () => {
   });
   describe('files data sets', () => {
     let dataSetId: CogniteInternalId;
-    let file: FilesMetadata;
+    let file: FileInfo;
 
     beforeAll(() => {
       dataSetId = datasets[0].id;
@@ -188,7 +188,7 @@ describe('data sets integration test', () => {
     });
   });
   describe('timeseries data sets', () => {
-    let timeseries: TimeSeries;
+    let timeseries: TimeSeriesImpl;
     let dataSetId: CogniteInternalId;
 
     beforeAll(() => {
@@ -206,7 +206,7 @@ describe('data sets integration test', () => {
     test('list', async () => {
       await runTestWithRetryWhenFailing(async () => {
         const filteredTimeseries = await client.timeseries
-          .list(dataSetFilter(dataSetId).filter)
+          .list(dataSetFilter(dataSetId))
           .autoPagingToArray();
 
         expect(filteredTimeseries.length).toBeTruthy();

--- a/packages/stable/src/__tests__/api/datasets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datasets.int.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Cognite AS
 
-import { TimeSeriesImpl } from '../../api/classes/timeSeries';
+import { TimeseriesImpl } from '../../api/classes/timeSeries';
 import CogniteClient from '../../cogniteClient';
 import {
   Asset,
@@ -188,7 +188,7 @@ describe('data sets integration test', () => {
     });
   });
   describe('timeseries data sets', () => {
-    let timeseries: TimeSeriesImpl;
+    let timeseries: TimeseriesImpl;
     let dataSetId: CogniteInternalId;
 
     beforeAll(() => {

--- a/packages/stable/src/__tests__/api/events.int.spec.ts
+++ b/packages/stable/src/__tests__/api/events.int.spec.ts
@@ -148,18 +148,11 @@ describe('Events integration test', () => {
               max: events[0].endTime! + 1,
             },
           },
+          partition: '1/10',
           limit: 3,
         })
         .autoPagingToArray({ limit: 5 });
       expect(response.length).toBeGreaterThan(0);
-    });
-
-    test('partitions', async () => {
-      const response = await client.events.list({
-        partition: '1/10',
-        limit: 10,
-      });
-      expect(response.items.length).toBeGreaterThan(0);
     });
 
     test('to json|string', async () => {

--- a/packages/stable/src/__tests__/api/files.int.spec.ts
+++ b/packages/stable/src/__tests__/api/files.int.spec.ts
@@ -2,9 +2,9 @@
 
 import { HttpResponseType } from '@cognite/sdk-core';
 import { readFileSync } from 'fs';
-import { Asset } from '../../api/classes/asset';
+import { AssetImpl } from '../../api/classes/asset';
 import CogniteClient from '../../cogniteClient';
-import { FilesMetadata } from '../../types';
+import { FileInfo } from '../../types';
 import { join } from 'path';
 import {
   getFileCreateArgs,
@@ -17,7 +17,7 @@ const testfile = join(__dirname, '../test3dFile.fbx');
 
 describe('Files integration test', () => {
   let client: CogniteClient;
-  let asset: Asset;
+  let asset: AssetImpl;
   beforeAll(async () => {
     client = setupLoggedInClient();
     [asset] = await client.assets.create([
@@ -38,7 +38,7 @@ describe('Files integration test', () => {
     sourceCreatedTime,
   } = getFileCreateArgs();
 
-  let file: FilesMetadata;
+  let file: FileInfo;
 
   test('create', async () => {
     file = await client.files.upload(localFileMeta, fileContent, false, true);
@@ -149,7 +149,7 @@ describe('Files integration test', () => {
       mimeType: 'application/octet-stream',
     };
     const fileContentBinary = readFileSync(testfile);
-    let binaryFile: FilesMetadata;
+    let binaryFile: FileInfo;
 
     test('create', async () => {
       binaryFile = await client.files.upload(

--- a/packages/stable/src/__tests__/api/revisions3D.int.spec.ts
+++ b/packages/stable/src/__tests__/api/revisions3D.int.spec.ts
@@ -7,7 +7,7 @@ import {
   AssetMapping3D,
   CreateAssetMapping3D,
   CreateRevision3D,
-  FilesMetadata,
+  FileInfo,
   Model3D,
   Node3D,
   Revision3D,
@@ -34,7 +34,7 @@ describeIfCondition(
     let client: CogniteClient;
 
     let revisions: Revision3D[];
-    let file: FilesMetadata;
+    let file: FileInfo;
     let model: Model3D;
     let assets: Asset[];
     let assetMappings: AssetMapping3D[];

--- a/packages/stable/src/__tests__/api/sequences.int.spec.ts
+++ b/packages/stable/src/__tests__/api/sequences.int.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 
 import * as nock from 'nock';
-import { Asset } from '../../api/classes/asset';
+import { Asset } from '../../types';
 import CogniteClient from '../../cogniteClient';
 import {
   ExternalSequence,

--- a/packages/stable/src/__tests__/api/timeSeriesList.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/timeSeriesList.unit.spec.ts
@@ -3,14 +3,14 @@ import { uniqBy } from 'lodash';
 import * as nock from 'nock';
 import { TimeSeriesList } from '../../api/classes/timeSeriesList';
 import CogniteClient from '../../cogniteClient';
-import { ExternalDatapoints, ExternalTimeSeries } from '../../types';
+import { ExternalDatapoints, ExternalTimeseries } from '../../types';
 import { mockBaseUrl, randomInt, setupMockableClient } from '../testUtils';
 
 describe('TimeSeriesList class unit test', async () => {
   let client: CogniteClient;
   let createdTimeSeries: TimeSeriesList;
   let datapointArray: ExternalDatapoints[] = [];
-  let timeseriesArray: ExternalTimeSeries[] = [];
+  let timeseriesArray: ExternalTimeseries[] = [];
   beforeAll(async () => {
     client = setupMockableClient();
     nock.cleanAll();

--- a/packages/stable/src/__tests__/api/timeSeriesList.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/timeSeriesList.unit.spec.ts
@@ -3,17 +3,14 @@ import { uniqBy } from 'lodash';
 import * as nock from 'nock';
 import { TimeSeriesList } from '../../api/classes/timeSeriesList';
 import CogniteClient from '../../cogniteClient';
-import {
-  DatapointsPostDatapoint,
-  PostTimeSeriesMetadataDTO,
-} from '../../types';
+import { ExternalDatapoints, ExternalTimeSeries } from '../../types';
 import { mockBaseUrl, randomInt, setupMockableClient } from '../testUtils';
 
 describe('TimeSeriesList class unit test', async () => {
   let client: CogniteClient;
   let createdTimeSeries: TimeSeriesList;
-  let datapointArray: DatapointsPostDatapoint[] = [];
-  let timeseriesArray: PostTimeSeriesMetadataDTO[] = [];
+  let datapointArray: ExternalDatapoints[] = [];
+  let timeseriesArray: ExternalTimeSeries[] = [];
   beforeAll(async () => {
     client = setupMockableClient();
     nock.cleanAll();

--- a/packages/stable/src/__tests__/api/timeSeriesObject.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/timeSeriesObject.unit.spec.ts
@@ -1,20 +1,17 @@
 // Copyright 2020 Cognite AS
 import * as nock from 'nock';
-import { Asset } from '../../api/classes/asset';
+import { AssetImpl } from '../../api/classes/asset';
 import { TimeSeriesList } from '../../api/classes/timeSeriesList';
 import CogniteClient from '../../cogniteClient';
-import {
-  DatapointsPostDatapoint,
-  PostTimeSeriesMetadataDTO,
-} from '../../types';
+import { ExternalDatapoints, ExternalTimeSeries } from '../../types';
 import { mockBaseUrl, randomInt, setupMockableClient } from '../testUtils';
 
 describe('TimeSeries class unit test', () => {
   let client: CogniteClient;
-  let newTimeSeries: PostTimeSeriesMetadataDTO;
+  let newTimeSeries: ExternalTimeSeries;
   let createdTimeSeries: TimeSeriesList;
-  let timeSeriesWithAssetId: PostTimeSeriesMetadataDTO;
-  let datapointArray: DatapointsPostDatapoint[] = [];
+  let timeSeriesWithAssetId: ExternalTimeSeries;
+  let datapointArray: ExternalDatapoints[] = [];
   beforeAll(() => {
     client = setupMockableClient();
     nock.cleanAll();
@@ -69,7 +66,7 @@ describe('TimeSeries class unit test', () => {
       });
     const assetFromTimeseries = await createdTimeSeries[1].getAsset();
     expect(assetFromTimeseries).not.toBe(null);
-    expect(assetFromTimeseries).toBeInstanceOf(Asset);
+    expect(assetFromTimeseries).toBeInstanceOf(AssetImpl);
   });
 
   test('delete', async () => {

--- a/packages/stable/src/__tests__/api/timeSeriesObject.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/timeSeriesObject.unit.spec.ts
@@ -3,14 +3,14 @@ import * as nock from 'nock';
 import { AssetImpl } from '../../api/classes/asset';
 import { TimeSeriesList } from '../../api/classes/timeSeriesList';
 import CogniteClient from '../../cogniteClient';
-import { ExternalDatapoints, ExternalTimeSeries } from '../../types';
+import { ExternalDatapoints, ExternalTimeseries } from '../../types';
 import { mockBaseUrl, randomInt, setupMockableClient } from '../testUtils';
 
 describe('TimeSeries class unit test', () => {
   let client: CogniteClient;
-  let newTimeSeries: ExternalTimeSeries;
+  let newTimeSeries: ExternalTimeseries;
   let createdTimeSeries: TimeSeriesList;
-  let timeSeriesWithAssetId: ExternalTimeSeries;
+  let timeSeriesWithAssetId: ExternalTimeseries;
   let datapointArray: ExternalDatapoints[] = [];
   beforeAll(() => {
     client = setupMockableClient();

--- a/packages/stable/src/__tests__/api/timeseries.int.spec.ts
+++ b/packages/stable/src/__tests__/api/timeseries.int.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { Asset, TimeSeries } from '../../types';
+import { Asset, Timeseries } from '../../types';
 import {
   randomInt,
   runTestWithRetryWhenFailing,
@@ -37,7 +37,7 @@ describe('Timeseries integration test', () => {
     },
   ];
 
-  let createdTimeseries: TimeSeries[];
+  let createdTimeseries: Timeseries[];
 
   test('create', async () => {
     createdTimeseries = await client.timeseries.create(timeseries);

--- a/packages/stable/src/__tests__/api/timeseries.int.spec.ts
+++ b/packages/stable/src/__tests__/api/timeseries.int.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 
 import CogniteClient from '../../cogniteClient';
-import { Asset, GetTimeSeriesMetadataDTO } from '../../types';
+import { Asset, TimeSeries } from '../../types';
 import {
   randomInt,
   runTestWithRetryWhenFailing,
@@ -37,7 +37,7 @@ describe('Timeseries integration test', () => {
     },
   ];
 
-  let createdTimeseries: GetTimeSeriesMetadataDTO[];
+  let createdTimeseries: TimeSeries[];
 
   test('create', async () => {
     createdTimeseries = await client.timeseries.create(timeseries);
@@ -86,7 +86,7 @@ describe('Timeseries integration test', () => {
   test('list from assetIds', async () => {
     await runTestWithRetryWhenFailing(async () => {
       const result = await client.timeseries
-        .list({ assetIds: [asset.id] })
+        .list({ filter: { assetIds: [asset.id] } })
         .autoPagingToArray({ limit: Infinity });
       expect(result.length).toBe(1);
       expect(result[0].id).toBe(createdTimeseries[0].id);
@@ -107,29 +107,26 @@ describe('Timeseries integration test', () => {
     const { isString, name, unit } = timeseries[1];
     const { items } = await client.timeseries.list({
       partition: '1/2',
-      isString,
-      name,
-      unit,
+      filter: {
+        isString,
+        name,
+        unit,
+      },
     });
     expect(items.length).toBeGreaterThan(0);
   });
 
   test('list', async () => {
-    await client.timeseries
-      .list({ includeMetadata: false })
-      .autoPagingToArray({ limit: 100 });
-  });
-
-  test('list partition', async () => {
-    const items = await client.timeseries
-      .list({ includeMetadata: false, partition: '1/10' })
-      .autoPagingToArray({ limit: 100 });
+    const { items } = await client.timeseries.list({
+      limit: 1,
+      partition: '1/10',
+    });
     expect(items.length).toBeGreaterThan(0);
   });
 
   test('list with assetExternalIds', async () => {
     const { items } = await client.timeseries.list({
-      assetExternalIds: [asset.externalId!],
+      filter: { assetExternalIds: [asset.externalId!] },
       limit: 1,
     });
     expect(items[0].id).toBe(createdTimeseries[0].id);
@@ -137,7 +134,7 @@ describe('Timeseries integration test', () => {
 
   test('list with assetSubtreeIds', async () => {
     const { items } = await client.timeseries.list({
-      assetSubtreeIds: [{ id: asset.id }],
+      filter: { assetSubtreeIds: [{ id: asset.id }] },
       limit: 1,
     });
     expect(items[0].id).toBe(createdTimeseries[0].id);

--- a/packages/stable/src/__tests__/testUtils.ts
+++ b/packages/stable/src/__tests__/testUtils.ts
@@ -3,7 +3,7 @@
 import { Constants } from '@cognite/sdk-core';
 import { TestUtils } from '@cognite/sdk-core';
 import CogniteClient from '../cogniteClient';
-import { ExternalFilesMetadata } from '../types';
+import { ExternalFileInfo } from '../types';
 
 export const {
   apiKey,
@@ -41,12 +41,12 @@ export function setupMockableClient() {
 }
 
 export const getFileCreateArgs = (
-  additionalFields: Partial<ExternalFilesMetadata> = {}
+  additionalFields: Partial<ExternalFileInfo> = {}
 ) => {
   const postfix = randomInt();
   const fileContent = 'content_' + new Date();
   const sourceCreatedTime = new Date();
-  const localFileMeta: ExternalFilesMetadata = {
+  const localFileMeta: ExternalFileInfo = {
     name: 'filename_0_' + postfix,
     mimeType: 'text/plain;charset=UTF-8',
     metadata: {

--- a/packages/stable/src/api/assets/assetsApi.ts
+++ b/packages/stable/src/api/assets/assetsApi.ts
@@ -10,7 +10,7 @@ import { RevertableArraySorter } from '@cognite/sdk-core';
 import { chunk } from 'lodash';
 import CogniteClient from '../../cogniteClient';
 import {
-  Asset as TypeAsset,
+  Asset,
   AssetAggregate,
   AssetAggregateQuery,
   AssetChange,
@@ -21,11 +21,11 @@ import {
   ExternalAssetItem,
   IdEither,
 } from '../../types';
-import { Asset } from '../classes/asset';
+import { AssetImpl } from '../classes/asset';
 import { AssetList } from '../classes/assetList';
 import { sortAssetCreateItems } from './assetUtils';
 
-export class AssetsAPI extends BaseResourceAPI<TypeAsset, Asset, AssetList> {
+export class AssetsAPI extends BaseResourceAPI<Asset, AssetImpl, AssetList> {
   /** @hidden */
   constructor(
     private client: CogniteClient,
@@ -63,7 +63,7 @@ export class AssetsAPI extends BaseResourceAPI<TypeAsset, Asset, AssetList> {
    */
   public list = (
     scope?: AssetListScope
-  ): CursorAndAsyncIterator<Asset, AssetList> => {
+  ): CursorAndAsyncIterator<AssetImpl, AssetList> => {
     return super.listEndpoint(this.callListEndpointWithPost, scope);
   };
 
@@ -146,11 +146,11 @@ export class AssetsAPI extends BaseResourceAPI<TypeAsset, Asset, AssetList> {
     return this.getAssetSubtree(rootAssetList, currentDepth, depth);
   };
 
-  protected transformToList(assets: TypeAsset[]) {
-    return assets.map(asset => new Asset(this.client, asset));
+  protected transformToList(assets: Asset[]) {
+    return assets.map(asset => new AssetImpl(this.client, asset));
   }
 
-  protected transformToClass(assets: TypeAsset[]) {
+  protected transformToClass(assets: Asset[]) {
     const assetArray = this.transformToList(assets);
     return new AssetList(this.client, assetArray);
   }
@@ -178,7 +178,7 @@ export class AssetsAPI extends BaseResourceAPI<TypeAsset, Asset, AssetList> {
   private getChildren = async (assets: AssetList) => {
     const ids = assets.map(asset => asset.id);
     const chunks = chunk(ids, 100);
-    const assetsArray: Asset[] = [];
+    const assetsArray: AssetImpl[] = [];
     for (const chunkOfAssetIds of chunks) {
       const childrenList = await this.client.assets
         .list({

--- a/packages/stable/src/api/classes/asset.ts
+++ b/packages/stable/src/api/classes/asset.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 
 import {
-  Asset as TypeAsset,
+  Asset,
   CogniteClient,
   EventFilter,
   FileFilter,
@@ -26,7 +26,7 @@ export interface SubtreeOptions {
 export interface DeleteOptions {
   recursive?: boolean;
 }
-export class Asset extends BaseResource<TypeAsset> implements TypeAsset {
+export class AssetImpl extends BaseResource<Asset> implements Asset {
   public id: CogniteInternalId;
   public externalId?: CogniteExternalId;
   public parentId?: CogniteInternalId;
@@ -42,7 +42,7 @@ export class Asset extends BaseResource<TypeAsset> implements TypeAsset {
   public dataSetId?: CogniteInternalId;
   public labels?: Label[];
 
-  constructor(client: CogniteClient, props: TypeAsset) {
+  constructor(client: CogniteClient, props: Asset) {
     super(client);
     this.id = props.id;
     this.externalId = props.externalId;
@@ -147,8 +147,10 @@ export class Asset extends BaseResource<TypeAsset> implements TypeAsset {
   public async timeSeries(filter: TimeseriesFilter = {}) {
     return this.client.timeseries
       .list({
-        ...filter,
-        assetIds: [this.id],
+        filter: {
+          ...filter,
+          assetIds: [this.id],
+        },
       })
       .autoPagingToArray({ limit: Infinity });
   }

--- a/packages/stable/src/api/classes/assetList.ts
+++ b/packages/stable/src/api/classes/assetList.ts
@@ -6,7 +6,7 @@ import {
   CogniteEvent,
   CogniteInternalId,
   FileInfo,
-  TimeSeries,
+  Timeseries,
 } from '../../types';
 import { EventsAPI } from '../events/eventsApi';
 import { FilesAPI } from '../files/filesApi';
@@ -37,7 +37,7 @@ export class AssetList extends Array<AssetImpl> {
   public timeSeries = async () => {
     return (await this.getResourcesFromAssets(
       this.client.timeseries
-    )) as TimeSeries[];
+    )) as Timeseries[];
   };
 
   /**
@@ -65,7 +65,7 @@ export class AssetList extends Array<AssetImpl> {
   private getResourcesFromAssets = async (
     accessedApi: TimeSeriesAPI | FilesAPI | EventsAPI
   ) => {
-    type Type = TimeSeries | FileInfo | CogniteEvent;
+    type Type = Timeseries | FileInfo | CogniteEvent;
     const chunks = this.toChunkedArrayOfIds();
     const promises: Promise<Type[]>[] = [];
     for (const idArray of chunks) {

--- a/packages/stable/src/api/classes/assetList.ts
+++ b/packages/stable/src/api/classes/assetList.ts
@@ -5,19 +5,17 @@ import CogniteClient from '../../cogniteClient';
 import {
   CogniteEvent,
   CogniteInternalId,
-  FilesMetadata,
-  GetTimeSeriesMetadataDTO,
+  FileInfo,
+  TimeSeries,
 } from '../../types';
 import { EventsAPI } from '../events/eventsApi';
 import { FilesAPI } from '../files/filesApi';
 import { TimeSeriesAPI } from '../timeSeries/timeSeriesApi';
-import { Asset } from './asset';
+import { AssetImpl } from './asset';
 
-export class AssetList extends Array<Asset> {
-  private client: CogniteClient;
-  constructor(client: CogniteClient, items: Asset[]) {
+export class AssetList extends Array<AssetImpl> {
+  constructor(private client: CogniteClient, items: AssetImpl[]) {
     super(...items);
-    this.client = client;
   }
 
   /**
@@ -39,7 +37,7 @@ export class AssetList extends Array<Asset> {
   public timeSeries = async () => {
     return (await this.getResourcesFromAssets(
       this.client.timeseries
-    )) as GetTimeSeriesMetadataDTO[];
+    )) as TimeSeries[];
   };
 
   /**
@@ -49,9 +47,7 @@ export class AssetList extends Array<Asset> {
    * ```
    */
   public files = async () => {
-    return (await this.getResourcesFromAssets(
-      this.client.files
-    )) as FilesMetadata[];
+    return (await this.getResourcesFromAssets(this.client.files)) as FileInfo[];
   };
 
   /**
@@ -69,22 +65,16 @@ export class AssetList extends Array<Asset> {
   private getResourcesFromAssets = async (
     accessedApi: TimeSeriesAPI | FilesAPI | EventsAPI
   ) => {
-    type Type = GetTimeSeriesMetadataDTO | FilesMetadata | CogniteEvent;
+    type Type = TimeSeries | FileInfo | CogniteEvent;
     const chunks = this.toChunkedArrayOfIds();
     const promises: Promise<Type[]>[] = [];
     for (const idArray of chunks) {
       const assetIds = { assetIds: idArray };
-      if (accessedApi instanceof TimeSeriesAPI) {
-        promises.push(
-          accessedApi.list(assetIds).autoPagingToArray({ limit: Infinity })
-        );
-      } else {
-        promises.push(
-          accessedApi
-            .list({ filter: assetIds })
-            .autoPagingToArray({ limit: Infinity })
-        );
-      }
+      promises.push(
+        accessedApi
+          .list({ filter: assetIds })
+          .autoPagingToArray({ limit: Infinity })
+      );
     }
     const results = await Promise.all(promises);
     const responses: Type[] = [];

--- a/packages/stable/src/api/classes/baseResource.ts
+++ b/packages/stable/src/api/classes/baseResource.ts
@@ -4,9 +4,7 @@ import CogniteClient from '../../cogniteClient';
 
 /** @hidden */
 export abstract class BaseResource<T> {
-  protected client: CogniteClient;
-
-  constructor(client: CogniteClient) {
+  constructor(protected client: CogniteClient) {
     this.client = client;
     Object.defineProperty(this, 'client', {
       value: this.client,

--- a/packages/stable/src/api/classes/timeSeries.ts
+++ b/packages/stable/src/api/classes/timeSeries.ts
@@ -4,14 +4,14 @@ import {
   CogniteExternalId,
   CogniteInternalId,
   DatapointsMultiQuery,
-  GetTimeSeriesMetadataDTO,
+  TimeSeries,
   LatestDataPropertyFilter,
   Metadata,
 } from '../../types';
 import { BaseResource } from './baseResource';
 
-export class TimeSeries extends BaseResource<GetTimeSeriesMetadataDTO>
-  implements GetTimeSeriesMetadataDTO {
+export class TimeSeriesImpl extends BaseResource<TimeSeries>
+  implements TimeSeries {
   public externalId?: CogniteExternalId;
   public name?: string;
   public isString: boolean;
@@ -26,7 +26,7 @@ export class TimeSeries extends BaseResource<GetTimeSeriesMetadataDTO>
   public lastUpdatedTime: Date;
   public id: CogniteInternalId;
 
-  constructor(client: CogniteClient, props: GetTimeSeriesMetadataDTO) {
+  constructor(client: CogniteClient, props: TimeSeries) {
     super(client);
     this.externalId = props.externalId;
     this.name = props.name;

--- a/packages/stable/src/api/classes/timeSeries.ts
+++ b/packages/stable/src/api/classes/timeSeries.ts
@@ -4,14 +4,14 @@ import {
   CogniteExternalId,
   CogniteInternalId,
   DatapointsMultiQuery,
-  TimeSeries,
+  Timeseries,
   LatestDataPropertyFilter,
   Metadata,
 } from '../../types';
 import { BaseResource } from './baseResource';
 
-export class TimeSeriesImpl extends BaseResource<TimeSeries>
-  implements TimeSeries {
+export class TimeseriesImpl extends BaseResource<Timeseries>
+  implements Timeseries {
   public externalId?: CogniteExternalId;
   public name?: string;
   public isString: boolean;
@@ -26,7 +26,7 @@ export class TimeSeriesImpl extends BaseResource<TimeSeries>
   public lastUpdatedTime: Date;
   public id: CogniteInternalId;
 
-  constructor(client: CogniteClient, props: TimeSeries) {
+  constructor(client: CogniteClient, props: Timeseries) {
     super(client);
     this.externalId = props.externalId;
     this.name = props.name;

--- a/packages/stable/src/api/classes/timeSeriesList.ts
+++ b/packages/stable/src/api/classes/timeSeriesList.ts
@@ -2,10 +2,10 @@
 import { uniqBy } from 'lodash';
 import CogniteClient from '../../cogniteClient';
 import { DatapointsMultiQueryBase } from '../../types';
-import { TimeSeriesImpl } from './timeSeries';
+import { TimeseriesImpl } from './timeSeries';
 
-export class TimeSeriesList extends Array<TimeSeriesImpl> {
-  constructor(private client: CogniteClient, items: TimeSeriesImpl[]) {
+export class TimeSeriesList extends Array<TimeseriesImpl> {
+  constructor(private client: CogniteClient, items: TimeseriesImpl[]) {
     super(...items);
   }
 

--- a/packages/stable/src/api/classes/timeSeriesList.ts
+++ b/packages/stable/src/api/classes/timeSeriesList.ts
@@ -2,13 +2,11 @@
 import { uniqBy } from 'lodash';
 import CogniteClient from '../../cogniteClient';
 import { DatapointsMultiQueryBase } from '../../types';
-import { TimeSeries } from './timeSeries';
+import { TimeSeriesImpl } from './timeSeries';
 
-export class TimeSeriesList extends Array<TimeSeries> {
-  private client: CogniteClient;
-  constructor(client: CogniteClient, items: TimeSeries[]) {
+export class TimeSeriesList extends Array<TimeSeriesImpl> {
+  constructor(private client: CogniteClient, items: TimeSeriesImpl[]) {
     super(...items);
-    this.client = client;
   }
 
   /**

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -3,13 +3,13 @@
 import { BaseResourceAPI } from '@cognite/sdk-core';
 import {
   DatapointsDeleteRequest,
-  DatapointsGetAggregateDatapoint,
-  DatapointsGetDatapoint,
+  DatapointAggregates,
+  Datapoints,
   DatapointsMultiQuery,
-  DatapointsPostDatapoint,
   IgnoreUnknownIds,
   ItemsWrapper,
   LatestDataBeforeRequest,
+  ExternalDatapointsQuery,
 } from '../../types';
 
 export class DataPointsAPI extends BaseResourceAPI<any> {
@@ -20,7 +20,7 @@ export class DataPointsAPI extends BaseResourceAPI<any> {
    * await client.datapoints.insert([{ id: 123, datapoints: [{timestamp: 1557320284000, value: -2}] }]);
    * ```
    */
-  public insert = (items: DatapointsPostDatapoint[]): Promise<{}> => {
+  public insert = (items: ExternalDatapointsQuery[]): Promise<{}> => {
     return this.insertEndpoint(items);
   };
 
@@ -33,7 +33,7 @@ export class DataPointsAPI extends BaseResourceAPI<any> {
    */
   public retrieve = (
     query: DatapointsMultiQuery
-  ): Promise<DatapointsGetAggregateDatapoint[] | DatapointsGetDatapoint[]> => {
+  ): Promise<DatapointAggregates[] | Datapoints[]> => {
     return this.retrieveDatapointsEndpoint(query);
   };
 
@@ -56,7 +56,7 @@ export class DataPointsAPI extends BaseResourceAPI<any> {
   public retrieveLatest = (
     items: LatestDataBeforeRequest[],
     params: LatestDataParams = {}
-  ): Promise<DatapointsGetDatapoint[]> => {
+  ): Promise<Datapoints[]> => {
     return this.retrieveLatestEndpoint(items, params);
   };
 
@@ -71,7 +71,7 @@ export class DataPointsAPI extends BaseResourceAPI<any> {
     return this.deleteDatapointsEndpoint(items);
   };
 
-  private async insertEndpoint(items: DatapointsPostDatapoint[]) {
+  private async insertEndpoint(items: ExternalDatapointsQuery[]) {
     const path = this.url();
     await this.postInParallelWithAutomaticChunking({ path, items });
     return {};
@@ -80,7 +80,7 @@ export class DataPointsAPI extends BaseResourceAPI<any> {
   private async retrieveDatapointsEndpoint(query: DatapointsMultiQuery) {
     const path = this.listPostUrl;
     const response = await this.httpClient.post<
-      ItemsWrapper<(DatapointsGetAggregateDatapoint | DatapointsGetDatapoint)[]>
+      ItemsWrapper<(DatapointAggregates | Datapoints)[]>
     >(path, {
       data: query,
     });
@@ -92,11 +92,12 @@ export class DataPointsAPI extends BaseResourceAPI<any> {
     params: LatestDataParams
   ) {
     const path = this.url('latest');
-    const response = await this.httpClient.post<
-      ItemsWrapper<DatapointsGetDatapoint[]>
-    >(path, {
-      data: { items, ...params },
-    });
+    const response = await this.httpClient.post<ItemsWrapper<Datapoints[]>>(
+      path,
+      {
+        data: { items, ...params },
+      }
+    );
     return this.addToMapAndReturn(response.data.items, response);
   }
 

--- a/packages/stable/src/api/timeSeries/timeSeriesApi.ts
+++ b/packages/stable/src/api/timeSeries/timeSeriesApi.ts
@@ -8,25 +8,24 @@ import {
 } from '@cognite/sdk-core';
 import CogniteClient from '../../cogniteClient';
 import {
-  GetTimeSeriesMetadataDTO,
+  TimeSeries,
   IdEither,
   IgnoreUnknownIds,
-  PostTimeSeriesMetadataDTO,
+  ExternalTimeSeries,
   SyntheticQuery,
   TimeseriesAggregate,
   TimeseriesAggregateQuery,
-  TimeseriesFilter,
   TimeseriesFilterQuery,
-  TimeSeriesSearchDTO,
+  TimeSeriesSearchFilter,
   TimeSeriesUpdate,
 } from '../../types';
-import { TimeSeries } from '../classes/timeSeries';
+import { TimeSeriesImpl } from '../classes/timeSeries';
 import { TimeSeriesList } from '../classes/timeSeriesList';
 import { SyntheticTimeSeriesAPI } from './syntheticTimeSeriesApi';
 
 export class TimeSeriesAPI extends BaseResourceAPI<
-  GetTimeSeriesMetadataDTO,
   TimeSeries,
+  TimeSeriesImpl,
   TimeSeriesList
 > {
   private syntheticTimeseriesApi: SyntheticTimeSeriesAPI;
@@ -57,9 +56,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    * const createdTimeseries = await client.timeseries.create(timeseries);
    * ```
    */
-  public create = (
-    items: PostTimeSeriesMetadataDTO[]
-  ): Promise<TimeSeriesList> => {
+  public create = (items: ExternalTimeSeries[]): Promise<TimeSeriesList> => {
     return super.createEndpoint(items);
   };
 
@@ -67,18 +64,13 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    * [List time series](https://doc.cognitedata.com/api/v1/#operation/getTimeSeries)
    *
    * ```js
-   * const timeseries = await client.timeseries.list({ includeMetadata: false, assetIds: [1, 2] });
+   * const timeseries = await client.timeseries.list({ filter: { assetIds: [1, 2] }});
    * ```
    */
   public list = (
-    scope?: TimeseriesFilter
-  ): CursorAndAsyncIterator<TimeSeries> => {
-    let query: TimeseriesFilterQuery = {};
-    if (scope) {
-      const { includeMetadata, limit, cursor, partition, ...filter } = scope;
-      query = { filter, limit, partition, cursor };
-    }
-    return super.listEndpoint(this.callListEndpointWithPost, query);
+    scope?: TimeseriesFilterQuery
+  ): CursorAndAsyncIterator<TimeSeriesImpl> => {
+    return super.listEndpoint(this.callListEndpointWithPost, scope);
   };
 
   /**
@@ -142,7 +134,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    * });
    * ```
    */
-  public search = (query: TimeSeriesSearchDTO) => {
+  public search = (query: TimeSeriesSearchFilter) => {
     return super.searchEndpoint(query);
   };
 
@@ -178,11 +170,13 @@ export class TimeSeriesAPI extends BaseResourceAPI<
     return this.syntheticTimeseriesApi.query(items);
   };
 
-  protected transformToList(timeSeries: GetTimeSeriesMetadataDTO[]) {
-    return timeSeries.map(timeSerie => new TimeSeries(this.client, timeSerie));
+  protected transformToList(timeSeries: TimeSeries[]) {
+    return timeSeries.map(
+      timeSerie => new TimeSeriesImpl(this.client, timeSerie)
+    );
   }
 
-  protected transformToClass(timeSeries: GetTimeSeriesMetadataDTO[]) {
+  protected transformToClass(timeSeries: TimeSeries[]) {
     const timeseriesArray = this.transformToList(timeSeries);
     return new TimeSeriesList(this.client, timeseriesArray);
   }

--- a/packages/stable/src/api/timeSeries/timeSeriesApi.ts
+++ b/packages/stable/src/api/timeSeries/timeSeriesApi.ts
@@ -8,24 +8,24 @@ import {
 } from '@cognite/sdk-core';
 import CogniteClient from '../../cogniteClient';
 import {
-  TimeSeries,
+  Timeseries,
   IdEither,
   IgnoreUnknownIds,
-  ExternalTimeSeries,
+  ExternalTimeseries,
   SyntheticQuery,
   TimeseriesAggregate,
   TimeseriesAggregateQuery,
   TimeseriesFilterQuery,
-  TimeSeriesSearchFilter,
+  TimeseriesSearchFilter,
   TimeSeriesUpdate,
 } from '../../types';
-import { TimeSeriesImpl } from '../classes/timeSeries';
+import { TimeseriesImpl } from '../classes/timeSeries';
 import { TimeSeriesList } from '../classes/timeSeriesList';
 import { SyntheticTimeSeriesAPI } from './syntheticTimeSeriesApi';
 
 export class TimeSeriesAPI extends BaseResourceAPI<
-  TimeSeries,
-  TimeSeriesImpl,
+  Timeseries,
+  TimeseriesImpl,
   TimeSeriesList
 > {
   private syntheticTimeseriesApi: SyntheticTimeSeriesAPI;
@@ -56,7 +56,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    * const createdTimeseries = await client.timeseries.create(timeseries);
    * ```
    */
-  public create = (items: ExternalTimeSeries[]): Promise<TimeSeriesList> => {
+  public create = (items: ExternalTimeseries[]): Promise<TimeSeriesList> => {
     return super.createEndpoint(items);
   };
 
@@ -69,7 +69,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    */
   public list = (
     scope?: TimeseriesFilterQuery
-  ): CursorAndAsyncIterator<TimeSeriesImpl> => {
+  ): CursorAndAsyncIterator<TimeseriesImpl> => {
     return super.listEndpoint(this.callListEndpointWithPost, scope);
   };
 
@@ -134,7 +134,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<
    * });
    * ```
    */
-  public search = (query: TimeSeriesSearchFilter) => {
+  public search = (query: TimeseriesSearchFilter) => {
     return super.searchEndpoint(query);
   };
 
@@ -170,13 +170,13 @@ export class TimeSeriesAPI extends BaseResourceAPI<
     return this.syntheticTimeseriesApi.query(items);
   };
 
-  protected transformToList(timeSeries: TimeSeries[]) {
+  protected transformToList(timeSeries: Timeseries[]) {
     return timeSeries.map(
-      timeSerie => new TimeSeriesImpl(this.client, timeSerie)
+      timeSerie => new TimeseriesImpl(this.client, timeSerie)
     );
   }
 
-  protected transformToClass(timeSeries: TimeSeries[]) {
+  protected transformToClass(timeSeries: Timeseries[]) {
     const timeseriesArray = this.transformToList(timeSeries);
     return new TimeSeriesList(this.client, timeseriesArray);
   }

--- a/packages/stable/src/index.ts
+++ b/packages/stable/src/index.ts
@@ -20,6 +20,6 @@ export {
 export { default as CogniteClient } from './cogniteClient';
 export * from './types';
 export { AssetImpl } from './api/classes/asset';
-export { TimeSeriesImpl } from './api/classes/timeSeries';
+export { TimeseriesImpl } from './api/classes/timeSeries';
 export { AssetList } from './api/classes/assetList';
 export { TimeSeriesList } from './api/classes/timeSeriesList';

--- a/packages/stable/src/index.ts
+++ b/packages/stable/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from '@cognite/sdk-core';
 export { default as CogniteClient } from './cogniteClient';
 export * from './types';
-export { Asset as AssetClass } from './api/classes/asset';
-export { TimeSeries as TimeSeriesClass } from './api/classes/timeSeries';
+export { AssetImpl } from './api/classes/asset';
+export { TimeSeriesImpl } from './api/classes/timeSeries';
 export { AssetList } from './api/classes/assetList';
 export { TimeSeriesList } from './api/classes/timeSeriesList';

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -1107,7 +1107,7 @@ export interface StringDatapoint extends DatapointMetadata {
   value: string;
 }
 
-export interface TimeSeries extends InternalId, CreatedAndLastUpdatedTime {
+export interface Timeseries extends InternalId, CreatedAndLastUpdatedTime {
   /**
    * Externally supplied id of the time series
    */
@@ -1135,7 +1135,7 @@ export interface TimeSeries extends InternalId, CreatedAndLastUpdatedTime {
   securityCategories?: number[];
 }
 
-export interface ExternalTimeSeries {
+export interface ExternalTimeseries {
   /**
    * Externally provided id for the time series (optional but recommended)
    */
@@ -1990,7 +1990,7 @@ export interface TimeSeriesPatch {
   };
 }
 
-export interface TimeSeriesSearch {
+export interface TimeseriesSearch {
   /**
    * Prefix and fuzzy search on name.
    */
@@ -2005,9 +2005,9 @@ export interface TimeSeriesSearch {
   query?: string;
 }
 
-export interface TimeSeriesSearchFilter extends Limit {
+export interface TimeseriesSearchFilter extends Limit {
   filter?: TimeseriesFilter;
-  search?: TimeSeriesSearch;
+  search?: TimeseriesSearch;
 }
 
 export type TimeSeriesUpdate =

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -1082,7 +1082,7 @@ export interface FilesSearchFilter extends FileFilter {
   };
 }
 
-export interface DatapointAggregate extends DatapointMetadata {
+export interface DatapointAggregate extends DatapointInfo {
   average?: number;
   max?: number;
   min?: number;
@@ -1095,15 +1095,15 @@ export interface DatapointAggregate extends DatapointMetadata {
   totalVariation?: number;
 }
 
-export interface DatapointMetadata {
+export interface DatapointInfo {
   timestamp: Date;
 }
 
-export interface DoubleDatapoint extends DatapointMetadata {
+export interface DoubleDatapoint extends DatapointInfo {
   value: number;
 }
 
-export interface StringDatapoint extends DatapointMetadata {
+export interface StringDatapoint extends DatapointInfo {
   value: string;
 }
 
@@ -1950,13 +1950,13 @@ export const SortOrder = {
  */
 export type SortOrder = 'asc' | 'desc';
 
-export interface SyntheticDataError extends DatapointMetadata {
+export interface SyntheticDataError extends DatapointInfo {
   error: string;
 }
 
 export type SyntheticDatapoint = SyntheticDataValue | SyntheticDataError;
 
-export interface SyntheticDataValue extends DatapointMetadata {
+export interface SyntheticDataValue extends DatapointInfo {
   value: number;
 }
 

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -291,7 +291,7 @@ export interface TimeseriesAggregateQuery {
   /**
    * Filter on timeseries with strict matching.
    */
-  filter?: TimeseriesFilterProps;
+  filter?: TimeseriesFilter;
 }
 
 export interface AssetAggregateResult {
@@ -450,7 +450,7 @@ export type AssetSource = string;
 /**
  * Data specific to Azure AD authentication
  */
-export interface AzureADConfigurationDTO {
+export interface AzureADConfiguration {
   /**
    * Azure application ID. You get this when creating the Azure app.
    */
@@ -671,15 +671,13 @@ export type DatapointsDeleteRequest =
   | (InternalId & DatapointsDeleteRange)
   | (ExternalId & DatapointsDeleteRange);
 
-export interface DatapointsGetAggregateDatapoint extends DatapointsMetadata {
-  datapoints: GetAggregateDatapoint[];
+export interface DatapointAggregates extends DatapointsMetadata {
+  datapoints: DatapointAggregate[];
 }
 
-export type DatapointsGetDatapoint =
-  | DatapointsGetStringDatapoint
-  | DatapointsGetDoubleDatapoint;
+export type Datapoints = StringDatapoints | DoubleDatapoints;
 
-export interface DatapointsGetDoubleDatapoint extends DatapointsMetadata {
+export interface DoubleDatapoints extends DatapointsMetadata {
   /**
    * Whether the time series is string valued or not.
    */
@@ -687,10 +685,10 @@ export interface DatapointsGetDoubleDatapoint extends DatapointsMetadata {
   /**
    * The list of datapoints
    */
-  datapoints: GetDoubleDatapoint[];
+  datapoints: DoubleDatapoint[];
 }
 
-export interface DatapointsGetStringDatapoint extends DatapointsMetadata {
+export interface StringDatapoints extends DatapointsMetadata {
   /**
    * Whether the time series is string valued or not.
    */
@@ -698,11 +696,11 @@ export interface DatapointsGetStringDatapoint extends DatapointsMetadata {
   /**
    * The list of datapoints
    */
-  datapoints: GetStringDatapoint[];
+  datapoints: StringDatapoint[];
 }
 
-export interface DatapointsInsertProperties {
-  datapoints: PostDatapoint[];
+export interface ExternalDatapoints {
+  datapoints: ExternalDatapoint[];
 }
 
 export interface DatapointsMetadata extends InternalId {
@@ -739,17 +737,15 @@ export interface DatapointsMultiQueryBase extends Limit, IgnoreUnknownIds {
   includeOutsidePoints?: boolean;
 }
 
-export type DatapointsPostDatapoint =
-  | DatapointsPostDatapointId
-  | DatapointsPostDatapointExternalId;
+export type ExternalDatapointsQuery =
+  | ExternalDatapointId
+  | ExternalDatapointExternalId;
 
-export interface DatapointsPostDatapointExternalId
-  extends DatapointsInsertProperties,
+export interface ExternalDatapointExternalId
+  extends ExternalDatapoints,
     ExternalId {}
 
-export interface DatapointsPostDatapointId
-  extends DatapointsInsertProperties,
-    InternalId {}
+export interface ExternalDatapointId extends ExternalDatapoints, InternalId {}
 
 export type DatapointsQuery = DatapointsQueryId | DatapointsQueryExternalId;
 
@@ -957,7 +953,7 @@ export interface ExternalEvent {
   source?: string;
 }
 
-export interface ExternalFilesMetadata {
+export interface ExternalFileInfo {
   externalId?: CogniteExternalId;
   name: FileName;
   source?: string;
@@ -1071,9 +1067,7 @@ export type FileName = string;
 
 export interface FileRequestFilter extends FilterQuery, FileFilter {}
 
-export interface FilesMetadata
-  extends ExternalFilesMetadata,
-    CreatedAndLastUpdatedTime {
+export interface FileInfo extends ExternalFileInfo, CreatedAndLastUpdatedTime {
   id: CogniteInternalId;
   /**
    * Whether or not the actual file is uploaded
@@ -1088,9 +1082,7 @@ export interface FilesSearchFilter extends FileFilter {
   };
 }
 
-export type Filter = TimeseriesFilterProps;
-
-export interface GetAggregateDatapoint extends GetDatapointMetadata {
+export interface DatapointAggregate extends DatapointMetadata {
   average?: number;
   max?: number;
   min?: number;
@@ -1103,21 +1095,19 @@ export interface GetAggregateDatapoint extends GetDatapointMetadata {
   totalVariation?: number;
 }
 
-export interface GetDatapointMetadata {
+export interface DatapointMetadata {
   timestamp: Date;
 }
 
-export interface GetDoubleDatapoint extends GetDatapointMetadata {
+export interface DoubleDatapoint extends DatapointMetadata {
   value: number;
 }
 
-export interface GetStringDatapoint extends GetDatapointMetadata {
+export interface StringDatapoint extends DatapointMetadata {
   value: string;
 }
 
-export interface GetTimeSeriesMetadataDTO
-  extends InternalId,
-    CreatedAndLastUpdatedTime {
+export interface TimeSeries extends InternalId, CreatedAndLastUpdatedTime {
   /**
    * Externally supplied id of the time series
    */
@@ -1141,6 +1131,53 @@ export interface GetTimeSeriesMetadataDTO
   description: string;
   /**
    * Security categories required in order to access this time series.
+   */
+  securityCategories?: number[];
+}
+
+export interface ExternalTimeSeries {
+  /**
+   * Externally provided id for the time series (optional but recommended)
+   */
+  externalId?: CogniteExternalId;
+  /**
+   * Set a value for legacyName to allow applications using API v0.3, v04, v05, and v0.6 to access this time series. The legacy name is the human-readable name for the time series and is mapped to the name field used in API versions 0.3-0.6. The legacyName field value must be unique, and setting this value to an already existing value will return an error. We recommend that you set this field to the same value as externalId.
+   */
+  legacyName?: string;
+  /**
+   * Human readable name of time series
+   */
+  name?: string;
+  /**
+   * Whether the time series is string valued or not.
+   */
+  isString?: boolean;
+  /**
+   * Additional metadata. String key -> String value.
+   */
+  metadata?: Metadata;
+  /**
+   * The physical unit of the time series.
+   */
+  unit?: string;
+  /**
+   * Asset that this time series belongs to.
+   */
+  assetId?: CogniteInternalId;
+  /**
+   * DataSet that this time series related with.
+   */
+  dataSetId?: CogniteInternalId;
+  /**
+   * Whether the time series is a step series or not.
+   */
+  isStep?: boolean;
+  /**
+   * Description of the time series.
+   */
+  description?: string;
+  /**
+   * Security categories required in order to access this time series."
    */
   securityCategories?: number[];
 }
@@ -1207,9 +1244,9 @@ export interface IgnoreUnknownIds {
  * Data about how to authenticate and authorize users
  */
 export interface InputProjectAuthentication {
-  azureADConfiguration?: AzureADConfigurationDTO;
-  oAuth2Configuration?: OAuth2ConfigurationDTO;
+  azureADConfiguration?: AzureADConfiguration;
   validDomains?: ValidDomains;
+  oAuth2Configuration?: OAuth2Configuration;
   applicationDomains?: ApplicationDomains;
 }
 
@@ -1381,7 +1418,7 @@ export type NullableSinglePatchString = { set: string } | { setNull: true };
 /**
  * Data related to generic OAuth2 authentication. Not used for Azure AD
  */
-export interface OAuth2ConfigurationDTO {
+export interface OAuth2Configuration {
   /**
    * Login URL of OAuth2 provider. E.g https://accounts.google.com/o/oauth2/v2/auth.
    */
@@ -1442,56 +1479,9 @@ export interface OutputProjectAuthentication {
  */
 export type Partition = string;
 
-export interface PostDatapoint {
+export interface ExternalDatapoint {
   timestamp: Timestamp;
   value: number | string;
-}
-
-export interface PostTimeSeriesMetadataDTO {
-  /**
-   * Externally provided id for the time series (optional but recommended)
-   */
-  externalId?: CogniteExternalId;
-  /**
-   * Set a value for legacyName to allow applications using API v0.3, v04, v05, and v0.6 to access this time series. The legacy name is the human-readable name for the time series and is mapped to the name field used in API versions 0.3-0.6. The legacyName field value must be unique, and setting this value to an already existing value will return an error. We recommend that you set this field to the same value as externalId.
-   */
-  legacyName?: string;
-  /**
-   * Human readable name of time series
-   */
-  name?: string;
-  /**
-   * Whether the time series is string valued or not.
-   */
-  isString?: boolean;
-  /**
-   * Additional metadata. String key -> String value.
-   */
-  metadata?: Metadata;
-  /**
-   * The physical unit of the time series.
-   */
-  unit?: string;
-  /**
-   * Asset that this time series belongs to.
-   */
-  assetId?: CogniteInternalId;
-  /**
-   * DataSet that this time series related with.
-   */
-  dataSetId?: CogniteInternalId;
-  /**
-   * Whether the time series is a step series or not.
-   */
-  isStep?: boolean;
-  /**
-   * Description of the time series.
-   */
-  description?: string;
-  /**
-   * Security categories required in order to access this time series."
-   */
-  securityCategories?: number[];
 }
 
 /**
@@ -1664,21 +1654,6 @@ export interface RevisionCameraProperties {
    * Initial camera position.
    */
   position?: Tuple3<number>;
-}
-
-export interface Search {
-  /**
-   * Prefix and fuzzy search on name.
-   */
-  name?: string;
-  /**
-   * Prefix and fuzzy search on description.
-   */
-  description?: string;
-  /**
-   * Search on name and description using wildcard search on each of the words (separated by spaces). Retrieves results where at least one word must match. Example: '*some* *other*'
-   */
-  query?: string;
 }
 
 export interface SecurityCategory {
@@ -1975,13 +1950,13 @@ export const SortOrder = {
  */
 export type SortOrder = 'asc' | 'desc';
 
-export interface SyntheticDataError extends GetDatapointMetadata {
+export interface SyntheticDataError extends DatapointMetadata {
   error: string;
 }
 
 export type SyntheticDatapoint = SyntheticDataValue | SyntheticDataError;
 
-export interface SyntheticDataValue extends GetDatapointMetadata {
+export interface SyntheticDataValue extends DatapointMetadata {
   value: number;
 }
 
@@ -2015,9 +1990,24 @@ export interface TimeSeriesPatch {
   };
 }
 
-export interface TimeSeriesSearchDTO extends Limit {
-  filter?: Filter;
-  search?: Search;
+export interface TimeSeriesSearch {
+  /**
+   * Prefix and fuzzy search on name.
+   */
+  name?: string;
+  /**
+   * Prefix and fuzzy search on description.
+   */
+  description?: string;
+  /**
+   * Search on name and description using wildcard search on each of the words (separated by spaces). Retrieves results where at least one word must match. Example: '*some* *other*'
+   */
+  query?: string;
+}
+
+export interface TimeSeriesSearchFilter extends Limit {
+  filter?: TimeseriesFilter;
+  search?: TimeSeriesSearch;
 }
 
 export type TimeSeriesUpdate =
@@ -2030,16 +2020,7 @@ export interface TimeSeriesUpdateByExternalId
 
 export interface TimeSeriesUpdateById extends TimeSeriesPatch, InternalId {}
 
-export interface TimeseriesFilter extends TimeseriesFilterProps, FilterQuery {
-  /**
-   * Decide if the metadata field should be returned or not.
-   * This property is ignored by SDK, you can call the endpoint manually if you want to leverage it.
-   */
-  includeMetadata?: boolean;
-  partition?: Partition;
-}
-
-interface TimeseriesFilterProps extends CreatedAndLastUpdatedTimeFilter {
+export interface TimeseriesFilter extends CreatedAndLastUpdatedTimeFilter {
   name?: TimeseriesName;
   unit?: TimeseriesUnit;
   isString?: TimeseriesIsString;
@@ -2070,7 +2051,7 @@ interface TimeseriesFilterProps extends CreatedAndLastUpdatedTimeFilter {
 }
 
 export interface TimeseriesFilterQuery extends FilterQuery {
-  filter?: TimeseriesFilterProps;
+  filter?: TimeseriesFilter;
   partition?: Partition;
 }
 
@@ -2137,7 +2118,7 @@ export interface UpdateRevision3D {
   };
 }
 
-export interface UploadFileMetadataResponse extends FilesMetadata {
+export interface FileUploadResponse extends FileInfo {
   uploadUrl: string;
 }
 


### PR DESCRIPTION
BREAKING CHANGE:

Interfaces renamed:
- AzureADConfigurationDTO -> AzureADConfiguration
- DatapointsGetAggregateDatapoint -> DatapointsAggregates
- DatapointsGetDatapoint -> Datapoints
- DatapointsGetDoubleDatapoint -> DoubleDatapoints
- DatapointsGetStringDatapoint -> StringDatapoints
- DatapointsInsertProperties -> ExternalDatapoints
- DatapointsPostDatapoint -> ExternalDatapointsQuery
- ExternalFilesMetadata -> ExternalFileInfo
- FilesMetadata -> FileInfo
- GetAggregateDatapoint -> DatapointAggregate
- GetDatapointMetadata -> DatapointMetadata
- GetDoubleDatapoint -> DoubleDatapoint
- GetStringDatapoint -> StringDatapoint
- GetTimeSeriesMetadataDTO -> TimeSeries
- OAuth2ConfigurationDTO -> OAuth2Configuration
- PostDatapoint -> ExternalDatapoint
- TimeSeriesSearchDTO -> TimeSeriesSearchFilter
- TimeseriesFilter -> TimeseriesFilterQuery (structure changed)
- TimeseriesFilterProps -> TimeseriesFilter
- UploadFileMetadataResponse -> FileUploadResponse

Removed interfaces:
- Filter (use TimeseriesFilter)
- Search (use TimeseriesSearch)

Changed:
- `timeseries.list()` signature is now consistent with other resource types