### PR TITLE
refactor: fix non-logical coupling

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -578,7 +578,12 @@ export interface LabelsPatch {
   remove?: Label[];
 }
 
-export interface ExternalLabelDefinition extends Label {
+export interface ExternalLabelDefinition {
+  /**
+   * The label's external id.
+   */
+  externalId: string;
+  
   /**
    * Name of the label.
    */


### PR DESCRIPTION
A Label and LabelDefinition is not connected so let's not extend from label in the definition