### PR TITLE
fix: beta re-export bug

### DIFF
--- a/packages/beta/rollup.config.js
+++ b/packages/beta/rollup.config.js
@@ -9,6 +9,7 @@ export default {
       dir: 'dist',
       format: 'cjs',
       sourcemap: true,
+      externalLiveBindings: false,
     },
   ],
   external: [

--- a/packages/beta/src/api/relationships/relationshipsApi.ts
+++ b/packages/beta/src/api/relationships/relationshipsApi.ts
@@ -6,9 +6,20 @@ import {
   ExternalId,
 } from '@cognite/sdk-core';
 import { IgnoreUnknownIds } from '@cognite/sdk';
-import { Relationship, RelationshipsFilterRequest } from '../../types';
+import {
+  ExternalRelationship,
+  Relationship,
+  RelationshipsFilterRequest,
+} from '../../types';
 
 export class RelationshipsApi extends BaseResourceAPI<Relationship> {
+  /**
+   * @hidden
+   */
+  protected getDateProps() {
+    return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
+  }
+
   /**
    * [Create relationship](https://docs.cognite.com/api/v1/#operation/createRelationships)
    *
@@ -25,7 +36,7 @@ export class RelationshipsApi extends BaseResourceAPI<Relationship> {
    * const createdRelationships = await client.relationships.create(relationships);
    * ```
    */
-  public create = (items: Relationship[]): Promise<Relationship[]> => {
+  public create = (items: ExternalRelationship[]): Promise<Relationship[]> => {
     return this.createEndpoint(items);
   };
 

--- a/packages/beta/src/api/relationships/relationshipsApi.ts
+++ b/packages/beta/src/api/relationships/relationshipsApi.ts
@@ -5,11 +5,8 @@ import {
   CursorAndAsyncIterator,
   ExternalId,
 } from '@cognite/sdk-core';
-import {
-  IgnoreUnknownIds,
-  Relationship,
-  RelationshipsFilterRequest,
-} from '../../types';
+import { IgnoreUnknownIds } from '@cognite/sdk';
+import { Relationship, RelationshipsFilterRequest } from '../../types';
 
 export class RelationshipsApi extends BaseResourceAPI<Relationship> {
   /**

--- a/packages/beta/src/cogniteClient.ts
+++ b/packages/beta/src/cogniteClient.ts
@@ -34,7 +34,6 @@ export default class CogniteClient extends CogniteClientCleaned {
    */
   constructor(options: ClientOptions) {
     super(options);
-    this.httpClient.setDefaultHeader('version', 'beta');
   }
 
   public get relationships() {

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -13,7 +13,6 @@ import {
   LabelFilter,
 } from '@cognite/sdk';
 
-export * from '@cognite/sdk';
 // This file is here mostly to allow apis to import { ... } from '../../types';
 // Overriding types should probably be done in their respective API endpoint files, where possible
 

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -11,6 +11,7 @@ import {
   Timestamp,
   Range,
   LabelFilter,
+  CreatedAndLastUpdatedTime,
 } from '@cognite/sdk';
 
 // This file is here mostly to allow apis to import { ... } from '../../types';
@@ -23,7 +24,7 @@ export type RelationshipResourceType =
   | 'event'
   | 'sequence';
 
-export interface Relationship {
+export interface ExternalRelationship {
   /**
    * External id of the relationship, must be unique within the project
    */
@@ -72,6 +73,10 @@ export interface Relationship {
    */
   labels?: Label[];
 }
+
+export interface Relationship
+  extends ExternalRelationship,
+    CreatedAndLastUpdatedTime {}
 
 export interface RelationshipsFilterRequest extends FilterQuery {
   /**


### PR DESCRIPTION
For now, beta package can't redefine `CogniteClient` instance of the sdk stable version in commonJS module builder by Rollup.JS


![image](https://user-images.githubusercontent.com/24567091/95179613-8bc9a100-07c9-11eb-8b0a-1133576814da.png)


This PR fixes this issue by disabling external live bindings (https://rollupjs.org/guide/en/#outputexternallivebindings)