### PR TITLE
fix: fileAPI upload endpoint

### DIFF
--- a/packages/core/src/__tests__/utils.unit.spec.ts
+++ b/packages/core/src/__tests__/utils.unit.spec.ts
@@ -9,7 +9,7 @@ import {
   sleepPromise,
   promiseEachInSequence,
   promiseAllAtOnce,
-  isJson
+  isJson,
 } from '../utils';
 
 describe('utils', () => {
@@ -149,5 +149,5 @@ describe('utils', () => {
 
   test('should isJson returns false in case of ArrayBuffer', () => {
     expect(isJson(new ArrayBuffer(16))).toBeFalsy();
-  })
+  });
 });

--- a/packages/core/src/__tests__/utils.unit.spec.ts
+++ b/packages/core/src/__tests__/utils.unit.spec.ts
@@ -9,6 +9,7 @@ import {
   sleepPromise,
   promiseEachInSequence,
   promiseAllAtOnce,
+  isJson
 } from '../utils';
 
 describe('utils', () => {
@@ -145,4 +146,8 @@ describe('utils', () => {
   test('isUsingSSL', () => {
     expect(isUsingSSL()).toBeTruthy();
   });
+
+  test('should isJson returns false in case of ArrayBuffer', () => {
+    expect(isJson(new ArrayBuffer(16))).toBeFalsy();
+  })
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,7 +2,6 @@
 
 import isObject from 'lodash/isObject';
 import isArray from 'lodash/isArray';
-import { isBuffer } from 'util';
 import { API_VERSION, BASE_URL } from './constants';
 import { CogniteError } from './error';
 import { CogniteMultiError } from './multiError';
@@ -51,7 +50,8 @@ export function convertToTimestampToDateTime(timestamp: number): Date {
 export function isJson(data: any) {
   return (
     (isArray(data) || isObject(data)) &&
-    !isBuffer(data) &&
+    !Buffer.isBuffer(data) &&
+    !(data instanceof ArrayBuffer) &&
     !(data instanceof Date)
   );
 }


### PR DESCRIPTION
Fixes `upload` endpoint of `FilesAPI` by preventing content-type header changes based on `isJson` check of the request body. 
Previously, `isJson` returns `true` for `ArrayBuffer` request body type and set `content-type: application/json` header instead of provided content-type header in params.
[release]