### PR TITLE
test: use beforeAll block for setup in assets.int.spec.ts

### DIFF
--- a/packages/stable/src/__tests__/api/assets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/assets.int.spec.ts
@@ -281,14 +281,16 @@ describe('Asset integration test', () => {
   });
 
   test('filter on parent external ids', async () => {
-    const { items } = await client.assets.list({
-      limit: 1,
-      filter: {
-        parentExternalIds: [createdRoot1.externalId!],
-      },
+    await runTestWithRetryWhenFailing(async () => {
+      const { items } = await client.assets.list({
+        limit: 1,
+        filter: {
+          parentExternalIds: [createdRoot1.externalId!],
+        },
+      });
+      expect(items[0].id).toEqual(createdChild1.id);
+      expect(items.length).toBe(1);
     });
-    expect(items[0].id).toEqual(createdChild1.id);
-    expect(items.length).toBe(1);
   });
 
   test('count aggregate', async () => {

--- a/packages/stable/src/__tests__/api/assets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/assets.int.spec.ts
@@ -29,33 +29,13 @@ describe('Asset integration test', () => {
     parentExternalId: rootAsset.externalId,
   };
   let assets: Asset[];
-  let [createdChild1, createdRoot1, ...createdAssets2]: Asset[] = [];
 
   beforeAll(async () => {
     client = setupLoggedInClient();
     assets = await client.assets.create([childAsset, rootAsset]);
-
-    const root1 = { name: 'root-1', externalId: 'root-1' + randomInt() };
-    const root2 = { name: 'root-2', externalId: 'root-2' + randomInt() };
-    const child1 = { name: 'child-1', parentExternalId: root1.externalId };
-    const child2 = { name: 'child-2', parentExternalId: root2.externalId };
-    [
-      createdChild1,
-      createdRoot1,
-      ...createdAssets2
-    ] = await client.assets.create([child1, root1, root2, child2]);
-  });
-
-  afterAll(async () => {
-    await client.assets.delete(
-      [createdChild1, createdRoot1, ...createdAssets2, ...assets].map(
-        ({ id }) => ({ id })
-      )
-    );
   });
 
   test('create', async () => {
-    //only tests that the assets were created during setup
     expect(assets[0].createdTime).toBeInstanceOf(Date);
     expect(assets[0].lastUpdatedTime).toBeInstanceOf(Date);
   });
@@ -251,6 +231,19 @@ describe('Asset integration test', () => {
         },
       })
       .autoPagingToArray({ limit: 100 });
+  });
+
+  let [createdChild1, createdRoot1, ...createdAssets2]: Asset[] = [];
+  beforeAll(async () => {
+    const root1 = { name: 'root-1', externalId: 'root-1' + randomInt() };
+    const root2 = { name: 'root-2', externalId: 'root-2' + randomInt() };
+    const child1 = { name: 'child-1', parentExternalId: root1.externalId };
+    const child2 = { name: 'child-2', parentExternalId: root2.externalId };
+    [
+      createdChild1,
+      createdRoot1,
+      ...createdAssets2
+    ] = await client.assets.create([child1, root1, root2, child2]);
   });
 
   test('filter rootIds', async () => {

--- a/packages/stable/src/__tests__/api/assets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/assets.int.spec.ts
@@ -11,6 +11,9 @@ import {
 
 describe('Asset integration test', () => {
   let client: CogniteClient;
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+  });
   const rootAsset = {
     name: 'test-root',
     description: 'Root asset for cognitesdk-js test',
@@ -30,12 +33,8 @@ describe('Asset integration test', () => {
   };
   let assets: Asset[];
 
-  beforeAll(async () => {
-    client = setupLoggedInClient();
-    assets = await client.assets.create([childAsset, rootAsset]);
-  });
-
   test('create', async () => {
+    assets = await client.assets.create([childAsset, rootAsset]);
     expect(assets[0].createdTime).toBeInstanceOf(Date);
     expect(assets[0].lastUpdatedTime).toBeInstanceOf(Date);
   });
@@ -234,7 +233,7 @@ describe('Asset integration test', () => {
   });
 
   let [createdChild1, createdRoot1, ...createdAssets2]: Asset[] = [];
-  beforeAll(async () => {
+  test('filter rootIds', async () => {
     const root1 = { name: 'root-1', externalId: 'root-1' + randomInt() };
     const root2 = { name: 'root-2', externalId: 'root-2' + randomInt() };
     const child1 = { name: 'child-1', parentExternalId: root1.externalId };
@@ -244,9 +243,7 @@ describe('Asset integration test', () => {
       createdRoot1,
       ...createdAssets2
     ] = await client.assets.create([child1, root1, root2, child2]);
-  });
 
-  test('filter rootIds', async () => {
     const nonRootAssets = await client.assets
       .list({
         filter: { root: false },

--- a/packages/stable/src/__tests__/api/assets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/assets.int.spec.ts
@@ -29,13 +29,33 @@ describe('Asset integration test', () => {
     parentExternalId: rootAsset.externalId,
   };
   let assets: Asset[];
+  let [createdChild1, createdRoot1, ...createdAssets2]: Asset[] = [];
 
   beforeAll(async () => {
     client = setupLoggedInClient();
     assets = await client.assets.create([childAsset, rootAsset]);
+
+    const root1 = { name: 'root-1', externalId: 'root-1' + randomInt() };
+    const root2 = { name: 'root-2', externalId: 'root-2' + randomInt() };
+    const child1 = { name: 'child-1', parentExternalId: root1.externalId };
+    const child2 = { name: 'child-2', parentExternalId: root2.externalId };
+    [
+      createdChild1,
+      createdRoot1,
+      ...createdAssets2
+    ] = await client.assets.create([child1, root1, root2, child2]);
+  });
+
+  afterAll(async () => {
+    await client.assets.delete(
+      [createdChild1, createdRoot1, ...createdAssets2, ...assets].map(
+        ({ id }) => ({ id })
+      )
+    );
   });
 
   test('create', async () => {
+    //only tests that the assets were created during setup
     expect(assets[0].createdTime).toBeInstanceOf(Date);
     expect(assets[0].lastUpdatedTime).toBeInstanceOf(Date);
   });
@@ -231,19 +251,6 @@ describe('Asset integration test', () => {
         },
       })
       .autoPagingToArray({ limit: 100 });
-  });
-
-  let [createdChild1, createdRoot1, ...createdAssets2]: Asset[] = [];
-  beforeAll(async () => {
-    const root1 = { name: 'root-1', externalId: 'root-1' + randomInt() };
-    const root2 = { name: 'root-2', externalId: 'root-2' + randomInt() };
-    const child1 = { name: 'child-1', parentExternalId: root1.externalId };
-    const child2 = { name: 'child-2', parentExternalId: root2.externalId };
-    [
-      createdChild1,
-      createdRoot1,
-      ...createdAssets2
-    ] = await client.assets.create([child1, root1, root2, child2]);
   });
 
   test('filter rootIds', async () => {

--- a/packages/stable/src/__tests__/api/assets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/assets.int.spec.ts
@@ -11,9 +11,6 @@ import {
 
 describe('Asset integration test', () => {
   let client: CogniteClient;
-  beforeAll(async () => {
-    client = setupLoggedInClient();
-  });
   const rootAsset = {
     name: 'test-root',
     description: 'Root asset for cognitesdk-js test',
@@ -33,8 +30,12 @@ describe('Asset integration test', () => {
   };
   let assets: Asset[];
 
-  test('create', async () => {
+  beforeAll(async () => {
+    client = setupLoggedInClient();
     assets = await client.assets.create([childAsset, rootAsset]);
+  });
+
+  test('create', async () => {
     expect(assets[0].createdTime).toBeInstanceOf(Date);
     expect(assets[0].lastUpdatedTime).toBeInstanceOf(Date);
   });
@@ -233,7 +234,7 @@ describe('Asset integration test', () => {
   });
 
   let [createdChild1, createdRoot1, ...createdAssets2]: Asset[] = [];
-  test('filter rootIds', async () => {
+  beforeAll(async () => {
     const root1 = { name: 'root-1', externalId: 'root-1' + randomInt() };
     const root2 = { name: 'root-2', externalId: 'root-2' + randomInt() };
     const child1 = { name: 'child-1', parentExternalId: root1.externalId };
@@ -243,7 +244,9 @@ describe('Asset integration test', () => {
       createdRoot1,
       ...createdAssets2
     ] = await client.assets.create([child1, root1, root2, child2]);
+  });
 
+  test('filter rootIds', async () => {
     const nonRootAssets = await client.assets
       .list({
         filter: { root: false },


### PR DESCRIPTION
Uses `beforeAll` and `afterAll` to do setup and cleanup, which probably fixes some test randomly failing in travis.
We previously used `--maxWorkers 1`, but even with that it would still sometimes fail, as awaiting a request could yield to another test. Now the order should be consistent.

I'm unsure about using `expect` in `beforeAll`, so the previous `'create'` test is still present, just checking if creation was successful.