### PR TITLE
feat: export dataclasses, types and Wells to SDK

### DIFF
--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -27,29 +27,39 @@ COGNITE_WELLS_PROJECT=<project-tenant>
 COGNITE_WELLS_CREDENTIALS=<your-api-key>
 ```
 
-##### setup client
+#### setup client
 
 ```bash
-let client: CogniteClient = setupLoggedInClient()
+const { CogniteClient } = require("@cognite/sdk-wells");
+
+let client = new CogniteClient({
+  appId: `JS SDK test (${name})`,
+  baseUrl: "https://api.cognitedata.com",
+});
+
+client.loginWithApiKey({
+  project: process.env.COGNITE_WELLS_PROJECT,
+  apiKey: process.env.COGNITE_WELLS_CREDENTIALS,
+});
 ```
 
-##### run a query
+#### run a query
 
 ```bash
-    const polygon = <GeoJson>{
-      type: 'Polygon',
-      coordinates: [
-        [
-          [-4.86423, 63.59999],
-          [19.86423, 63.59999],
-          [19.86423, 52.59999],
-          [-4.86423, 52.59999],
-          [-4.86423, 63.59999],
-        ],
-      ],
-    };
+const polygon = <GeoJson>{
+    type: 'Polygon',
+    coordinates: [
+    [
+        [-4.86423, 63.59999],
+        [19.86423, 63.59999],
+        [19.86423, 52.59999],
+        [-4.86423, 52.59999],
+        [-4.86423, 63.59999],
+    ],
+    ],
+};
 
-    const response = await client.wells.getWellsByPolygon({geometry: polygon});
+const response = await client.wells.getWellsByPolygon({geometry: polygon});
 ```
 
 ![query](figures/wells-sdk.png)

--- a/packages/wells/rollup.config.js
+++ b/packages/wells/rollup.config.js
@@ -9,7 +9,7 @@ export default {
       dir: 'dist',
       format: 'cjs',
       sourcemap: true,
-      externalLiveBindings: true,
+      externalLiveBindings: false,
     },
   ],
   external: [

--- a/packages/wells/rollup.config.js
+++ b/packages/wells/rollup.config.js
@@ -9,6 +9,7 @@ export default {
       dir: 'dist',
       format: 'cjs',
       sourcemap: true,
+      externalLiveBindings: true,
     },
   ],
   external: [

--- a/packages/wells/src/__tests__/unit/geoJson.int.spec.ts
+++ b/packages/wells/src/__tests__/unit/geoJson.int.spec.ts
@@ -2,7 +2,7 @@ import {
   stringify as convertGeoJsonToWKT,
   parse as convertWKTToGeoJson,
 } from 'wkt';
-import { GeoJson, Polygon, Geometry } from 'wells/src/client/model/GeoJson';
+import { GeoJson, Polygon } from 'wells/src/client/model/GeoJson';
 
 describe('GeoJson unit tests', () => {
   test('convert GeoJson to WKT (well-known text)', () => {
@@ -11,7 +11,7 @@ describe('GeoJson unit tests', () => {
       coordinates: [[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]],
     };
 
-    const originalGeometry = <Geometry>{
+    const originalGeometry = {
       type: 'wellmodel',
       geometry: <GeoJson>polygon,
     };

--- a/packages/wells/src/client/model/GeoJson.ts
+++ b/packages/wells/src/client/model/GeoJson.ts
@@ -4,31 +4,6 @@ export type Point2D = [number, number];
 
 export type GeoJson = Point | Polygon;
 
-/* Interfaces */
-
-export interface Geometry {
-  /**
-   * @type {string}
-   * @memberof Geometry
-   */
-  id?: string;
-  /**
-   * @type {string}
-   * @memberof Geometry
-   */
-  type?: string;
-  /**
-   * @type {any}
-   * @memberof Geometry
-   */
-  properties?: any;
-  /**
-   * @type {Geometry}
-   * @memberof Geometry
-   */
-  geometry: GeoJson;
-}
-
 export interface Point {
   /**
    * @type {string}

--- a/packages/wells/src/index.ts
+++ b/packages/wells/src/index.ts
@@ -2,3 +2,9 @@
 
 export * from '@cognite/sdk';
 export { default as CogniteClient } from './client/cogniteClient';
+export { Wells } from './client/api/wells';
+
+// dataclasses and types
+export * from './client/model/Well';
+export * from './client/model/GeoJson';
+export * from './client/model/WellHeadLocation';


### PR DESCRIPTION
So, I just recently published the first version of the cognite/sdk-wells to npm [@cognite/sdk-wells](https://www.npmjs.com/package/@cognite/sdk-wells). I then tried to create a small javascript project to import the sdk and run the client. However, there seems to be an issue occurring in the `index.ts` of the wells-sdk when doing the import `const { CogniteClient } = require("@cognite/sdk-wells");` where I get a `exports.CogniteClient = CogniteClient; TypeError: Cannot set property CogniteClient of #<Object> which has only a getter`. This is how the code-snippet looks: 

![image](https://user-images.githubusercontent.com/25263842/96462047-699e3d00-1225-11eb-8c29-88a42f78210e.png)

and this is the stack trace when executing the import at **line 2** of `app.js`:

![image](https://user-images.githubusercontent.com/25263842/96462163-876ba200-1225-11eb-939e-f3b5df77d550.png)

I then looked in the `README.MD` for the [derived-sdk](https://github.com/cognitedata/cognite-sdk-js/blob/master/guides/derived_SDKs.md) and noticed that I had forgotten to export the new classes and interfaces, so I have added them in now. I think that might cause some troubles when using the sdk, but is it the root cause of the error @cognitedata/core-api ? Because it seems to me that the root cause is that the `CogniteClient` does not contain a `setter()` as described by:

![image](https://user-images.githubusercontent.com/25263842/96463846-71f77780-1227-11eb-80dc-36501d9735c1.png)

It might be that the lack of exports in the `index.ts` is the root cause, and that the TypeError is the most current exception and that there is a prior exception in the inner exception property that is really where things start failing. What is your thoughts here? FYI this is the CogniteClient extension for the wells package: 
![image](https://user-images.githubusercontent.com/25263842/96464574-4923b200-1228-11eb-9abe-61367069f25f.png)
