### PR TITLE
docs: write docstring about CursorAndAsyncIterator

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,6 +58,29 @@ export interface LogoutUrlResponse {
   data: { url: LogoutUrl };
 }
 
+/**
+ * A Promise to a response that can be awaited like normal,
+ * but at the risk of not getting all results due to API limits.
+ * In which case a nextCursor field is provided to request the next page.
+ * Helper methods are provided to abstract away the pagination.
+ *
+ * Example using `client.timeseries.list`:
+ * ```
+ * const response = client.timeseries.list({ filter: { assetIds: [ASSET_ID] } });
+ * ```
+ *
+ * You can iterate through all returned items like so:
+ * ```
+ * for await (const value of response) {
+ *   // do something to value
+ * }
+ * ```
+ *
+ * Or get an array of up to 1000 items like so:
+ * ```
+ * const timeseries = await response.autoPagingToArray({limit: 1000});
+ * ```
+ */
 export type CursorAndAsyncIterator<T> = Promise<ListResponse<T[]>> &
   CogniteAsyncIterator<T>;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -66,19 +66,26 @@ export interface LogoutUrlResponse {
  *
  * Example using `client.timeseries.list`:
  * ```js
- * const response = client.timeseries.list({ filter: { assetIds: [ASSET_ID] } });
+ * const response = client.timeseries.list({ filter: { assetIds: [ASSET_ID] }, limit: 1000 });
  * ```
  *
- * You can iterate through all returned items like so:
+ * You can get up to 1000 elements with normal await:
+ * ```js
+ * const items = await response;
+ * ```
+ *
+ * You can use `autoPagingToArray` to get more items than the per-request limit.
+ * E.g. an array of up to 5000 items:
+ * ```js
+ * const timeseries = await response.autoPagingToArray({ limit: 5000 });
+ * ```
+ * You may also specify `{ limit: Infinity }` to get all pages of results.
+ *
+ * You can also iterate through all items like so:
  * ```js
  * for await (const value of response) {
  *   // do something to value
  * }
- * ```
- *
- * Or get an array of up to 1000 items like so:
- * ```js
- * const timeseries = await response.autoPagingToArray({ limit: 1000 });
  * ```
  */
 export type CursorAndAsyncIterator<T> = Promise<ListResponse<T[]>> &

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,20 +65,20 @@ export interface LogoutUrlResponse {
  * Helper methods are provided to abstract away the pagination.
  *
  * Example using `client.timeseries.list`:
- * ```
+ * ```js
  * const response = client.timeseries.list({ filter: { assetIds: [ASSET_ID] } });
  * ```
  *
  * You can iterate through all returned items like so:
- * ```
+ * ```js
  * for await (const value of response) {
  *   // do something to value
  * }
  * ```
  *
  * Or get an array of up to 1000 items like so:
- * ```
- * const timeseries = await response.autoPagingToArray({limit: 1000});
+ * ```js
+ * const timeseries = await response.autoPagingToArray({ limit: 1000 });
  * ```
  */
 export type CursorAndAsyncIterator<T> = Promise<ListResponse<T[]>> &

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,17 +61,17 @@ export interface LogoutUrlResponse {
 /**
  * A Promise to a response that can be awaited like normal,
  * but at the risk of not getting all results due to API limits.
- * In which case a nextCursor field is provided to request the next page.
+ * In which case a nextCursor field is returned to request the next page.
  * Helper methods are provided to abstract away the pagination.
  *
- * Example using `client.timeseries.list`:
+ * Example using `client.timeseries.list` with a per-request limit of 1000:
  * ```js
  * const response = client.timeseries.list({ filter: { assetIds: [ASSET_ID] }, limit: 1000 });
  * ```
  *
  * You can get up to 1000 elements with normal await:
  * ```js
- * const items = await response;
+ * const { items, nextCursor } = await response;
  * ```
  *
  * You can use `autoPagingToArray` to get more items than the per-request limit.
@@ -79,9 +79,9 @@ export interface LogoutUrlResponse {
  * ```js
  * const timeseries = await response.autoPagingToArray({ limit: 5000 });
  * ```
- * You may also specify `{ limit: Infinity }` to get all pages of results.
+ * You may also specify `{ limit: Infinity }` to get all results.
  *
- * You can also iterate through all items like so:
+ * You can also iterate through all items (unless you break out of the loop) like so:
  * ```js
  * for await (const value of response) {
  *   // do something to value


### PR DESCRIPTION
As a small improvement to the reference documentation, where some requests return this object without full explanation of how it can be used.