### PR TITLE
feat: add logger to sdk-core

### DIFF
--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -14,8 +14,12 @@ import { apiKey, authTokens, project } from '../testUtils';
 
 const mockBaseUrl = 'https://example.com';
 
-function setupClient(baseUrl: string = BASE_URL) {
-  return new BaseCogniteClient({ appId: 'JS SDK integration tests', baseUrl });
+function setupClient(baseUrl: string = BASE_URL, debug: boolean = false) {
+  return new BaseCogniteClient({
+    appId: 'JS SDK integration tests',
+    baseUrl,
+    debug,
+  });
 }
 
 function setupMockableClient() {
@@ -419,6 +423,67 @@ describe('CogniteClient', () => {
           client.get('/');
         });
       });
+    });
+  });
+
+  describe('logger', () => {
+    const errorMessage = `You can only call authenticate after you have called loginWithOAuth`;
+    const loggerFunc = jest.fn();
+    const spyOnConsoleLog = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => {
+        /* ignore console.log */
+      });
+    let client: BaseCogniteClient;
+    beforeEach(() => {
+      client = setupClient();
+      loggerFunc.mockReset();
+      spyOnConsoleLog.mockReset();
+    });
+    afterAll(() => {
+      spyOnConsoleLog.mockRestore();
+    });
+    test('should be disabled by default', async () => {
+      await expect(
+        client.authenticate
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"${errorMessage}"`);
+      expect(spyOnConsoleLog).toHaveBeenCalledTimes(0);
+    });
+
+    test('should call console log if debug option has been set', async () => {
+      client = setupClient(BASE_URL, true);
+
+      await expect(
+        client.authenticate
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"${errorMessage}"`);
+      expect(spyOnConsoleLog).toHaveBeenCalledWith({ message: errorMessage });
+    });
+
+    test('should enable logging if custom logger function has been attached', async () => {
+      client.attachLogger(loggerFunc);
+
+      await expect(
+        client.authenticate
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"${errorMessage}"`);
+      expect(spyOnConsoleLog).toHaveBeenCalledTimes(0);
+      expect(loggerFunc).toHaveBeenCalledWith({ message: errorMessage });
+    });
+
+    test('should detach logger and disable logging', async () => {
+      client.attachLogger(loggerFunc);
+
+      await expect(
+        client.authenticate
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"${errorMessage}"`);
+      expect(loggerFunc).toHaveBeenCalledWith({ message: errorMessage });
+
+      client.detachLogger();
+
+      await expect(
+        client.authenticate
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"${errorMessage}"`);
+      expect(loggerFunc).toHaveBeenCalledTimes(1);
+      expect(spyOnConsoleLog).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/packages/core/src/__tests__/logger.unit.spec.ts
+++ b/packages/core/src/__tests__/logger.unit.spec.ts
@@ -18,33 +18,41 @@ describe('Logger', () => {
   });
 
   test('should call console.log by default', () => {
-    const logger = new Logger(true);
+    const logger = new Logger();
+    const loggerId = 'some-id';
 
-    logger.log(message);
+    logger.attach(loggerId).enable(loggerId);
+    logger.log(loggerId, message);
 
     expect(spyConsoleLog).toHaveBeenCalledWith({ message });
   });
 
   test('should be disabled by default', () => {
     const logger = new Logger();
+    const loggerId = 'some-id';
 
-    logger.log('message');
+    logger.attach(loggerId);
+    logger.log(loggerId, 'message');
 
     expect(spyConsoleLog).toHaveBeenCalledTimes(0);
   });
 
   test('should attach logger if provided', () => {
-    const logger = new Logger(true, mockLogger);
+    const logger = new Logger();
+    const loggerId = 'some-id';
 
-    logger.log(message);
+    logger.attach(loggerId, mockLogger).enable(loggerId);
+    logger.log(loggerId, message);
 
     expect(mockLogger).toHaveBeenCalledWith({ message });
   });
 
   test('should call logger with data if provided', () => {
-    const logger = new Logger(true);
+    const logger = new Logger();
+    const loggerId = 'some-id';
 
-    logger.attach(mockLogger).log({ message, data });
+    logger.attach(loggerId, mockLogger).enable(loggerId);
+    logger.log(loggerId, { message, data });
 
     expect(mockLogger).toHaveBeenCalledWith({ message, data });
   });

--- a/packages/core/src/__tests__/logger.unit.spec.ts
+++ b/packages/core/src/__tests__/logger.unit.spec.ts
@@ -1,0 +1,51 @@
+import { Logger } from '../logger';
+
+describe('Logger', () => {
+  const spyConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {
+    /* ignore console.log */
+  });
+  const mockLogger = jest.fn();
+  const message = 'message';
+  const data = { test: 'test' };
+
+  beforeEach(() => {
+    spyConsoleLog.mockClear();
+    mockLogger.mockReset();
+  });
+
+  afterAll(() => {
+    spyConsoleLog.mockRestore();
+  });
+
+  test('should call console.log by default', () => {
+    const logger = new Logger(true);
+
+    logger.log(message);
+
+    expect(spyConsoleLog).toHaveBeenCalledWith({ message });
+  });
+
+  test('should be disabled by default', () => {
+    const logger = new Logger();
+
+    logger.log('message');
+
+    expect(spyConsoleLog).toHaveBeenCalledTimes(0);
+  });
+
+  test('should attach logger if provided', () => {
+    const logger = new Logger(true, mockLogger);
+
+    logger.log(message);
+
+    expect(mockLogger).toHaveBeenCalledWith({ message });
+  });
+
+  test('should call logger with data if provided', () => {
+    const logger = new Logger(true);
+
+    logger.attach(mockLogger).log({ message, data });
+
+    expect(mockLogger).toHaveBeenCalledWith({ message, data });
+  });
+});

--- a/packages/core/src/__tests__/login.spec.ts
+++ b/packages/core/src/__tests__/login.spec.ts
@@ -72,8 +72,8 @@ describe('Login', () => {
         await loginSilently(httpClient, authorizeParams);
       } catch ({ message, data = {} }) {
         errorMessage = message;
-        error = data.error
-        errorDescr = data.errorDescription
+        error = data.error;
+        errorDescr = data.errorDescription;
       }
       expect(errorMessage).toBe(`Failed to parse token query parameters`);
       expect(error).toBe(`failed`);
@@ -88,28 +88,31 @@ describe('Login', () => {
       );
       spiedCreateElement.mockReturnValueOnce(iframe);
 
-      try {
-        await loginSilently(httpClient, authorizeParams, onLoginFailed);
-      } catch (_) {}
+      await loginSilently(httpClient, authorizeParams, onLoginFailed);
 
-      expect(onLoginFailed.mock.calls[0][0].data).toEqual({error: 'failed', errorDescription: 'message'});
+      expect(onLoginFailed.mock.calls[0][0].data).toEqual({
+        error: 'failed',
+        errorDescription: 'message',
+      });
     });
 
     test('trigger onLoginFailed on nullable token query', async () => {
       const onLoginFailed = jest.fn();
-      const iframeUrl = `?query=true`
+      const iframeUrl = `?query=true`;
       window.history.pushState({}, '', '/abc/def');
-      const iframe = createIframe(iframeUrl)
+      const iframe = createIframe(iframeUrl);
       spiedCreateElement.mockReturnValueOnce(iframe);
 
-      try {
-        await loginSilently(httpClient, authorizeParams, onLoginFailed);
-      } catch (_) {}
-      const {message, data : {url, params}} = onLoginFailed.mock.calls[0][0];
+      await loginSilently(httpClient, authorizeParams, onLoginFailed);
+
+      const {
+        message,
+        data: { url, params },
+      } = onLoginFailed.mock.calls[0][0];
 
       expect(message).toBe(`Failed to login due nullable tokens`);
       expect(url && params).toBeTruthy();
-    })
+    });
 
     function createIframe(search: string) {
       return {

--- a/packages/core/src/__tests__/login.spec.ts
+++ b/packages/core/src/__tests__/login.spec.ts
@@ -3,7 +3,7 @@
 import nock from 'nock';
 import { AUTHORIZATION_HEADER } from '../constants';
 import { CDFHttpClient } from '../httpClient/cdfHttpClient';
-import { logger } from '../logger';
+import { logger, LoggerEventTypes } from '../logger';
 import {
   getIdInfoFromAccessToken,
   loginSilently,
@@ -92,6 +92,7 @@ describe('Login', () => {
       await loginSilently(httpClient, authorizeParams);
 
       expect(loggerFunc.mock.calls[0][0].data).toEqual({
+        type: LoggerEventTypes.Error,
         query: iframeUrl,
         error: 'failed',
         errorDescription: 'message',
@@ -108,11 +109,11 @@ describe('Login', () => {
 
       const {
         message,
-        data: { url, params },
+        data: { url, params, type },
       } = loggerFunc.mock.calls[0][0];
 
       expect(message).toBe(`Failed to login due nullable tokens`);
-      expect(url && params).toBeTruthy();
+      expect(url && params && type).toBeTruthy();
     });
 
     function createIframe(search: string) {

--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -133,9 +133,10 @@ export default class BaseCogniteClient {
   }
 
   public authenticate: () => Promise<boolean> = async () => {
-    throw Error(
-      'You can only call authenticate after you have called loginWithOAuth'
-    );
+    const message = `You can only call authenticate after you have called loginWithOAuth`;
+
+    this.logger.log(message);
+    throw Error(message);
   };
 
   public get project() {
@@ -238,6 +239,7 @@ export default class BaseCogniteClient {
       httpClient: this.httpClient,
       onAuthenticate,
       onTokens,
+      logger: this.logger,
     });
 
     this.httpClient.set401ResponseHandler(async (_, retry, reject) => {

--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -16,6 +16,7 @@ import {
   HttpResponse,
 } from './httpClient/basicHttpClient';
 import { CDFHttpClient } from './httpClient/cdfHttpClient';
+import { Logger, LoggerFunc } from './logger';
 import {
   createAuthenticateFunction,
   OnAuthenticate,
@@ -34,6 +35,7 @@ export interface ClientOptions {
   /** App identifier (ex: 'FileExtractor') */
   appId: string;
   baseUrl?: string;
+  debug?: boolean;
 }
 
 export interface Project {
@@ -90,6 +92,7 @@ export default class BaseCogniteClient {
   private hasBeenLoggedIn: boolean = false;
   private loginApi: LoginAPI;
   private logoutApi: LogoutApi;
+  private logger: Logger;
   /**
    * Create a new SDK client
    *
@@ -126,6 +129,7 @@ export default class BaseCogniteClient {
     this.metadata = new MetadataMap();
     this.loginApi = new LoginAPI(this.httpClient, this.metadataMap);
     this.logoutApi = new LogoutApi(this.httpClient, this.metadataMap);
+    this.logger = new Logger(options.debug);
   }
 
   public authenticate: () => Promise<boolean> = async () => {
@@ -357,6 +361,14 @@ export default class BaseCogniteClient {
 
   public setOneTimeSdkHeader(value: string) {
     this.httpClient.addOneTimeHeader(X_CDF_SDK_HEADER, value);
+  }
+
+  public attachLogger(logger: LoggerFunc) {
+    this.logger.attach(logger).enable();
+  }
+
+  public detachLogger() {
+    this.logger.detach().disable();
   }
 
   protected initAPIs() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export { CogniteError } from './error';
 export { CogniteMultiError } from './multiError';
 export { CogniteLoginError } from './loginError';
 export { HttpError } from './httpClient/httpError';
+export { LoggerFunc, LoggerEventTypes } from './logger';
 export {
   HttpResponse,
   HttpHeaders,

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -8,7 +8,6 @@ export interface LoggerEventData {
 
 export enum LoggerEventTypes {
   Error = 'error',
-  Warning = 'warning',
 }
 
 export interface LoggerEvent {

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,53 @@
+// Copyright 2020 Cognite AS
+export type LoggerFunc = (event: LoggerEvent) => void;
+
+export interface LoggerEventData {
+  [key: string]: any;
+}
+
+export interface LoggerEvent {
+  message: string;
+  data?: LoggerEventData;
+}
+
+const defaultLogger = (event: LoggerEvent) => console.log(event);
+
+export class Logger {
+  private logger: LoggerFunc;
+  private active: boolean;
+
+  constructor(active = false, logger?: LoggerFunc) {
+    this.logger = logger || defaultLogger;
+    this.active = active;
+  }
+
+  public log(event: string | LoggerEvent) {
+    if (!this.active) {
+      return;
+    }
+
+    const loggedEvent = typeof event === 'string' ? { message: event } : event;
+
+    this.logger(loggedEvent);
+  }
+
+  public enable() {
+    this.active = true;
+  }
+
+  public disable() {
+    this.active = false;
+  }
+
+  public attach(logger: LoggerFunc): Logger {
+    this.logger = logger;
+
+    return this;
+  }
+
+  public detach(): Logger {
+    this.logger = defaultLogger;
+
+    return this;
+  }
+}

--- a/packages/core/src/login.ts
+++ b/packages/core/src/login.ts
@@ -113,7 +113,7 @@ export async function loginSilently(
     }
   } catch (error) {
     if (onLoginFailed) {
-      onLoginFailed(error)
+      onLoginFailed(error);
     }
   }
 
@@ -243,7 +243,10 @@ function parseTokenQueryParameters(query: string): null | AuthTokens {
   } = parse(query);
   if (error !== undefined) {
     throw new CogniteLoginError(`Failed to parse token query parameters`, {
-      accessToken, idToken, error, errorDescription
+      accessToken,
+      idToken,
+      error,
+      errorDescription,
     });
   }
   if (isString(accessToken) && isString(idToken)) {
@@ -276,7 +279,10 @@ async function silentLogin(params: AuthorizeParams): Promise<AuthTokens> {
           iframe.contentWindow!.location.search
         );
         if (authTokens === null) {
-          throw new CogniteLoginError('Failed to login due nullable tokens', {params, url})
+          throw new CogniteLoginError('Failed to login due nullable tokens', {
+            params,
+            url,
+          });
         }
         resolve(authTokens);
       } catch (e) {

--- a/packages/core/src/login.ts
+++ b/packages/core/src/login.ts
@@ -243,6 +243,7 @@ function parseTokenQueryParameters(query: string): null | AuthTokens {
   } = parse(query);
   if (error !== undefined) {
     throw new CogniteLoginError(`Failed to parse token query parameters`, {
+      query,
       accessToken,
       idToken,
       error,

--- a/packages/core/src/login.ts
+++ b/packages/core/src/login.ts
@@ -242,8 +242,6 @@ function parseTokenQueryParameters(query: string): null | AuthTokens {
   if (error !== undefined) {
     throw new CogniteLoginError(`Failed to parse token query parameters`, {
       query,
-      accessToken,
-      idToken,
       error,
       errorDescription,
     });

--- a/packages/core/src/loginError.ts
+++ b/packages/core/src/loginError.ts
@@ -1,11 +1,11 @@
 // Copyright 2020 Cognite AS
 
 export class CogniteLoginError extends Error {
-  public data: { [key: string]: any };
-  constructor(message?: string, data?: { [key: string]: any }) {
-    super(message || 'Not able to login');
-
-    this.data = data || {};
+  constructor(
+    message: string = 'Not able to login',
+    public data: { [key: string]: any } = {}
+  ) {
+    super(message);
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);

--- a/packages/core/src/loginError.ts
+++ b/packages/core/src/loginError.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 
 export class CogniteLoginError extends Error {
-  public data: {[key: string]: any}
+  public data: { [key: string]: any };
   constructor(message?: string, data?: { [key: string]: any }) {
     super(message || 'Not able to login');
 

--- a/packages/core/src/loginError.ts
+++ b/packages/core/src/loginError.ts
@@ -1,11 +1,15 @@
 // Copyright 2020 Cognite AS
 
+import { LoggerEventTypes } from './logger';
+
 export class CogniteLoginError extends Error {
   constructor(
     message: string = 'Not able to login',
     public data: { [key: string]: any } = {}
   ) {
     super(message);
+
+    this.data = { type: LoggerEventTypes.Error, ...this.data };
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);

--- a/packages/core/src/loginError.ts
+++ b/packages/core/src/loginError.ts
@@ -1,8 +1,12 @@
 // Copyright 2020 Cognite AS
 
 export class CogniteLoginError extends Error {
-  constructor(message?: string) {
+  public data: {[key: string]: any}
+  constructor(message?: string, data?: { [key: string]: any }) {
     super(message || 'Not able to login');
+
+    this.data = data || {};
+
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     } else {


### PR DESCRIPTION
Added ability to provide logger function to the `sdk-core`. For now, the logger will be called only in places inside `loginSilently` method, which don't expose error and catch it inside sdk. Can be used to cover with logging other places in the code.