### PR TITLE
fix: make Node3D.boundingBox optional

### DIFF
--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -1397,7 +1397,7 @@ export interface Node3D {
    *  The bounding box of the subtree with this sector as the root sector.
    *  Is null if there are no geometries in the subtree.
    */
-  boundingBox: BoundingBox3D;
+  boundingBox?: BoundingBox3D;
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE:
Node3D.boundingBox has always been optional in API. This commit just fixes the bug in interface and documentation.

https://cognitedata.atlassian.net/browse/CDF-6135