### PR TITLE
feat(datapoints): add unit property to retrieve response object

### DIFF
--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -47,9 +47,8 @@ describe('Datapoints integration test', () => {
       end: new Date(),
     });
     expect(response[0].datapoints.length).toBeGreaterThan(0);
-    expect(response[0].datapoints[0].timestamp).toBeDefined();
+    expect(response[0].datapoints[0].timestamp).toBeInstanceOf(Date);
     expect(response[0].isString).toBe(false);
-    expect(!response[0].isString && response[0].isStep).toBeDefined();
   });
 
   test('retrieve latest', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -48,6 +48,8 @@ describe('Datapoints integration test', () => {
     });
     expect(response[0].datapoints.length).toBeGreaterThan(0);
     expect(response[0].datapoints[0].timestamp).toBeDefined();
+    expect(response[0].isString).toBe(false);
+    expect(!response[0].isString && response[0].isStep).toBeDefined();
   });
 
   test('retrieve latest', async () => {

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -93,7 +93,7 @@ export class DataPointsAPI extends BaseResourceAPI<
   private async retrieveDatapointsEndpoint(query: DatapointsMultiQuery) {
     const path = this.listPostUrl;
     const response = await this.post<
-      ItemsWrapper<(DatapointAggregates | Datapoints)[]>
+      ItemsWrapper<DatapointAggregates[] | Datapoints[]>
     >(path, {
       data: query,
     });

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -672,6 +672,9 @@ export type DatapointsDeleteRequest =
   | (ExternalId & DatapointsDeleteRange);
 
 export interface DatapointAggregates extends DatapointsMetadata {
+  /**
+   * false for aggregate time series values
+   */
   isString: false;
   /**
    * Whether the timeseries is a step series or not
@@ -683,6 +686,9 @@ export interface DatapointAggregates extends DatapointsMetadata {
 export type Datapoints = StringDatapoints | DoubleDatapoints;
 
 export interface DoubleDatapoints extends DatapointsMetadata {
+  /**
+   * false for timeseries with double values
+   */
   isString: false;
   /**
    * Whether the timeseries is a step series or not
@@ -695,6 +701,9 @@ export interface DoubleDatapoints extends DatapointsMetadata {
 }
 
 export interface StringDatapoints extends DatapointsMetadata {
+  /**
+   * true for timeseries with string values
+   */
   isString: true;
   /**
    * The list of datapoints

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -672,9 +672,6 @@ export type DatapointsDeleteRequest =
   | (ExternalId & DatapointsDeleteRange);
 
 export interface DatapointAggregates extends DatapointsMetadata {
-  /**
-   * false for aggregate time series values.
-   */
   isString: false;
   /**
    * Whether the timeseries is a step series or not
@@ -686,9 +683,6 @@ export interface DatapointAggregates extends DatapointsMetadata {
 export type Datapoints = StringDatapoints | DoubleDatapoints;
 
 export interface DoubleDatapoints extends DatapointsMetadata {
-  /**
-   * false for timeseries with double values.
-   */
   isString: false;
   /**
    * Whether the timeseries is a step series or not
@@ -701,9 +695,6 @@ export interface DoubleDatapoints extends DatapointsMetadata {
 }
 
 export interface StringDatapoints extends DatapointsMetadata {
-  /**
-   * true for timeseries with string values.
-   */
   isString: true;
   /**
    * The list of datapoints

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -673,7 +673,7 @@ export type DatapointsDeleteRequest =
 
 export interface DatapointAggregates extends DatapointsMetadata {
   /**
-   * false for aggregate time series values
+   * false for aggregate time series values.
    */
   isString: false;
   /**
@@ -687,7 +687,7 @@ export type Datapoints = StringDatapoints | DoubleDatapoints;
 
 export interface DoubleDatapoints extends DatapointsMetadata {
   /**
-   * false for timeseries with double values
+   * false for timeseries with double values.
    */
   isString: false;
   /**
@@ -702,7 +702,7 @@ export interface DoubleDatapoints extends DatapointsMetadata {
 
 export interface StringDatapoints extends DatapointsMetadata {
   /**
-   * true for timeseries with string values
+   * true for timeseries with string values.
    */
   isString: true;
   /**

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -672,16 +672,16 @@ export type DatapointsDeleteRequest =
   | (ExternalId & DatapointsDeleteRange);
 
 export interface DatapointAggregates extends DatapointsMetadata {
+  isString: false;
+  isStep: boolean;
   datapoints: DatapointAggregate[];
 }
 
 export type Datapoints = StringDatapoints | DoubleDatapoints;
 
 export interface DoubleDatapoints extends DatapointsMetadata {
-  /**
-   * Whether the time series is string valued or not.
-   */
   isString: false;
+  isStep?: boolean;
   /**
    * The list of datapoints
    */
@@ -689,9 +689,6 @@ export interface DoubleDatapoints extends DatapointsMetadata {
 }
 
 export interface StringDatapoints extends DatapointsMetadata {
-  /**
-   * Whether the time series is string valued or not.
-   */
   isString: true;
   /**
    * The list of datapoints
@@ -708,6 +705,10 @@ export interface DatapointsMetadata extends InternalId {
    * External id of the timeseries the datapoints belong to.
    */
   externalId?: CogniteExternalId;
+  /**
+   * Name of the physical unit of the time series
+   */
+  unit?: string;
 }
 
 export interface DatapointsMultiQuery extends DatapointsMultiQueryBase {

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -673,6 +673,9 @@ export type DatapointsDeleteRequest =
 
 export interface DatapointAggregates extends DatapointsMetadata {
   isString: false;
+  /**
+   * Whether the timeseries is a step series or not
+   */
   isStep: boolean;
   datapoints: DatapointAggregate[];
 }
@@ -681,6 +684,9 @@ export type Datapoints = StringDatapoints | DoubleDatapoints;
 
 export interface DoubleDatapoints extends DatapointsMetadata {
   isString: false;
+  /**
+   * Whether the timeseries is a step series or not
+   */
   isStep?: boolean;
   /**
    * The list of datapoints
@@ -705,6 +711,10 @@ export interface DatapointsMetadata extends InternalId {
    * External id of the timeseries the datapoints belong to.
    */
   externalId?: CogniteExternalId;
+  /**
+   * Whether or not the datapoints are string values.
+   */
+  isString: boolean;
   /**
    * Name of the physical unit of the time series
    */


### PR DESCRIPTION
Also add isStep where applicable.
The spec says isStep is a required response field in aggregates but optional in normal double value datapoints. Is this correct?