### PR TITLE
feat: add wellbores search to wells sdk [release]

### DIFF
--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -22,7 +22,7 @@ yarn install
 yarn build
 ```
 
-### consuming
+## consuming
 
 ##### set your env variables (must be valid for both cdf and geospatial API)
 
@@ -31,14 +31,14 @@ COGNITE_WELLS_PROJECT=<project-tenant>
 COGNITE_WELLS_CREDENTIALS=<your-api-key>
 ```
 
-#### setup client
+### setup client
 
-```bash
-const { CogniteClient } = require("@cognite/sdk-wells");
+```js
+const { CogniteClient } = require('@cognite/sdk-wells');
 
 let client = new CogniteClient({
   appId: `JS SDK test (${name})`,
-  baseUrl: "https://api.cognitedata.com",
+  baseUrl: 'https://api.cognitedata.com',
 });
 
 client.loginWithApiKey({
@@ -47,42 +47,84 @@ client.loginWithApiKey({
 });
 ```
 
+### well queries
+
 #### run a polygon query by GeoJson
 
-```bash
+```js
 const polygon = {
-    type: 'Polygon',
-    coordinates: [
+  type: 'Polygon',
+  coordinates: [
     [
-        [-4.86423, 63.59999],
-        [19.86423, 63.59999],
-        [19.86423, 52.59999],
-        [-4.86423, 52.59999],
-        [-4.86423, 63.59999],
+      [-4.86423, 63.59999],
+      [19.86423, 63.59999],
+      [19.86423, 52.59999],
+      [-4.86423, 52.59999],
+      [-4.86423, 63.59999],
     ],
-    ],
+  ],
 };
 
-const response = await client.wells.searchByPolygon({geometry: polygon});
+const response = await client.wells.searchByPolygon({ geometry: polygon });
 ```
 
 #### run a polygon query by wkt
 
-```bash
-const polygon = 'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))';
+```js
+const polygon =
+  'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))';
 
-const response = await client.wells.searchByPolygon({geometry: polygon});
+const response = await client.wells.searchByPolygon({ geometry: polygon });
 ```
 
-#### run a polygon query by wkt
+#### run a custom query
 
-```bash
-const polygon = 'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))';
+```js
+const polygon =
+  'POLYGON ((-4.86423 63.59999, 19.86423 63.59999, 19.86423 52.59999, -4.86423 52.59999, -4.86423 63.59999))';
 
-const response = await client.wells.getWellsByPolygon({geometry: polygon});
+// create a custom method
+const fn: SearchWells = async (geometry: GeoJson) =>
+  await someClient.myCustomPolygonSearch({ geometry: geometry });
+
+// input that custom filter
+const response = await client.wells.searchByPolygon({
+  geometry: polygon,
+  customFilter: fn,
+});
 ```
 
-![query](figures/wells-sdk.png)
+### wellbore queries
+
+#### List all wellbores in tenant
+
+```js
+const response = await client.wellbores.listAll();
+```
+
+#### List immediate children wellbore of parentId
+
+```js
+const wellId = 2278618537691581;
+const response = await client.wellbores.listChildren(wellId);
+```
+
+#### List all wellbores (all levels of subtree) from wellId
+
+```js
+const rootId = 4438800495523058;
+const response = await client.wellbores.listByWellI(rootId);
+```
+
+#### Custom method for listing wellbores
+
+```js
+const fn: SearchWellbores = async (args: number) =>
+  await myClient.customWellboresMethod(args);
+
+const rootId = 4438800495523058;
+const response = await client.wellbores.listByWellId(rootId, fn);
+```
 
 ### Testing the wells package only
 

--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -113,7 +113,7 @@ const response = await client.wellbores.listChildren(wellId);
 
 ```js
 const rootId = 4438800495523058;
-const response = await client.wellbores.listByWellI(rootId);
+const response = await client.wellbores.listByWellId(rootId);
 ```
 
 #### Custom method for listing wellbores

--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -4,6 +4,10 @@
 
 # Cognite Wells JS SDK (derived from stable)
 
+The purpose of the wells-sdk is to build a layer on top of the core CDF API that allows for interpreting and querying data in the context of the Cognite well model / wells data layer. The well model / wells data layer is a representation of how well data can be described and modeled in terms of Cognite’s reusable resources (assets, sequences, geospatial, etc).
+
+The importance of such a representation is being able to concatenate data from different sources into a single contextualized representation that is independent of source and customer. This allows both apps, such as Discover, and also geoscientists running models on top of well data, to be able to find the data they need and use it without having to consider where this data came from and what is its original format.
+
 This package provides an SDK derived from `@cognite/sdk`, aka
 [stable](https://github.com/cognitedata/cognite-sdk-js/blob/master/packages/stable/README.md).
 

--- a/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
@@ -3,11 +3,8 @@
 import { setupLoggedInClient } from '../testUtils';
 import CogniteClient from '../../client/cogniteClient';
 import { SearchWellbores } from 'wells/src/client/model/Wellbore';
-//import { SearchWellbores, SearchWellbore } from 'wells/src/client/model/Wellbore';
-//import { assert } from 'console';
 
 // suggested solution/hack for conditional tests: https://github.com/facebook/jest/issues/3652#issuecomment-385262455
-
 const describeIfCondition =
   process.env.COGNITE_WELLS_PROJECT && process.env.COGNITE_WELLS_CREDENTIALS
     ? describe
@@ -21,16 +18,62 @@ describeIfCondition(
       client = setupLoggedInClient();
     });
 
-    test('standard filter - get all wellbores', async () => {
+    test('standard filter - list all wellbores', async () => {
       const response = await client.wellbores.listAll();
       expect(response.length).toBe(5);
+      response.forEach(element => {
+        expect(element.name).toContain('Wellbore');
+      });
     });
 
-    test('custom filter - get all wellbores', async () => {
+    test('custom filter - list all wellbores', async () => {
       const fn: SearchWellbores = async () => await client.wellbores.listAll();
 
       const response = await client.wellbores.listAll(fn);
       expect(response.length).toBe(5);
+      response.forEach(element => {
+        expect(element.name).toContain('Wellbore');
+      });
+    });
+
+    test('standard filter - list immediate children wellbores', async () => {
+      const wellId = 2278618537691581;
+      const response = await client.wellbores.listChildren(wellId);
+      response.forEach(element => {
+        expect(element.parentId).toBe(wellId);
+      });
+    });
+
+    test('custom filter - list immediate children wellbores ', async () => {
+      const fn: SearchWellbores = async (args: number) =>
+        await client.wellbores.listChildren(args);
+
+      const wellId = 2278618537691581;
+      const response = await client.wellbores.listChildren(wellId, fn);
+      response.forEach(element => {
+        expect(element.parentId).toBe(wellId);
+      });
+    });
+
+    test('standard filter - list all children ', async () => {
+      const rootId = 4438800495523058;
+      const response = await client.wellbores.listByWellId(rootId);
+      expect(response.length).toBe(5);
+      response.forEach(element => {
+        if (element.metadata) expect(element.metadata['type']).toBe('Wellbore');
+      });
+    });
+
+    test('custom filter - list all children ', async () => {
+      const fn: SearchWellbores = async (args: number) =>
+        await client.wellbores.listByWellId(args);
+
+      const rootId = 4438800495523058;
+      const response = await client.wellbores.listByWellId(rootId, fn);
+      expect(response.length).toBe(5);
+      response.forEach(element => {
+        if (element.metadata) expect(element.metadata['type']).toBe('Wellbore');
+      });
     });
   }
 );

--- a/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
@@ -1,0 +1,36 @@
+// Copyright 2020 Cognite AS
+
+import { setupLoggedInClient } from '../testUtils';
+import CogniteClient from '../../client/cogniteClient';
+import { SearchWellbores } from 'wells/src/client/model/Wellbore';
+//import { SearchWellbores, SearchWellbore } from 'wells/src/client/model/Wellbore';
+//import { assert } from 'console';
+
+// suggested solution/hack for conditional tests: https://github.com/facebook/jest/issues/3652#issuecomment-385262455
+
+const describeIfCondition =
+  process.env.COGNITE_WELLS_PROJECT && process.env.COGNITE_WELLS_CREDENTIALS
+    ? describe
+    : describe.skip;
+
+describeIfCondition(
+  'CogniteClient setup in wellbores - integration test',
+  () => {
+    let client: CogniteClient;
+    beforeAll(async () => {
+      client = setupLoggedInClient();
+    });
+
+    test('standard filter - get all wellbores', async () => {
+      const response = await client.wellbores.listAll();
+      expect(response.length).toBe(5);
+    });
+
+    test('custom filter - get all wellbores', async () => {
+      const fn: SearchWellbores = async () => await client.wellbores.listAll();
+
+      const response = await client.wellbores.listAll(fn);
+      expect(response.length).toBe(5);
+    });
+  }
+);

--- a/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
@@ -55,7 +55,7 @@ describeIfCondition(
       });
     });
 
-    test('standard filter - list all children ', async () => {
+    test('standard filter - list all children wellbores', async () => {
       const rootId = 4438800495523058;
       const response = await client.wellbores.listByWellId(rootId);
       expect(response.length).toBe(5);
@@ -64,7 +64,7 @@ describeIfCondition(
       });
     });
 
-    test('custom filter - list all children ', async () => {
+    test('custom filter - list all children wellbores', async () => {
       const fn: SearchWellbores = async (args: number) =>
         await client.wellbores.listByWellId(args);
 

--- a/packages/wells/src/client/api/wellbores.ts
+++ b/packages/wells/src/client/api/wellbores.ts
@@ -30,13 +30,13 @@ export class Wellbores extends AssetsAPI {
    * A generic template for searching wellbores based on strict filtering and/or fuzzy filtering
    *
    * ```js
-   * const created = await client.wellbores.listAssets(exactSearch: {key: val}, fuzzySearch: {key: val});
+   * const created = await client.wellbores.searchAssets(exactSearch: {key: val}, fuzzySearch: {key: val});
    * ```
    *
    * @param exactSearch Filter on assets with strict matching.
    * @param fuzzySearch Fulltext search for assets. Primarily meant for for human-centric use-cases, not for programs.
    */
-  private listAssets = async (
+  private searchAssets = async (
     exactSearch = {},
     fuzzySearch = {}
   ): Promise<Asset[]> => {
@@ -55,7 +55,7 @@ export class Wellbores extends AssetsAPI {
   };
 
   /**
-   * Get all wellbores
+   * List all wellbores
    *
    * ```js
    * const created = await client.wells.listAll();
@@ -69,6 +69,50 @@ export class Wellbores extends AssetsAPI {
     if (customFilter) {
       return await customFilter();
     }
-    return Wellbores.mapToWellbore(await this.listAssets());
+    return Wellbores.mapToWellbore(await this.searchAssets());
+  };
+
+  /**
+   * Get all wellbores that are immediate children of an parentId
+   *
+   * ```js
+   * const created = await client.wellbores.listChildren(parentId: 31647372237);
+   * ```
+   *
+   * @param parentId the parent Id of a particular asset
+   * @param customFilter a custom filter you can apply, input: any -> output: Promise<Wellbore[]>
+   */
+  public listChildren = async (
+    parentId: number,
+    customFilter?: SearchWellbores
+  ) => {
+    if (customFilter) {
+      return await customFilter(parentId);
+    }
+
+    const exactSearch = { parentIds: [parentId] };
+    return Wellbores.mapToWellbore(await this.searchAssets(exactSearch));
+  };
+
+  /**
+   * List assets (wellbores) in subtrees rooted at the specified assets (wells)
+   *
+   * ```js
+   * const created = await client.wellbores.listByWellId(wellId: 21646274724);
+   * ```
+   *
+   * @param parentId the parent Id of a particular asset
+   * @param customFilter a custom filter you can apply, input: any -> output: Promise<Wellbore[]>
+   */
+  public listByWellId = async (
+    wellId: number,
+    customFilter?: SearchWellbores
+  ) => {
+    if (customFilter) {
+      return await customFilter(wellId);
+    }
+
+    const exactSearch = { assetSubtreeIds: [{ id: wellId }] };
+    return Wellbores.mapToWellbore(await this.searchAssets(exactSearch));
   };
 }

--- a/packages/wells/src/client/api/wellbores.ts
+++ b/packages/wells/src/client/api/wellbores.ts
@@ -1,6 +1,6 @@
 //import { SpatialRel, GeometryRel } from '@cognite/geospatial-sdk-js';
 import { Asset, AssetsAPI } from '@cognite/sdk';
-import { Wellbore } from '../model/Wellbore';
+import { SearchWellbores, Wellbore } from '../model/Wellbore';
 //import { WellHeadLocation } from '../model/WellHeadLocation';
 //import { geospatialClient } from './utils';
 //import { GeoJson } from '../model/GeoJson';
@@ -17,17 +17,26 @@ export class Wellbores extends AssetsAPI {
    */
   static mapToWellbore = (assets: Asset[]): Wellbore[] => {
     return assets.map(asset => {
-      return <Wellbore>(<unknown>{
+      return <Wellbore>{
         id: asset.id,
         name: asset.name,
         parentId: asset.parentId,
         metadata: asset.metadata,
-      });
+      };
     });
   };
 
-  /*
-  private searchForWellbore = async (
+  /**
+   * A generic template for searching wellbores based on strict filtering and/or fuzzy filtering
+   *
+   * ```js
+   * const created = await client.wellbores.listAssets(exactSearch: {key: val}, fuzzySearch: {key: val});
+   * ```
+   *
+   * @param exactSearch Filter on assets with strict matching.
+   * @param fuzzySearch Fulltext search for assets. Primarily meant for for human-centric use-cases, not for programs.
+   */
+  private listAssets = async (
     exactSearch = {},
     fuzzySearch = {}
   ): Promise<Asset[]> => {
@@ -44,5 +53,22 @@ export class Wellbores extends AssetsAPI {
     };
     return await this.search(body);
   };
-  */
+
+  /**
+   * Get all wellbores
+   *
+   * ```js
+   * const created = await client.wells.listAll();
+   * ```
+   *
+   * @param customFilter a custom filter you can apply, input: any -> output: Promise<Wellbore[]>
+   */
+  public listAll = async (
+    customFilter?: SearchWellbores
+  ): Promise<Wellbore[]> => {
+    if (customFilter) {
+      return await customFilter();
+    }
+    return Wellbores.mapToWellbore(await this.listAssets());
+  };
 }

--- a/packages/wells/src/client/api/wellbores.ts
+++ b/packages/wells/src/client/api/wellbores.ts
@@ -1,9 +1,5 @@
-//import { SpatialRel, GeometryRel } from '@cognite/geospatial-sdk-js';
 import { Asset, AssetsAPI } from '@cognite/sdk';
 import { SearchWellbores, Wellbore } from '../model/Wellbore';
-//import { WellHeadLocation } from '../model/WellHeadLocation';
-//import { geospatialClient } from './utils';
-//import { GeoJson } from '../model/GeoJson';
 
 export class Wellbores extends AssetsAPI {
   /**
@@ -36,19 +32,13 @@ export class Wellbores extends AssetsAPI {
    * @param exactSearch Filter on assets with strict matching.
    * @param fuzzySearch Fulltext search for assets. Primarily meant for for human-centric use-cases, not for programs.
    */
-  private searchAssets = async (
-    exactSearch = {},
-    fuzzySearch = {}
-  ): Promise<Asset[]> => {
+  private searchAssets = async (exactSearch = {}): Promise<Asset[]> => {
     const body = {
       filter: {
         metadata: {
           type: 'Wellbore',
         },
         ...exactSearch,
-      },
-      search: {
-        ...fuzzySearch,
       },
     };
     return await this.search(body);

--- a/packages/wells/src/client/api/wellbores.ts
+++ b/packages/wells/src/client/api/wellbores.ts
@@ -1,0 +1,48 @@
+//import { SpatialRel, GeometryRel } from '@cognite/geospatial-sdk-js';
+import { Asset, AssetsAPI } from '@cognite/sdk';
+import { Wellbore } from '../model/Wellbore';
+//import { WellHeadLocation } from '../model/WellHeadLocation';
+//import { geospatialClient } from './utils';
+//import { GeoJson } from '../model/GeoJson';
+
+export class Wellbores extends AssetsAPI {
+  /**
+   * converts asset into a wellbore
+   *
+   * ```js
+   * var wells: WellHeadLocation = Wellbores.mapToWellHeadLocation(asset);
+   * ```
+   *
+   * @param asset
+   */
+  static mapToWellbore = (assets: Asset[]): Wellbore[] => {
+    return assets.map(asset => {
+      return <Wellbore>(<unknown>{
+        id: asset.id,
+        name: asset.name,
+        parentId: asset.parentId,
+        metadata: asset.metadata,
+      });
+    });
+  };
+
+  /*
+  private searchForWellbore = async (
+    exactSearch = {},
+    fuzzySearch = {}
+  ): Promise<Asset[]> => {
+    const body = {
+      filter: {
+        metadata: {
+          type: 'Wellbore',
+        },
+        ...exactSearch,
+      },
+      search: {
+        ...fuzzySearch,
+      },
+    };
+    return await this.search(body);
+  };
+  */
+}

--- a/packages/wells/src/client/api/wells.ts
+++ b/packages/wells/src/client/api/wells.ts
@@ -48,7 +48,7 @@ export class Wells extends AssetsAPI {
    * A generic template for searching wells based on strict filtering and/or fuzzy filtering
    *
    * ```js
-   * const created = await client.wells.searchForWell(exactSearch: {key: val}, fuzzySearch: {key: val});
+   * const created = await client.wells.listAssets(exactSearch: {key: val}, fuzzySearch: {key: val});
    * ```
    *
    * @param exactSearch Filter on assets with strict matching.
@@ -76,7 +76,7 @@ export class Wells extends AssetsAPI {
    * Get wells filtering and/or with fuzzy search on name
    *
    * ```js
-   * const created = await client.wells.getWellByName('name');
+   * const created = await client.wells.listByName('name');
    * ```
    *
    * @param wellName the full name of the well
@@ -98,7 +98,7 @@ export class Wells extends AssetsAPI {
    * Get a list of wells that contains the specified search prefix in the name
    *
    * ```js
-   * const created = await client.wells.getWellsByNamePrefix(namePrefix: 'somePrefix');
+   * const created = await client.wells.listByNamePrefix(namePrefix: 'somePrefix');
    * ```
    *
    * @param namePrefix specify a prefix that the wellname should contain
@@ -125,7 +125,7 @@ export class Wells extends AssetsAPI {
    * Get a multiple wells filtering and/or with fuzzy search on name
    *
    * ```js
-   * const created = await client.wells.getWellsByIds([{id: 123}, {externalId: 'abc'}]);
+   * const created = await client.wells.getByIds([{id: 123}, {externalId: 'abc'}]);
    * ```
    *
    * @param ids contains unions of internal ids and external ids
@@ -146,7 +146,7 @@ export class Wells extends AssetsAPI {
    * Get a single well filtering and/or with fuzzy search on name
    *
    * ```js
-   * const created = await client.wells.getWellById(id: 123);
+   * const created = await client.wells.getById(id: 123);
    * ```
    *
    * @param id specific internal id for a particular well
@@ -168,7 +168,7 @@ export class Wells extends AssetsAPI {
    * Receives a geoJson or wkt polygon like in Discover and return a list of well objects
    *
    * ```js
-   * const created = await client.wells.getWellsByPolygon(....);
+   * const created = await client.wells.searchByPolygon(....);
    * ```
    *
    * @param polygon lat and lon that make up a polygon

--- a/packages/wells/src/client/api/wells.ts
+++ b/packages/wells/src/client/api/wells.ts
@@ -36,11 +36,11 @@ export class Wells extends AssetsAPI {
    */
   static mapToWell = (assets: Asset[]): Well[] => {
     return assets.map(asset => {
-      return <Well>(<unknown>{
+      return <Well>{
         id: asset.id,
         name: asset.name,
         wellHeadLocation: Wells.mapToWellHeadLocation(asset),
-      });
+      };
     });
   };
 

--- a/packages/wells/src/client/cogniteClient.ts
+++ b/packages/wells/src/client/cogniteClient.ts
@@ -2,10 +2,12 @@
 import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
 import { version } from '../../package.json';
 import { Wells } from './api/wells';
+import { Wellbores } from './api/wellbores';
 import { accessApi } from '@cognite/sdk-core';
 
 export default class CogniteClient extends CogniteClientStable {
   private wellsSDK?: Wells;
+  private wellboresSDK?: Wellbores;
 
   protected initAPIs() {
     super.initAPIs();
@@ -16,6 +18,10 @@ export default class CogniteClient extends CogniteClientStable {
 
   get wells(): Wells {
     return accessApi(this.wellsSDK);
+  }
+
+  get wellbores(): Wellbores {
+    return accessApi(this.wellboresSDK);
   }
 
   protected get version() {

--- a/packages/wells/src/client/cogniteClient.ts
+++ b/packages/wells/src/client/cogniteClient.ts
@@ -14,6 +14,7 @@ export default class CogniteClient extends CogniteClientStable {
 
     // Turns into $BASE_URL/api/$API_VERSION/projects/$PROJECT/assets
     this.wellsSDK = this.apiFactory(Wells, 'assets');
+    this.wellboresSDK = this.apiFactory(Wellbores, 'assets');
   }
 
   get wells(): Wells {

--- a/packages/wells/src/client/model/Wellbore.ts
+++ b/packages/wells/src/client/model/Wellbore.ts
@@ -1,6 +1,6 @@
 // Customizable function that takes in CogniteClient and args, and return a promise of a wellbore
-export type SearchWellbores = (args: any) => Promise<Wellbore[]>;
-export type SearchWellbore = (args: any) => Promise<Wellbore>;
+export type SearchWellbores = (args?: any) => Promise<Wellbore[]>;
+export type SearchWellbore = (args?: any) => Promise<Wellbore>;
 
 /**
  * A wellbore is an asset.

--- a/packages/wells/src/client/model/Wellbore.ts
+++ b/packages/wells/src/client/model/Wellbore.ts
@@ -1,0 +1,34 @@
+// Customizable function that takes in CogniteClient and args, and return a promise of a wellbore
+export type SearchWellbores = (args: any) => Promise<Wellbore[]>;
+export type SearchWellbore = (args: any) => Promise<Wellbore>;
+
+/**
+ * A wellbore is an asset.
+ * Each wellbore is part of a well hierarchy
+ * with either a well or another wellbore as it’s parent.
+ * @export
+ * @interface Wellbore
+ */
+export interface Wellbore {
+  /**
+   * @type {number}
+   * @memberof Wellbore
+   */
+  id: number;
+  /**
+   * @type {string}
+   * @memberof Wellbore
+   */
+  name: string;
+  /**
+   * @type {number}
+   * @memberof Wellbore
+   */
+  parentId: number;
+  /**
+   * Custom, application specific metadata. String key -> String value.
+   * @type {{ [key: string]: string; }}
+   * @memberof Well
+   */
+  metadata?: { [key: string]: string };
+}


### PR DESCRIPTION
[SBS-2734] - List method which can return all wellbores from CDF
[SBS-2735] - Extend list method which can return all immediate children
[SBS-2736] - Extend list method to return all children of a given well

also: added more examples to readme and added wellbores to subsurface-test tentant for running integration tests.

[SBS-2734]: https://cognitedata.atlassian.net/browse/SBS-2734
[SBS-2735]: https://cognitedata.atlassian.net/browse/SBS-2735
[SBS-2736]: https://cognitedata.atlassian.net/browse/SBS-2736