### PR TITLE
feat: Publish wells sdk

### DIFF
--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -11,11 +11,45 @@ It is recomended to install this package under the same name as `@cognite/sdk`.
 This allows you to change SDK versions without changing your imports.
 See the [beta readme](https://github.com/cognitedata/cognite-sdk-js/blob/master/packages/beta/README.md) for details.
 
-### build
+### install and build
 
 ```bash
-yarn
+yarn install
 yarn build
+```
+
+### consuming
+
+##### set your env variables (must be valid for both cdf and geospatial API)
+
+```bash
+COGNITE_WELLS_PROJECT=<project-tenant>
+COGNITE_WELLS_CREDENTIALS=<your-api-key>
+```
+
+##### setup client
+
+```bash
+let client: CogniteClient = setupLoggedInClient()
+```
+
+##### run a query
+
+```bash
+    const polygon = <GeoJson>{
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-4.86423, 63.59999],
+          [19.86423, 63.59999],
+          [19.86423, 52.59999],
+          [-4.86423, 52.59999],
+          [-4.86423, 63.59999],
+        ],
+      ],
+    };
+
+    const response = await client.wells.getWellsByPolygon({geometry: polygon});
 ```
 
 ### Testing the wells package only

--- a/packages/wells/package.json
+++ b/packages/wells/package.json
@@ -1,12 +1,12 @@
 {
-  "private": true,
+  "private": false,
   "name": "@cognite/sdk-wells",
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.js",
   "types": "dist/src/index.d.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",
     "test": "jest --config=../../jest.config.js --testPathPattern=/wells/",
@@ -22,7 +22,7 @@
     "test-snippets": "yarn extract-snippets && yarn tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/geospatial-sdk-js": "^0.0.3",
+    "@cognite/geospatial-sdk-js": "^0.0.4",
     "@cognite/sdk": "^3.0.0",
     "@cognite/sdk-core": "^1.0.0"
   },

--- a/packages/wells/package.json
+++ b/packages/wells/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@cognite/geospatial-sdk-js": "^0.0.4",
     "@cognite/sdk": "^3.0.0",
-    "@cognite/sdk-core": "^1.0.0"
+    "@cognite/sdk-core": "^1.0.0",
+    "wkt": "^0.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -45,14 +45,12 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
   });
 
   test('get well by polygon', async () => {
-    const response = await client.wells.getWellsByPolygon(
-      'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))',
-      'wellmodel',
-      'epsg:4326',
-      'point',
-      1,
-      0
-    );
+    const response = await client.wells.getWellsByPolygon({
+      polygon:
+        'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))',
+      limit: 1,
+      offset: 0,
+    });
 
     response.forEach(function(well) {
       expect(well.name.startsWith('Well')).toBe(true);

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -45,9 +45,11 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
   });
 
   test('get well by polygon', async () => {
+    const polygon =
+      'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))';
+
     const response = await client.wells.getWellsByPolygon({
-      polygon:
-        'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))',
+      geometry: polygon,
       limit: 1,
       offset: 0,
     });

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -2,6 +2,7 @@
 
 import { setupLoggedInClient } from '../testUtils';
 import CogniteClient from '../../client/cogniteClient';
+import { GeoJson } from 'wells/src/client/model/GeoJson';
 
 // suggested solution/hack for conditional tests: https://github.com/facebook/jest/issues/3652#issuecomment-385262455
 const describeIfCondition =
@@ -44,9 +45,35 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
     expect(response.length).toBe(1);
   });
 
-  test('get well by polygon', async () => {
+  test('get well by polygon wkt', async () => {
     const polygon =
       'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))';
+
+    const response = await client.wells.getWellsByPolygon({
+      geometry: polygon,
+      limit: 1,
+      offset: 0,
+    });
+
+    response.forEach(function(well) {
+      expect(well.name.startsWith('Well')).toBe(true);
+    });
+    expect(response.length).toBe(2);
+  });
+
+  test('get well by geoJson', async () => {
+    const polygon = <GeoJson>{
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-4.86423, 63.59999],
+          [19.86423, 63.59999],
+          [19.86423, 52.59999],
+          [-4.86423, 52.59999],
+          [-4.86423, 63.59999],
+        ],
+      ],
+    };
 
     const response = await client.wells.getWellsByPolygon({
       geometry: polygon,

--- a/packages/wells/src/__tests__/unit/geoJson.int.spec.ts
+++ b/packages/wells/src/__tests__/unit/geoJson.int.spec.ts
@@ -1,0 +1,5 @@
+describe('GeoJson unit tests', () => {
+  test('convert GeoJson to WKT (well-known text)', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/packages/wells/src/__tests__/unit/geoJson.int.spec.ts
+++ b/packages/wells/src/__tests__/unit/geoJson.int.spec.ts
@@ -1,5 +1,28 @@
+import { GeoJson, Polygon, Geometry } from 'wells/src/client/model/GeoJson';
+import {
+  stringify as convertGeoJsonToWKT,
+  parse as convertWKTToGeoJson,
+} from 'wkt';
+
 describe('GeoJson unit tests', () => {
   test('convert GeoJson to WKT (well-known text)', () => {
-    expect(1).toBe(1);
+    const polygon = <GeoJson>{
+      type: 'Polygon',
+      coordinates: [[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]],
+    };
+
+    const originalGeometry = <Geometry>{
+      type: 'wellmodel',
+      geometry: <GeoJson>polygon,
+    };
+
+    const originalWkt = <string>convertGeoJsonToWKT(originalGeometry.geometry);
+    const reproducedGeoJson = <Polygon>convertWKTToGeoJson(originalWkt);
+
+    const poly1 = <GeoJson>originalGeometry.geometry;
+    const poly2 = <GeoJson>reproducedGeoJson;
+
+    expect(poly1.type).toBe(poly2.type);
+    expect(poly2.coordinates.pop.length).toBe(poly1.coordinates.pop.length);
   });
 });

--- a/packages/wells/src/client/api/utils.ts
+++ b/packages/wells/src/client/api/utils.ts
@@ -6,14 +6,3 @@ export const geospatialClient = CogniteGeospatialClient({
   api_key: process.env.COGNITE_WELLS_CREDENTIALS as string,
   api_url: Constants.BASE_URL,
 });
-
-export enum SpatialRelationshipNameDTO {
-  Within = 'within',
-  WithinDistance = 'withinDistance',
-  WithinCompletely = 'withinCompletely',
-  Intersect = 'intersect',
-  Within3d = 'within3d',
-  WithinDistance3d = 'withinDistance3d',
-  WithinCompletely3d = 'withinCompletely3d',
-  Intersect3d = 'intersect3d',
-}

--- a/packages/wells/src/client/api/wells.ts
+++ b/packages/wells/src/client/api/wells.ts
@@ -3,6 +3,10 @@ import { Asset, AssetsAPI, IdEither } from '@cognite/sdk';
 import { Well } from '../model/Well';
 import { WellHeadLocation } from '../model/WellHeadLocation';
 import { geospatialClient } from './utils';
+import {
+  stringify as convertGeoJsonToWKT,
+  parse as convertWKTToGeoJson,
+} from 'wkt';
 
 export class Wells extends AssetsAPI {
   /**
@@ -194,3 +198,12 @@ export class Wells extends AssetsAPI {
     return await this.getWellsByIds(assetIds);
   };
 }
+
+const geometry = {
+  type: 'Point',
+  coordinates: [125.6, 10.1, 54.2],
+};
+
+//  See return values in output section
+const wkt = convertGeoJsonToWKT(geometry);
+convertWKTToGeoJson(wkt);

--- a/packages/wells/src/client/api/wells.ts
+++ b/packages/wells/src/client/api/wells.ts
@@ -133,7 +133,7 @@ export class Wells extends AssetsAPI {
   };
 
   /**
-   * Receives a geoJson polygon like in Discover and return a list of well objects
+   * Receives a geoJson or wkt polygon like in Discover and return a list of well objects
    *
    * ```js
    * const created = await client.wells.getWellsByPolygon(....);
@@ -150,15 +150,19 @@ export class Wells extends AssetsAPI {
   public getWellsByPolygon = async ({
     geometry,
     source = 'wellmodel',
+    layer = 'point',
     crs = 'epsg:4326',
-    layerName = 'point',
+    outputCrs = 'EPSG:4326',
+    attributes = ['geometry'],
     limit = 1000,
     offset = 0,
   }: {
     geometry: string | GeoJson;
     source?: string;
+    layer?: string;
     crs?: string;
-    layerName?: string;
+    outputCrs?: string;
+    attributes?: string[];
     limit?: number;
     offset?: number;
   }): Promise<Well[]> => {
@@ -180,11 +184,13 @@ export class Wells extends AssetsAPI {
     do {
       /*eslint-disable */
       var page = await geospatialClient.findSpatial({
-        layer: layerName,
+        layer: layer,
         source: source,
+        attributes: attributes,
         geometry_rel: geometryRelBody,
         limit: limit,
         offset: offset,
+        outputCRS: outputCrs,
       });
       points.push.apply(points, page);
       /*eslint-enable */

--- a/packages/wells/src/client/api/wells.ts
+++ b/packages/wells/src/client/api/wells.ts
@@ -3,10 +3,8 @@ import { Asset, AssetsAPI, IdEither } from '@cognite/sdk';
 import { Well } from '../model/Well';
 import { WellHeadLocation } from '../model/WellHeadLocation';
 import { geospatialClient } from './utils';
-import {
-  stringify as convertGeoJsonToWKT,
-  parse as convertWKTToGeoJson,
-} from 'wkt';
+import { stringify as convertGeoJsonToWKT } from 'wkt';
+import { GeoJson } from '../model/GeoJson';
 
 export class Wells extends AssetsAPI {
   /**
@@ -150,20 +148,23 @@ export class Wells extends AssetsAPI {
    */
 
   public getWellsByPolygon = async ({
-    polygon,
+    geometry,
     source = 'wellmodel',
     crs = 'epsg:4326',
     layerName = 'point',
     limit = 1000,
     offset = 0,
   }: {
-    polygon: string;
+    geometry: string | GeoJson;
     source?: string;
     crs?: string;
     layerName?: string;
     limit?: number;
     offset?: number;
   }): Promise<Well[]> => {
+    const polygon =
+      typeof geometry === 'string' ? geometry : convertGeoJsonToWKT(geometry);
+
     const geometryBody = {
       wkt: polygon,
       crs: crs,
@@ -198,12 +199,3 @@ export class Wells extends AssetsAPI {
     return await this.getWellsByIds(assetIds);
   };
 }
-
-const geometry = {
-  type: 'Point',
-  coordinates: [125.6, 10.1, 54.2],
-};
-
-//  See return values in output section
-const wkt = convertGeoJsonToWKT(geometry);
-convertWKTToGeoJson(wkt);

--- a/packages/wells/src/client/api/wells.ts
+++ b/packages/wells/src/client/api/wells.ts
@@ -1,7 +1,8 @@
+import { SpatialRel } from '@cognite/geospatial-sdk-js';
 import { Asset, AssetsAPI, IdEither } from '@cognite/sdk';
 import { Well } from '../model/Well';
 import { WellHeadLocation } from '../model/WellHeadLocation';
-import { geospatialClient, SpatialRelationshipNameDTO } from './utils';
+import { geospatialClient } from './utils';
 
 export class Wells extends AssetsAPI {
   /**
@@ -143,14 +144,22 @@ export class Wells extends AssetsAPI {
    * @param limit max number of objects to be returned
    * @param offset the starting offset of objects in the results
    */
-  public getWellsByPolygon = async (
-    polygon: string,
-    source: string,
-    crs: string,
-    layerName: string,
-    limit: number = 1000,
-    offset: number = 0
-  ): Promise<Well[]> => {
+
+  public getWellsByPolygon = async ({
+    polygon,
+    source = 'wellmodel',
+    crs = 'epsg:4326',
+    layerName = 'point',
+    limit = 1000,
+    offset = 0,
+  }: {
+    polygon: string;
+    source?: string;
+    crs?: string;
+    layerName?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Well[]> => {
     const geometryBody = {
       wkt: polygon,
       crs: crs,
@@ -158,7 +167,7 @@ export class Wells extends AssetsAPI {
 
     const geometryRelBody = {
       geometry: geometryBody,
-      relation: SpatialRelationshipNameDTO.Within,
+      relation: SpatialRel.Within,
     };
 
     const points: any[] = [];

--- a/packages/wells/src/client/model/GeoJson.ts
+++ b/packages/wells/src/client/model/GeoJson.ts
@@ -1,19 +1,3 @@
-// Type definitions for wkt
-// Project: https://github.com/benrei/wkt
-// Definitions by: Adam Tombleson rekarnar@gmail.com
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-const { stringify } = require('wkt');
-const { parse } = require('wkt');
-
-const geometry = {
-  type: 'Point',
-  coordinates: [125.6, 10.1, 54.2],
-};
-
-//  See return values in output section
-const wkt = stringify(geometry);
-parse(wkt);
-
 /* Types */
 
 export type GEOJSONPoint = [number, number]; // DEPRECATED <- use LngLatLike instead

--- a/packages/wells/src/client/model/GeoJson.ts
+++ b/packages/wells/src/client/model/GeoJson.ts
@@ -1,0 +1,71 @@
+// Type definitions for wkt
+// Project: https://github.com/benrei/wkt
+// Definitions by: Adam Tombleson rekarnar@gmail.com
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+const { stringify } = require('wkt');
+const { parse } = require('wkt');
+
+const geometry = {
+  type: 'Point',
+  coordinates: [125.6, 10.1, 54.2],
+};
+
+//  See return values in output section
+const wkt = stringify(geometry);
+parse(wkt);
+
+/* Types */
+
+export type GEOJSONPoint = [number, number]; // DEPRECATED <- use LngLatLike instead
+
+/* Interfaces */
+
+export interface GeoJson {
+  /**
+   * @type {string}
+   * @memberof GeoJson
+   */
+  id?: string;
+  /**
+   * @type {string}
+   * @memberof GeoJson
+   */
+  type?: string;
+  /**
+   * @type {any}
+   * @memberof GeoJson
+   */
+  properties?: any;
+  /**
+   * @type {Geometry}
+   * @memberof GeoJson
+   */
+  geometry: Geometry;
+}
+
+export interface GeometryPoint {
+  /**
+   * @type {string}
+   * @memberof GeometryPoint
+   */
+  type: string;
+
+  /**
+   * @type {GEOJSONPoint}
+   * @memberof GeometryPoint
+   */
+  coordinates: GEOJSONPoint;
+}
+
+export interface Geometry {
+  /**
+   * @type {string}
+   * @memberof Geometry
+   */
+  type: string;
+  /**
+   * @type {GeometryPoint[]}
+   * @memberof Geometry
+   */
+  coordinates: GEOJSONPoint[];
+}

--- a/packages/wells/src/client/model/GeoJson.ts
+++ b/packages/wells/src/client/model/GeoJson.ts
@@ -1,10 +1,12 @@
 /* Types */
 
-export type GEOJSONPoint = [number, number]; // DEPRECATED <- use LngLatLike instead
+export type Point2D = [number, number];
+
+export type GeoJson = Point | Polygon;
 
 /* Interfaces */
 
-export interface GeoJson {
+export interface Geometry {
   /**
    * @type {string}
    * @memberof GeoJson
@@ -24,32 +26,31 @@ export interface GeoJson {
    * @type {Geometry}
    * @memberof GeoJson
    */
-  geometry: Geometry;
+  geometry: GeoJson;
 }
 
-export interface GeometryPoint {
+export interface Point {
   /**
    * @type {string}
-   * @memberof GeometryPoint
+   * @memberof Point
    */
-  type: string;
-
+  type: 'Point';
   /**
-   * @type {GEOJSONPoint}
-   * @memberof GeometryPoint
+   * @type {Point2D}
+   * @memberof Point
    */
-  coordinates: GEOJSONPoint;
+  coordinates: Point2D;
 }
 
-export interface Geometry {
+export interface Polygon {
   /**
    * @type {string}
-   * @memberof Geometry
+   * @memberof Polygon
    */
-  type: string;
+  type: 'Polygon';
   /**
    * @type {GeometryPoint[]}
    * @memberof Geometry
    */
-  coordinates: GEOJSONPoint[];
+  coordinates: Point2D[][];
 }

--- a/packages/wells/src/typings/wkt.d.ts
+++ b/packages/wells/src/typings/wkt.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for wkt
+// Project: https://github.com/benrei/wkt
+// Definitions by: Adam Tombleson rekarnar@gmail.com
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+declare module 'wkt' {
+  function stringify(geoJSON: object): string;
+  function parse(wkt: string): object;
+}

--- a/packages/wells/tsconfig.build.json
+++ b/packages/wells/tsconfig.build.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "declarationDir": "dist",
     "outDir": "dist",
-    "baseUrl": ".."
+    "baseUrl": "..",
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
-  "include": ["src/"]
+  "include": ["src/"],
+  "exclude": ["node_modules", "build", "typings"]
 }


### PR DESCRIPTION
[SBS-2708] - Handle union of GeoJson and polygon wkt input for method getWellsByPolygon

You can now fetch wells by either a polygon [ WKT (well-known text)](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) or by [GeoJson](https://geojson.org/).

I have also made the package public (v0.0.1). @mrtraser does my package.json look right?

ps! had to create a new PR due to commit lint.

[SBS-2708]: https://cognitedata.atlassian.net/browse/SBS-2708