### PR TITLE
fix: exports from packages, add guide for making derived SDKs

### DIFF
--- a/guides/derived_SDKs.md
+++ b/guides/derived_SDKs.md
@@ -1,0 +1,374 @@
+# Derived SDKs HOW-TO
+
+This document serves as a guide for working with SDK packages.
+First there is an overview, describing the most important packages
+in the repository and how they interact. Then there are guides for
+creating your own SDK packages, how to add APIs to the SDK, how to
+make a derived SDK, and how to override APIs from the derived SDK.
+
+## Overview of packages
+
+### @cognite/sdk-core
+exports a `BaseCogniteClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/core/classes/basecogniteclient.html)) which supports logging in, upon which it creates
+a `CDFHttpClient` containing the API keys needed to interract with the API.
+Helper functions for logging in with browser popups and redirects also live here, and a generic `BaseResourceApi<T>` class provides protected templated methods for working with resource APIs with
+pagination and chunking.
+
+### @cognite/sdk (stable)
+exports a `CogniteClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/classes/cogniteclient.html)) which inherits from the `BaseCogniteClient` to add accessors to all stable API endpoints. Endpoint access is grouped by resource type. Example: `TimeSeriesAPI` ([docs](https://cognitedata.github.io/cognite-sdk-js/classes/timeseriesapi.html)) lets you create, filter, count, delete etc. timeseries.
+
+Most types used in requests and responses are defined as interfaces and type aliases in `src/types.ts`,
+and closely mimic the structure of the REST API.
+
+### @cognite/sdk-beta
+depends on both stable and core, and uses inheritence to augment the stable sdk.
+The resulting class is exported as `CogniteClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/beta/classes/cogniteclient.html)), and the rest of stable is forward-exported as well,
+which makes the beta package behave as stable by default. To understand how the beta class can override
+parts of stable, see the sections below.
+
+### Any other potential packages
+This is not an exhaustive list, because you can create your own packages.
+See the sections below.
+
+# Creating an SDK derived from stable
+
+To create a new package, copy the `packages/template` folder in place and give it a new name. Go into the folder and change `package.json` to give the npm package a name. Tooling expects the package name to match the folder name like so:
+```json
+    "private": true,
+    "name": "@cognite/sdk-<folder name>",
+    "version": "0.0.0",
+```
+Keep the package private until it's ready to be published, since CI will version and publish all public packages
+when releases are triggered.
+
+You should also update the `"test"` script to run the tests inside your newly created folder:
+```json
+        "test": "jest --config=../../jest.config.js --testPathPattern=/<folder name>/",
+```
+
+Finally, if you want docs from this SDK to appear as a subfolder on the reference docs,
+add the following script, which will run when docs are built for deployment:
+```json
+        "docs:bundle": "yarn docs && mkdir -p ../../docs/<subfolder> && cp -r docs/* ../../docs/<subfolder>/" 
+```
+
+The `README.md` file will appear on npm if published, so write something about the package.
+
+## The structure of a package
+In your newly created folder you will find some config files and a `src/` directory.
+```
+ src/
+ |--> __test__/
+ |--> cogniteClient.ts
+ \--> index.ts
+```
+
+The client is defined in `cogniteClient.ts` and is exported from `index.ts`.
+The simplest possible client (derived from stable) looks like this:
+```ts
+import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
+
+export default class CogniteClient extends CogniteClientStable {
+
+}
+```
+With the accompanying `index.ts`:
+```ts
+export * from '@cognite/sdk';
+export { default as CogniteClient } from './cogniteClient';
+```
+
+# Adding endpoints to an SDK
+
+Endpoints are all implemented as functions on subclasses of `BaseResourceAPI<T>`, but that is not a strict
+requirement. The class simply helps with common actions on resources (when the REST API is laid out like in CDF), and the generic parameter lets you specify
+the type. For an example, see `TimeSeriesAPI` [here](../packages/stable/src/api/timeSeries/timeSeriesApi.ts).
+The class has several endpoints, most of which already have generic implementations in the superclass.
+
+Let's define a new API class in `src/api/coolThing/coolThingApi.ts`:
+```ts
+import {
+    BaseResourceAPI,
+    InternalId,
+    CursorAndAsyncIterator,
+} from '@cognite/sdk-core';
+
+export interface ExternalCoolThing {
+    name: string;
+    coolness: number;
+}
+
+export type CoolThing = ExternalCoolThing & InternalId;
+
+export interface CoolThingQuery {
+    /** Only get cool things at least this cool */
+    min?: number;
+
+    /** Only get cool things no cooler than */
+    max?: number;
+}
+
+export class CoolThingAPI extends BaseResource<CoolThing> {
+
+    /**
+    * [Create cool things](https://doc.cognitedata.com/api/v1/#operation/postCoolThing)
+    *
+    * ```js
+    * const coolthings = [
+    *   { name: 'Shrub', coolness: 40 },
+    *   { name: 'Cactus', coolness: 80 },
+    * ];
+    * const created = await client.coolThing.create(coolthings);
+    * ```
+    */
+    public create = (items: ExternalCoolThing[]): Promise<CoolThing[]> => {
+        return super.createEndpoint(items);
+    };
+
+    /** <docstring here> */
+    public list = (query?: CoolThingQuery): CursorAndAsyncIterator<CoolThing> => {
+        return super.listEndpoints(this.callListEndpointWithPost, query);
+    }
+}
+```
+
+The `CogniteClient` class makes instances of these classes in `initAPIs()`, which is called once credentials and project name are set. The accessor helper `accessApi()` reminds the user to set credentials before using APIs.
+
+Let's add our `CoolThingAPI` to our derived `CogniteClient`.
+```ts
+import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
+import { CoolThingAPI } from './api/coolThing/coolThingApi';
+import { accessApi } from '@cognite/sdk-core';
+
+export default class CogniteClient extends CogniteClientStable {
+
+    private coolThingApi?: CoolThingAPI;
+
+    protected initAPIs() {
+        super.initAPIs();
+
+        // Turns into $BASE_URL/api/$API_VERSION/projects/$PROJECT/coolthing
+        this.coolThingApi = this.apiFactory(CoolThingAPI, 'coolthing');
+    }
+
+    get coolThing(): CoolThingAPI {
+        return accessApi(this.coolThingApi);
+    }
+}
+```
+
+The resulting CogniteClient now contains all API classes from stable, as well as our new API class.
+When you create API classes, they should be exported in `index.ts`, along with any types used by
+the API class.
+```ts
+export * from '@cognite/sdk';
+export { default as CogniteClient } from './cogniteClient';
+export {
+    CoolThingAPI,
+    ExternalCoolThing,
+    CoolThing,
+    CoolThingQuery,
+} from './api/coolThing/coolThingApi';
+```
+
+In the stable API all type definitons are placed in `types.ts`, and then `*` is exported from `types.ts`. If `CoolThingAPI` was in stable, the types would be there instead, and we wouldn't have to explicitly export them in `index.ts`.
+
+In derived SDKs, it is recommended to put the types with the API file that uses it.
+Then it is easier to see what has been changed when moving features to stable.
+
+# Adding an endpoint in a derived API class
+
+Let's say we are writing an SDK derived from stable and want to add a new endpoint in `TimeSeriesAPI`.
+To do this, we can create our own `TimeSeriesAPI` class inheriting from the stable class,
+and put our new endpoint there.
+
+We make our own `src/api/timeseries/timeSeriesApi.ts`:
+```ts
+import { TimeSeriesAPI as TimeSeriesAPIStable } from '@cognite/sdk';
+import { InternalId } from '@cognite/sdk-core';
+
+export class TimeSeriesAPI extends TimeSeriesAPIStable {
+    /** <docstring> */
+    public flip = async (id: InternalId) => {
+        const path = this.url('flip');
+        const response = await this.post(path, { data: { id }});
+        return this.addToMapAndReturn({}, response);
+    }
+}
+```
+
+Then we need to use this new `TimeSeriesAPI` in the client. It's not enough to
+give it the same name. We must re-define the `timeseries` field to return an instance
+of our new class. The problem is that stable's `CogniteClient.timeseries` already has a defined type.
+Subclasses normally can't broaden the type of fields. We do however have a trick:
+```ts
+import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
+import { TimeSeriesAPI } from './api/timeSeries/timeSeriesApi';
+
+class CogniteClientCleaned extends CogniteClientStable {
+    // Remove type restriction on timeseries
+    timeseries: any;
+}
+
+export default class CogniteClient extends CogniteClientCleaned {
+
+    private timeSeriesApi?: TimeSeriesAPI;
+    protected initAPIs() {
+        super.initAPIs();
+        this.timeSeriesApiBeta = this.apiFactory(TimeSeriesAPI, 'timeseries');
+    }
+
+    get timeseries(): TimeSeriesAPI {
+        return accessApi(this.timeSeriesApiBeta);
+    }
+}
+```
+
+Typescript always allows the `any` type to be used, which weakens the type of `timeseries` in `CogniteClientCleaned`.
+We can then override that class again, and specify the correct strict type.
+IDEs now understand that the `timeseries` field has the new type, and gives correct suggestions.
+
+It is now very important to export this new `TimeSeriesAPI` in `index.ts`:
+```ts
+export * from '@cognite/sdk'; // This /won't/ export TimeSeriesAPI
+export { default as CogniteClient } from './cogniteClient';
+export { TimeSeriesAPI } from './api/timeSeries/timeSeriesApi'; // Because we export it here
+```
+
+Because we specify by name, it will take precedence over `export * from @cognite/sdk`,
+which normally exports its own `TimeSeriesAPI`.
+
+# Changing existsing endpoints and types
+
+If you want to change an exisiting endpoint, such as adding a field to Timeseries,
+the easiest way is to completely copy the `timeSeriesApi.ts` file. In here you define your
+own `Timeseries` interface, instead of importing it from `../../types`.
+You must then export this new API class and new type, just like in previous sections.
+
+The resulting `index.ts` should look something like this:
+```ts
+export * from '@cognite/sdk'; // This /won't/ export Timeseries
+export { default as CogniteClient } from './cogniteClient';
+export { TimeSeriesAPI, Timeseries } from './api/timeSeries/timeSeriesApi';
+```
+
+# Adding tests
+
+Each SDK has its own `src/__tests__/` folder where all `*.test.ts` and `*.spec.ts` get run.
+There are some example tests in the template, but you should add your own, in seperate files
+for separate API classes.
+
+# Accessing endpoints from outside of CDF
+
+If you want to access a different domain, it is recomended to make your own
+ `BasicHttpClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/beta/classes/basichttpclient.html)). You specify a `baseUrl` in the constructor, and relative paths in calls to `get`, `post` etc.
+ 
+Example of a custom `CogniteClient` class with an external API:
+```ts
+import { BasicHttpClient } from '@cognite/sdk-core';
+
+export default class CogniteClient extends CogniteClientStable {
+
+    private openDoor?: (name: string) => Promise<boolean>;
+
+    protected initAPIs() {
+        super.initAPIs();
+
+        const doorClient = new BasicHttpClient("https://example.com");
+
+        type DoorState = {
+            open: boolean;
+        };
+
+        this.openDoor = async (name: string) => {
+            // calls https://example.com/doors/open?name=<name>
+            const response = await doorClient.post<DoorState>('doors/open', { params: { name } });
+            return response.data.open;
+        }
+    }
+
+    get doorControl() {
+        return {
+            openDoor: accessApi(this.openDoor)
+        };
+    }
+}
+```
+You may also provide full paths (starting in `http://` or `https://`) to `get`, `post`, etc.,
+which will cause the `baseUrl` to be ignored. 
+
+
+# Compiling and testing your SDK
+
+The monorepo tooling will compile and test all packages when commits are pushed to GitHub,
+but you can also (and should) do it locally.
+
+You should first make sure all packages are built, since your dependencies live in the repository.
+```sh
+yarn
+yarn build
+```
+
+After this is done, you can go into your package folder and run
+```
+yarn test
+```
+
+Whenever you make changes, remember to `yarn build`, and if other packages in the repo change,
+go back to the root and run the command there.
+
+# Creating an SDK not derived from stable
+If you want to make an SDK derived from a beta or alpha, replace the dependency on `@cognite/sdk` with the correct package,
+and yarn workspace will find it. All imports must be changed to the new package.
+In theory all SDK versions are quite similar, except for aditions and small changes, so find & replace on imports should mostly work.
+```ts
+import { CogniteClient as CogniteClientStable } from '@cognite/sdk-beta';
+```
+
+If however, you want to create an SDK not based on any existing SDK, you only need to depend on core.
+The stable SDK is such an SDK, see [stable/src/cogniteClient.ts](../packages/stable/src/cogniteClient.ts).
+
+# Publishing your SDK
+
+There are two ways of publishing your derived SDK.
+
+Any package with `"private": false` in the master branch will be published
+to npm when a `[release]` commit happens. The version number will also be automatically
+bumped based on commit messages. See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+**NOTE:** If you depend on e.g. `stable`, and `stable` changes, your PATCH version will be bumped
+to use the new version of `stable`.
+
+It's also possible to keep your package private and only relese it manually.
+In this case you need to update the version and versions of dependencies yourself.
+
+# Using a derived SDK as a drop-in replacement
+
+If your derived SDK is backwards compatible with its parent, you can use your derived SDK under an alias to make it a drop-in replacement.
+Let's say you have a feature in `@cognite/sdk-beta@1.3.0` that
+you would like to use in an app where `@cognite/sdk` is a dependency.
+
+Assuming the beta package is published to npm, use the following line in the app's `package.json`:
+```json
+"dependencies": {
+    "@cognite/sdk": "npm:@cognite/sdk-beta@^1.3.0",
+    ...
+}
+```
+Run `yarn` or `npm install` to install the beta in place of stable, with the same name.
+All your imports will stay the same, but now reference the beta package.
+```ts
+import { CogniteClient } from '@cognite/sdk'; // Now gives the beta client
+```
+
+# Moving features upstream
+
+One of the main use cases for derived SDKs is implementing experimental features before they
+reach stable. When the features do reach stable, the SDK implementation should move as well.
+The guides above try making this move as painless as possible, and in general the following should be enough:
+ - Move the new API class file to replace the old one
+ - Move types into `types.ts` if applicable (e.g. when moving to stable)
+ - Move any tests concerning new features
+ - Remove overridden API class accessors
+ - build & test
+ - Look very hard at the diff to see that you didn't lose anything

--- a/guides/derived_SDKs.md
+++ b/guides/derived_SDKs.md
@@ -10,18 +10,18 @@ make a derived SDK, and how to override APIs from the derived SDK.
 
 ### @cognite/sdk-core
 exports a `BaseCogniteClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/core/classes/basecogniteclient.html)) which supports logging in, upon which it creates
-a `CDFHttpClient` containing the API keys needed to interract with the API.
+a `CDFHttpClient` containing the API keys needed to interact with the API.
 Helper functions for logging in with browser popups and redirects also live here, and a generic `BaseResourceApi<T>` class provides protected templated methods for working with resource APIs with
 pagination and chunking.
 
 ### @cognite/sdk (stable)
-exports a `CogniteClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/classes/cogniteclient.html)) which inherits from the `BaseCogniteClient` to add accessors to all stable API endpoints. Endpoint access is grouped by resource type. Example: `TimeSeriesAPI` ([docs](https://cognitedata.github.io/cognite-sdk-js/classes/timeseriesapi.html)) lets you create, filter, count, delete etc. timeseries.
+exports a `CogniteClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/classes/cogniteclient.html)) which inherits from the `BaseCogniteClient` to add accessors to all stable API endpoints. Endpoint access is grouped by resource type. Example: `TimeSeriesAPI` ([docs](https://cognitedata.github.io/cognite-sdk-js/classes/timeseriesapi.html)) lets you create, filter, count, delete time series.
 
 Most types used in requests and responses are defined as interfaces and type aliases in `src/types.ts`,
 and closely mimic the structure of the REST API.
 
 ### @cognite/sdk-beta
-depends on both stable and core, and uses inheritence to augment the stable sdk.
+depends on both stable and core, and uses inheritance to augment the stable sdk.
 The resulting class is exported as `CogniteClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/beta/classes/cogniteclient.html)), and the rest of stable is forward-exported as well,
 which makes the beta package behave as stable by default. To understand how the beta class can override
 parts of stable, see the sections below.
@@ -171,7 +171,7 @@ export {
 } from './api/coolThing/coolThingApi';
 ```
 
-In the stable API all type definitons are placed in `types.ts`, and then `*` is exported from `types.ts`. If `CoolThingAPI` was in stable, the types would be there instead, and we wouldn't have to explicitly export them in `index.ts`.
+In the stable API all type definitions are placed in `types.ts`, and then `*` is exported from `types.ts`. If `CoolThingAPI` was in stable, the types would be there instead, and we wouldn't have to explicitly export them in `index.ts`.
 
 In derived SDKs, it is recommended to put the types with the API file that uses it.
 Then it is easier to see what has been changed when moving features to stable.
@@ -238,9 +238,9 @@ export { TimeSeriesAPI } from './api/timeSeries/timeSeriesApi'; // Because we ex
 Because we specify by name, it will take precedence over `export * from @cognite/sdk`,
 which normally exports its own `TimeSeriesAPI`.
 
-# Changing existsing endpoints and types
+# Changing existing endpoints and types
 
-If you want to change an exisiting endpoint, such as adding a field to Timeseries,
+If you want to change an existing endpoint, such as adding a field to time series,
 the easiest way is to completely copy the `timeSeriesApi.ts` file. In here you define your
 own `Timeseries` interface, instead of importing it from `../../types`.
 You must then export this new API class and new type, just like in previous sections.
@@ -255,12 +255,12 @@ export { TimeSeriesAPI, Timeseries } from './api/timeSeries/timeSeriesApi';
 # Adding tests
 
 Each SDK has its own `src/__tests__/` folder where all `*.test.ts` and `*.spec.ts` get run.
-There are some example tests in the template, but you should add your own, in seperate files
+There are some example tests in the template, but you should add your own, in separate files
 for separate API classes.
 
 # Accessing endpoints from outside of CDF
 
-If you want to access a different domain, it is recomended to make your own
+If you want to access a different domain, it is recommended to make your own
  `BasicHttpClient` ([docs](https://cognitedata.github.io/cognite-sdk-js/beta/classes/basichttpclient.html)). You specify a `baseUrl` in the constructor, and relative paths in calls to `get`, `post` etc.
  
 Example of a custom `CogniteClient` class with an external API:
@@ -320,7 +320,7 @@ go back to the root and run the command there.
 # Creating an SDK not derived from stable
 If you want to make an SDK derived from a beta or alpha, replace the dependency on `@cognite/sdk` with the correct package,
 and yarn workspace will find it. All imports must be changed to the new package.
-In theory all SDK versions are quite similar, except for aditions and small changes, so find & replace on imports should mostly work.
+In theory all SDK versions are quite similar, except for additions and small changes, so find & replace on imports should mostly work.
 ```ts
 import { CogniteClient as CogniteClientStable } from '@cognite/sdk-beta';
 ```
@@ -339,7 +339,7 @@ bumped based on commit messages. See [CONTRIBUTING.md](../CONTRIBUTING.md).
 **NOTE:** If you depend on e.g. `stable`, and `stable` changes, your PATCH version will be bumped
 to use the new version of `stable`.
 
-It's also possible to keep your package private and only relese it manually.
+It's also possible to keep your package private and only release it manually.
 In this case you need to update the version and versions of dependencies yourself.
 
 # Using a derived SDK as a drop-in replacement

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "yarn allsdk build --stream",
     "watch": "yarn allsdk watch --parallel",
     "docs": "yarn allsdk docs --stream",
-    "docs:bundle": "rm -rf docs/ && yarn docs && mkdir -p docs/ docs/beta && cp -r packages/stable/docs/* docs/ && cp -r packages/beta/docs/* docs/beta",
+    "docs:bundle": "rm -rf docs/ && yarn allsdk docs:bundle --stream",
     "validateDocLinks": "find . -name \\*.md -not -path '*/node_modules/*' -print0 | xargs -0 -n1 yarn markdown-link-check",
     "test-snippets": "yarn allsdk test-snippets --stream",
     "test-samples": "yarn allsamples test --stream"

--- a/packages/beta/README.md
+++ b/packages/beta/README.md
@@ -4,11 +4,11 @@ The package `@cognite/sdk-beta` provides convenient access to the beta version o
 Setup is very similar to [stable](https://github.com/cognitedata/cognite-sdk-js/blob/master/packages/stable/README.md),
 but use the following command to install:
 ```
-$ yarn add @cognite/sdk@npm:@cognite/sdk-beta
+yarn add @cognite/sdk@npm:@cognite/sdk-beta
 ```
 or with npm
 ```
-$ npm install @cognite/sdk@npm:@cognite/sdk-beta --save
+npm install @cognite/sdk@npm:@cognite/sdk-beta --save
 ```
 
 This will install the package `@cognite/sdk-beta` as a dependency, but aliased as `@cognite/sdk`.
@@ -26,7 +26,6 @@ import { CogniteClient } from '@congite/sdk';
 
 ## Documentation
 
-When you import `CogniteClient` from the beta sdk, you will in reality get the subclass `CogniteClientBeta`.
-See the reference doc [here](https://cognitedata.github.io/cognite-sdk-js/beta/classes/cogniteclientbeta.html).
+See the reference doc of `CogniteClient` [here](https://cognitedata.github.io/cognite-sdk-js/beta/classes/cogniteclientbeta.html).
 
 The beta API is mostly a superset of stable. See the [stable readme](https://github.com/cognitedata/cognite-sdk-js/blob/master/packages/stable/README.md).

--- a/packages/beta/package.json
+++ b/packages/beta/package.json
@@ -15,8 +15,9 @@
     "prepublishOnly": "yarn build",
     "build": "yarn clean && rollup -c && yarn esCheck",
     "watch": "rollup -cw",
-    "docs": "typedoc --options typedoc.js --tsconfig tsconfig.json src/index.ts",
     "esCheck": "es-check es5 './dist/index.js'",
+    "docs": "typedoc --options typedoc.js --tsconfig tsconfig.json src/index.ts",
+    "docs:bundle": "yarn docs && mkdir -p ../../docs/beta && cp -r docs/* ../../docs/beta/",
     "extract-snippets": "rm -rf codeSnippets/ && yarn docs --json codeSnippets/docs.json && node ../../scripts/extractCodeSnippets.js",
     "test-snippets": "yarn extract-snippets && yarn tsc -p codeSnippets/tsconfig.build.json"
   },

--- a/packages/beta/src/cogniteClient.ts
+++ b/packages/beta/src/cogniteClient.ts
@@ -5,7 +5,11 @@ import {
 } from '@cognite/sdk';
 import { version } from '../package.json';
 
-export default class CogniteClientBeta extends CogniteClientStable {
+class CogniteClientCleaned extends CogniteClientStable {
+  // Remove type restrictions
+}
+
+export default class CogniteClient extends CogniteClientCleaned {
   /**
    * Create a new SDK client (beta)
    *
@@ -31,5 +35,3 @@ export default class CogniteClientBeta extends CogniteClientStable {
     return `${version}-beta`;
   }
 }
-
-export * from '@cognite/sdk';

--- a/packages/beta/src/index.ts
+++ b/packages/beta/src/index.ts
@@ -1,5 +1,5 @@
 // Copyright 2020 Cognite AS
 
 export * from '@cognite/sdk';
-export * from './types';
 export { default as CogniteClient } from './cogniteClient';
+export { TimeSeriesAPI, Timeseries } from './api/timeseries/timeSeriesApi';

--- a/packages/beta/src/index.ts
+++ b/packages/beta/src/index.ts
@@ -2,4 +2,3 @@
 
 export * from '@cognite/sdk';
 export { default as CogniteClient } from './cogniteClient';
-export { TimeSeriesAPI, Timeseries } from './api/timeseries/timeSeriesApi';

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -1,3 +1,5 @@
 // Copyright 2020 Cognite AS
 
 export * from '@cognite/sdk';
+// This file is here mostly to allow apis to import { ... } from '../../types';
+// Overriding types should probably be done in their respective API endpoint files, where possible

--- a/packages/beta/typedoc.js
+++ b/packages/beta/typedoc.js
@@ -1,13 +1,18 @@
 module.exports = {
-  name: 'Cognite JavaScript SDK',
-  mode: 'file',
+  name: 'Cognite JavaScript SDK (beta)',
+
+  // Stable and core use 'file' mode, which makes reference pages based on the names of classes and types.
+  // Derived SDKs usually re-definine classes using the same name, which breaks in file mode.
+  // 'modules' mode makes the file path part of the url, which allows classes with overlapping
+  // names across packages.
+  mode: 'modules',
   module: 'umd',
   target: 'ES6',
   exclude: ['**/__tests__/**', '**/node_modules/**'],
   out: './docs/',
   readme: 'README.md',
   ignoreCompilerErrors: true,
-  excludeNotExported: true,
+  excludeNotExported: false,
   hideGenerator: true,
   excludePrivate: true,
   excludeProtected: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,14 +8,16 @@
   "types": "dist/src/index.d.js",
   "version": "1.0.0",
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist/ docs/",
     "test": "jest --config=../../jest.config.js --testPathPattern=/core/",
     "lint": "eslint 'src/**/*.{js,ts}'",
     "lint:fix": "yarn lint --fix",
     "prepublishOnly": "yarn build",
     "build": "yarn clean && yarn rollup -c && yarn esCheck",
     "watch": "rollup -cw",
-    "esCheck": "es-check es5 './dist/index.js'"
+    "esCheck": "es-check es5 './dist/index.js'",
+    "docs": "typedoc --options typedoc.js --tsconfig tsconfig.json src/index.ts",
+    "docs:bundle": "yarn docs && mkdir -p ../../docs/core && cp -r docs/* ../../docs/core/"
   },
   "dependencies": {
     "cross-fetch": "^3.0.4",

--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -76,7 +76,6 @@ export function throwReLogginError() {
   );
 }
 
-/** @hidden */
 export default class BaseCogniteClient {
   public get login() {
     return this.loginApi;

--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -76,10 +76,9 @@ export class BasicHttpClient {
    * A basic http client with the option of adding default headers,
    * and the option of using a baseUrl.
    * Note: If the path given starts with `https://`, the baseUrl is ignored.
-   * If the baseUrl is overridden,
    *
-   * It handles query parameters and request body data, which gets encoded as json if
-   * needed. It
+   * It handles query parameters, and request body data which gets encoded as json if
+   * needed.
    *
    * See HttpRequest.
    *

--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -72,6 +72,19 @@ export class BasicHttpClient {
 
   private defaultHeaders: HttpHeaders = {};
 
+  /**
+   * A basic http client with the option of adding default headers,
+   * and the option of using a baseUrl.
+   * Note: If the path given starts with `https://`, the baseUrl is ignored.
+   * If the baseUrl is overridden,
+   *
+   * It handles query parameters and request body data, which gets encoded as json if
+   * needed. It
+   *
+   * See HttpRequest.
+   *
+   * @param baseUrl
+   */
   constructor(protected baseUrl: string) {}
 
   public setDefaultHeader(name: string, value: string) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,8 @@ export { default as BaseCogniteClient } from './baseCogniteClient';
 export { default as DateParser } from './dateParser';
 export * from './baseCogniteClient';
 
+export { BasicHttpClient } from './httpClient/basicHttpClient';
+export { RetryableHttpClient } from './httpClient/retryableHttpClient';
 export { CDFHttpClient } from './httpClient/cdfHttpClient';
 export { CogniteError } from './error';
 export { CogniteMultiError } from './multiError';

--- a/packages/core/typedoc.js
+++ b/packages/core/typedoc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'Cognite JavaScript SDK',
+  name: 'Cognite JavaScript SDK core',
   mode: 'file',
   module: 'umd',
   target: 'ES6',

--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -15,8 +15,9 @@
     "prepublishOnly": "yarn build",
     "build": "yarn clean && rollup -c && yarn esCheck",
     "watch": "rollup -cw",
-    "docs": "typedoc --options typedoc.js --tsconfig tsconfig.json src/index.ts",
     "esCheck": "es-check es5 './dist/index.js'",
+    "docs": "typedoc --options typedoc.js --tsconfig tsconfig.json src/index.ts",
+    "docs:bundle": "yarn docs && mkdir -p ../../docs && cp -r docs/* ../../docs/",
     "extract-snippets": "rm -rf codeSnippets/ && yarn docs --json codeSnippets/docs.json && node ../../scripts/extractCodeSnippets.js",
     "test-snippets": "yarn extract-snippets && yarn tsc -p codeSnippets/tsconfig.build.json"
   },

--- a/packages/stable/src/__tests__/cogniteClient.int.spec.ts
+++ b/packages/stable/src/__tests__/cogniteClient.int.spec.ts
@@ -10,13 +10,13 @@ import {
 } from './testUtils';
 
 describe('createClientWithApiKey - integration', () => {
-  test('handle non-exisiting api-key', async () => {
+  test('handle non-existing api-key', async () => {
     const client = new CogniteClient({
       appId: 'JS Integration test',
     });
     client.loginWithApiKey({
       project: 'cognitesdk-js',
-      apiKey: 'non-exisiting-api-key',
+      apiKey: 'non-existing-api-key',
     });
     await expect(
       client.assets.list({ limit: 1 }).autoPagingToArray({ limit: 1 })

--- a/packages/stable/src/api/datasets/datasetsApi.ts
+++ b/packages/stable/src/api/datasets/datasetsApi.ts
@@ -11,7 +11,7 @@ import {
   IdEither,
 } from '../../types';
 
-export class DataSetsApi extends BaseResourceAPI<DataSet> {
+export class DataSetsAPI extends BaseResourceAPI<DataSet> {
   /**
    * @hidden
    */

--- a/packages/stable/src/cogniteClient.ts
+++ b/packages/stable/src/cogniteClient.ts
@@ -14,7 +14,7 @@ import { Viewer3DAPI } from './api/3d/viewer3DApi';
 import { ApiKeysAPI } from './api/apiKeys/apiKeysApi';
 import { AssetsAPI } from './api/assets/assetsApi';
 import { DataPointsAPI } from './api/dataPoints/dataPointsApi';
-import { DataSetsApi } from './api/datasets/datasetsApi';
+import { DataSetsAPI } from './api/datasets/datasetsApi';
 import { EventsAPI } from './api/events/eventsApi';
 import { FilesAPI } from './api/files/filesApi';
 import { GroupsAPI } from './api/groups/groupsApi';
@@ -101,7 +101,7 @@ export default class CogniteClient extends BaseCogniteClient {
   private models3DApi?: Models3DAPI;
   private revisions3DApi?: Revisions3DAPI;
   private files3DApi?: Files3DAPI;
-  private datasetsApi?: DataSetsApi;
+  private datasetsApi?: DataSetsAPI;
   private assetMappings3DApi?: AssetMappings3DAPI;
   private viewer3DApi?: Viewer3DAPI;
   private apiKeysApi?: ApiKeysAPI;
@@ -124,7 +124,7 @@ export default class CogniteClient extends BaseCogniteClient {
     this.eventsApi = this.apiFactory(EventsAPI, 'events');
     this.filesApi = this.apiFactory(FilesAPI, 'files');
     this.labelsApi = this.apiFactory(LabelsAPI, 'labels');
-    this.datasetsApi = this.apiFactory(DataSetsApi, 'datasets');
+    this.datasetsApi = this.apiFactory(DataSetsAPI, 'datasets');
     this.rawApi = this.apiFactory(RawAPI, 'raw/dbs');
     this.groupsApi = this.apiFactory(GroupsAPI, 'groups');
     this.securityCategoriesApi = this.apiFactory(
@@ -148,14 +148,3 @@ export default class CogniteClient extends BaseCogniteClient {
     );
   }
 }
-
-export {
-  POPUP,
-  REDIRECT,
-  ApiKeyLoginOptions,
-  BaseRequestOptions,
-  ClientOptions,
-  OAuthLoginOptions,
-  Project,
-  Response,
-} from '@cognite/sdk-core';

--- a/packages/stable/src/index.ts
+++ b/packages/stable/src/index.ts
@@ -23,4 +23,39 @@ export {
   REDIRECT,
 } from '@cognite/sdk-core';
 export { default as CogniteClient } from './cogniteClient';
+
+export { AssetMappings3DAPI } from './api/3d/assetMappings3DApi';
+export { Files3DAPI } from './api/3d/files3DApi';
+export { Models3DAPI } from './api/3d/models3DApi';
+export { Nodes3DAPI } from './api/3d/nodes3DApi';
+export { RevealNodes3DAPI } from './api/3d/revealNodes3DApi';
+export { RevealRevisions3DAPI } from './api/3d/revealRevisions3DApi';
+export { RevealSectors3DAPI } from './api/3d/revealSectors3DApi';
+export { Revisions3DAPI } from './api/3d/revisions3DApi';
+export { UnrealRevisions3DAPI } from './api/3d/unrealRevisions3DApi';
+export { Viewer3DAPI } from './api/3d/viewer3DApi';
+export { ApiKeysAPI } from './api/apiKeys/apiKeysApi';
+export { AssetsAPI } from './api/assets/assetsApi';
+export { DataPointsAPI } from './api/dataPoints/dataPointsApi';
+export { DataSetsAPI } from './api/datasets/datasetsApi';
+export { EventsAggregateAPI } from './api/events/eventsAggregateApi';
+export { EventsAPI } from './api/events/eventsApi';
+export { FilesAPI } from './api/files/filesApi';
+export { GroupsAPI } from './api/groups/groupsApi';
+export { LabelsAPI } from './api/labels/labelsApi';
+export { ProjectsAPI } from './api/projects/projectsApi';
+export { RawAPI } from './api/raw/rawApi';
+export { RawRowsAPI } from './api/raw/rawRowsApi';
+export { RawTablesAPI } from './api/raw/rawTablesApi';
+export {
+  SecurityCategoriesAPI,
+} from './api/securityCategories/securityCategoriesApi';
+export { SequenceRowsAPI } from './api/sequences/sequenceRowsApi';
+export { SequencesAPI } from './api/sequences/sequencesApi';
+export { ServiceAccountsAPI } from './api/serviceAccounts/serviceAccountsApi';
+export {
+  SyntheticTimeSeriesAPI,
+} from './api/timeSeries/syntheticTimeSeriesApi';
+export { TimeSeriesAPI } from './api/timeSeries/timeSeriesApi';
+
 export * from './types';

--- a/packages/template/LICENSE
+++ b/packages/template/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/template/README.md
+++ b/packages/template/README.md
@@ -1,0 +1,9 @@
+Cognite Javascript SDK (derived)
+================================
+This package provides an SDK derived from `@cognite/sdk`, aka
+[stable](https://github.com/cognitedata/cognite-sdk-js/blob/master/packages/stable/README.md).
+
+It is recomended to install this package under the same name as `@cognite/sdk`.
+This allows you to change SDK versions without changing your imports.
+See the [beta readme](https://github.com/cognitedata/cognite-sdk-js/blob/master/packages/beta/README.md) for details.
+

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,0 +1,30 @@
+{
+  "private": true,
+  "name": "@cognite/sdk-template",
+  "license": "Apache-2.0",
+  "repository": "cognitedata/cognite-sdk-js",
+  "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
+  "main": "dist/index.js",
+  "types": "dist/src/index.d.js",
+  "version": "0.0.0",
+  "scripts": {
+    "clean": "rm -rf dist/ docs/ codeSnippets/",
+    "test": "jest --config=../../jest.config.js --testPathPattern=/template/",
+    "lint": "eslint 'src/**/*.{js,ts}'",
+    "lint:fix": "yarn lint --fix",
+    "prepublishOnly": "yarn build",
+    "build": "yarn clean && rollup -c && yarn esCheck",
+    "watch": "rollup -cw",
+    "esCheck": "es-check es5 './dist/index.js'",
+    "docs": "typedoc --options typedoc.js --tsconfig tsconfig.json src/index.ts",
+    "extract-snippets": "rm -rf codeSnippets/ && yarn docs --json codeSnippets/docs.json && node ../../scripts/extractCodeSnippets.js",
+    "test-snippets": "yarn extract-snippets && yarn tsc -p codeSnippets/tsconfig.build.json"
+  },
+  "dependencies": {
+    "@cognite/sdk": "^3.0.0",
+    "@cognite/sdk-core": "^1.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/template/rollup.config.js
+++ b/packages/template/rollup.config.js
@@ -1,0 +1,44 @@
+import typescript from '@rollup/plugin-typescript';
+import pkg from './package.json';
+import json from '@rollup/plugin-json';
+
+export default {
+  input: 'src/index.ts',
+  output: [
+    {
+      dir: 'dist',
+      format: 'cjs',
+      sourcemap: true,
+    },
+  ],
+  external: [
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {}),
+  ],
+  plugins: [
+    typescript({
+      tsconfig: './tsconfig.build.json',
+      typescript: require('typescript'),
+      exclude: '**/__tests__/**',
+    }),
+    json({
+      // All JSON files will be parsed by default,
+      // but you can also specifically include/exclude files
+      include: ['./package.json'],
+
+      // for tree-shaking, properties will be declared as
+      // variables, using either `var` or `const`
+      preferConst: false, // Default: false
+
+      // specify indentation for the generated default export —
+      // defaults to '\t'
+      indent: '  ',
+
+      // ignores indent and generates the smallest code
+      compact: true, // Default: false
+
+      // generate a named export for every property of the JSON object
+      namedExports: true, // Default: true
+    }),
+  ],
+};

--- a/packages/template/src/__tests__/cogniteClient.int.spec.ts
+++ b/packages/template/src/__tests__/cogniteClient.int.spec.ts
@@ -1,0 +1,20 @@
+// Copyright 2020 Cognite AS
+
+import CogniteClient from '../cogniteClient';
+import { setupLoggedInClient } from './testUtils';
+
+describe('derived integration', () => {
+  let client: CogniteClient;
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+  });
+  // test that the client behaves as stable
+  test('assets list', async () => {
+    const response = await client.assets.list();
+    expect(response.items.length).toBeGreaterThan(0);
+  });
+  test('raw get assets', async () => {
+    const response = await client.get('/api/v1/projects/cognitesdk-js/assets');
+    expect(response.data).toHaveProperty('items');
+  });
+});

--- a/packages/template/src/__tests__/testUtils.ts
+++ b/packages/template/src/__tests__/testUtils.ts
@@ -1,0 +1,21 @@
+// Copyright 2020 Cognite AS
+
+import { Constants } from '@cognite/sdk-core';
+import CogniteClient from '../cogniteClient';
+import { name } from '../../package.json';
+
+export function setupClient(baseUrl: string = Constants.BASE_URL) {
+  return new CogniteClient({
+    appId: `JS SDK integration tests (${name})`,
+    baseUrl,
+  });
+}
+
+export function setupLoggedInClient() {
+  const client = setupClient();
+  client.loginWithApiKey({
+    project: process.env.COGNITE_PROJECT as string,
+    apiKey: process.env.COGNITE_CREDENTIALS as string,
+  });
+  return client;
+}

--- a/packages/template/src/cogniteClient.ts
+++ b/packages/template/src/cogniteClient.ts
@@ -4,7 +4,6 @@ import {
   CogniteClient as CogniteClientStable,
 } from '@cognite/sdk';
 import { version } from '../package.json';
-import { accessApi } from '@cognite/sdk-core';
 
 export default class CogniteClient extends CogniteClientStable {
   /**

--- a/packages/template/src/cogniteClient.ts
+++ b/packages/template/src/cogniteClient.ts
@@ -1,0 +1,21 @@
+// Copyright 2020 Cognite AS
+import {
+  ClientOptions,
+  CogniteClient as CogniteClientStable,
+} from '@cognite/sdk';
+import { version } from '../package.json';
+import { accessApi } from '@cognite/sdk-core';
+
+export default class CogniteClient extends CogniteClientStable {
+  /**
+   * Create a new SDK client (derived)
+   * @param options Client options
+   */
+  constructor(options: ClientOptions) {
+    super(options);
+  }
+
+  protected get version() {
+    return `${version}-derived`;
+  }
+}

--- a/packages/template/src/index.ts
+++ b/packages/template/src/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2020 Cognite AS
+
+export * from '@cognite/sdk';
+export { default as CogniteClient } from './cogniteClient';

--- a/packages/template/src/types.ts
+++ b/packages/template/src/types.ts
@@ -1,0 +1,5 @@
+// Copyright 2020 Cognite AS
+
+export * from '@cognite/sdk';
+// This file is here mostly to allow apis to import { ... } from '../../types';
+// Overriding types should probably be done in their respective API endpoint files, where possible

--- a/packages/template/tsconfig.build.json
+++ b/packages/template/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build",
+  "compilerOptions": {
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "baseUrl": ".."
+  },
+  "include": ["src/"]
+}

--- a/packages/template/tsconfig.json
+++ b/packages/template/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig"
+}

--- a/packages/template/typedoc.js
+++ b/packages/template/typedoc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  name: 'Cognite JavaScript SDK',
+  
+  // Stable and core use 'file' mode, which makes reference pages based on the names of classes and types.
+  // Derived SDKs usually re-definine classes using the same name, which breaks in file mode.
+  // 'modules' mode makes the file path part of the url, which allows classes with overlapping
+  // names across packages.
+  mode: 'modules',
+  module: 'umd',
+  target: 'ES6',
+  exclude: ['**/__tests__/**', '**/node_modules/**'],
+  out: './docs/',
+  readme: 'README.md',
+  ignoreCompilerErrors: true,
+  excludeNotExported: false,
+  hideGenerator: true,
+  excludePrivate: true,
+  excludeProtected: true,
+  includeDeclarations: true,
+  excludeExternals: false,
+};

--- a/samples/nodejs/package.json
+++ b/samples/nodejs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
-    "@cognite/sdk": "^2"
+    "@cognite/sdk": "^3"
   },
   "scripts": {
     "test": "node quickstart.js && yarn test-for-await",

--- a/samples/typescript/package.json
+++ b/samples/typescript/package.json
@@ -8,7 +8,7 @@
     "test": "yarn tsc && node build/quickstart.js"
   },
   "dependencies": {
-    "@cognite/sdk": "^2"
+    "@cognite/sdk": "^3"
   },
   "devDependencies": {
     "typescript": "^3.9",


### PR DESCRIPTION
Also adds some exports to core and stable, so there are some `feat` commits. (You could change them if you don't want a MINOR bump). Fixes casing in an api class (should not a breaking change, as the type wasn't exported).