### PR TITLE
fix: incorrect rotation types for 3d revision

### DIFF
--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -518,7 +518,7 @@ export interface CreateRevision3D {
    * Global rotation to be applied to the entire model.
    * The rotation is expressed by Euler angles in radians and in XYZ order.
    */
-  rotation?: [boolean, boolean, boolean];
+  rotation?: Tuple3<number>;
   camera?: RevisionCameraProperties;
   /**
    * The file id to a file uploaded to Cognite's Files API.
@@ -1847,7 +1847,7 @@ export interface Revision3D {
    * Global rotation to be applied to the entire model.
    * The rotation is expressed by Euler angles in radians and in XYZ order.
    */
-  rotation?: [number, number, number];
+  rotation?: Tuple3<number>;
   camera?: RevisionCameraProperties;
   /**
    * The status of the revision.


### PR DESCRIPTION
There were few places where I had type errors that came from sdk so I fixed them. 

* consistent Tuple usage 
* `CreateRevision3D` had incorrect rotation type (booleans instead of numbers)
* ~correct type alias for Tuple3(array must have fixed length for Tuple3, just as we have for Tuple2)~ gave up on that one because of failing tests which use empty arrays, IDK if it's intentional so left as it was