### PR TITLE
feat: accessor for filtering 3D Asset Mappings [BND3D-676]

### DIFF
--- a/packages/stable/src/__tests__/api/assetMappings3D.int.spec.ts
+++ b/packages/stable/src/__tests__/api/assetMappings3D.int.spec.ts
@@ -1,21 +1,130 @@
 // Copyright 2020 Cognite AS
 
+import {
+  Asset,
+  AssetMapping3D,
+  Model3D,
+  Node3D,
+  Revision3D,
+} from 'stable/src/types';
 import CogniteClient from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
 
 describe('AssetMappings3D integration test', () => {
   let client: CogniteClient;
+  let model: Model3D;
+  let revision: Revision3D;
+  let asset: Asset;
+  let node: Node3D;
+  let assetMapping: AssetMapping3D;
+
   beforeAll(async () => {
     client = setupLoggedInClient();
+
+    // Find 3D model with revision (there are many models without revisions in the test data)
+    const models = await client.models3D.list().autoPagingToArray();
+    for (const m of models) {
+      const revisions = (await client.revisions3D.list(m.id, {})).items;
+      if (revisions.length > 0) {
+        model = m;
+        revision = revisions[0];
+        break;
+      }
+    }
+    if (model === undefined || revision === undefined) {
+      fail('Could not find 3D model with a valid revision in the test data');
+    }
+
+    [asset] = (await client.assets.list()).items;
+    if (asset === undefined) {
+      fail('Could not find any assets in the test dataset');
+    }
+
+    [node] = (await client.revisions3D.list3DNodes(
+      model.id,
+      revision.id
+    )).items;
+    if (node === undefined) {
+      fail(
+        `Could not find any nodes for 3D model ${model.id}/${
+          revision.id
+        } in the test data`
+      );
+    }
+
+    // Create asset mapping
+    await client.assetMappings3D.create(model.id, revision.id, [
+      {
+        assetId: asset.id,
+        nodeId: node.id,
+      },
+    ]);
+    // Retrieve asset mapping (bug in create causes it not to return treeIndex which we need, see
+    // https://cognitedata.atlassian.net/browse/BND3D-677)
+    [assetMapping] = (await client.assetMappings3D.list(model.id, revision.id, {
+      assetId: asset.id,
+    })).items;
+
+    if (assetMapping === undefined) {
+      fail('Was not able to fetch asset mapping from test data');
+    }
+  });
+
+  afterAll(async () => {
+    await client.assetMappings3D.delete(model.id, revision.id, [
+      { nodeId: node.id, assetId: asset.id },
+    ]);
   });
 
   test('list with wrong intersectsBoundingBox query fails', async () => {
     await expect(
-      client.assetMappings3D.list(1, 1, {
+      client.assetMappings3D.list(model.id, revision.id, {
         intersectsBoundingBox: { min: [], max: [] },
       })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"max and min must have length 3 | code: 400"`
     );
+  });
+
+  test('filter without query succeeds', async () => {
+    const response = await client.assetMappings3D.filter(
+      model.id,
+      revision.id,
+      {}
+    );
+    expect(response.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('filter with nodeIds filter succeeds', async () => {
+    const response = await client.assetMappings3D.filter(
+      model.id,
+      revision.id,
+      {
+        filter: { nodeIds: [assetMapping.nodeId] },
+      }
+    );
+    expect(response.items.length).toBeGreaterThanOrEqual(1); // Test data might contain more than one mapping
+  });
+
+  test('filter with treeIndexes filter succeeds', async () => {
+    const response = await client.assetMappings3D.filter(
+      model.id,
+      revision.id,
+      {
+        filter: { treeIndexes: [assetMapping.treeIndex] },
+      }
+    );
+    expect(response.items.length).toBeGreaterThanOrEqual(1); // Test data might contain more than one mapping
+  });
+
+  test('filter with assetIds filter succeeds', async () => {
+    const response = await client.assetMappings3D.filter(
+      model.id,
+      revision.id,
+      {
+        filter: { assetIds: [assetMapping.assetId] },
+      }
+    );
+    expect(response.items.length).toBeGreaterThanOrEqual(1); // Test data might contain more than one mapping
   });
 });

--- a/packages/stable/src/api/3d/assetMappings3DApi.ts
+++ b/packages/stable/src/api/3d/assetMappings3DApi.ts
@@ -13,13 +13,6 @@ import {
 
 export class AssetMappings3DAPI extends BaseResourceAPI<AssetMapping3D> {
   /**
-   * @override
-   */
-  protected get searchUrl() {
-    return this.url('filter');
-  }
-
-  /**
    * [List 3D asset mappings](https://doc.cognitedata.com/api/v1/#operation/get3DMappings)
    *
    * ```js

--- a/packages/stable/src/api/3d/assetMappings3DApi.ts
+++ b/packages/stable/src/api/3d/assetMappings3DApi.ts
@@ -8,9 +8,17 @@ import {
   CreateAssetMapping3D,
   CursorResponse,
   DeleteAssetMapping3D,
+  Filter3DAssetMappingsQuery,
 } from '../../types';
 
 export class AssetMappings3DAPI extends BaseResourceAPI<AssetMapping3D> {
+  /**
+   * @override
+   */
+  protected get searchUrl() {
+    return this.url('filter');
+  }
+
   /**
    * [List 3D asset mappings](https://doc.cognitedata.com/api/v1/#operation/get3DMappings)
    *
@@ -27,6 +35,30 @@ export class AssetMappings3DAPI extends BaseResourceAPI<AssetMapping3D> {
     return super.listEndpoint(
       params => this.get<CursorResponse<AssetMapping3D[]>>(path, { params }),
       scope
+    );
+  };
+
+  /**
+   * [Filter 3D asset mappings](https://docs.cognite.com/api/v1/#operation/filter3DAssetMappings)
+   *
+   * ```js
+   * const mappings3D = await client.assetMappings3D.filter(3244265346345, 32423454353545, {
+   *   filter: {
+   *     treeIndexes: [1000, 1001, 1002]
+   *   }
+   * });
+   * ```
+   */
+  public filter = (
+    modelId: CogniteInternalId,
+    revisionId: CogniteInternalId,
+    query: Filter3DAssetMappingsQuery
+  ): CursorAndAsyncIterator<AssetMapping3D> => {
+    const path = `${this.encodeUrl(modelId, revisionId)}/list`;
+    return super.listEndpoint(
+      params =>
+        this.post<CursorResponse<AssetMapping3D[]>>(path, { data: params }),
+      query
     );
   };
 

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -416,6 +416,28 @@ export interface AssetMappings3DListFilter extends FilterQuery {
   intersectsBoundingBox?: BoundingBox3D;
 }
 
+export interface AssetMappings3DAssetFilter {
+  assetIds: CogniteInternalId[];
+}
+
+export interface AssetMappings3DNodeFilter {
+  nodeIds: CogniteInternalId[];
+}
+
+export interface AssetMappings3DTreeIndexFilter {
+  treeIndexes: CogniteInternalId[];
+}
+
+export interface Filter3DAssetMappingsQuery extends FilterQuery {
+  /**
+   * A filter for either `assetIds`, `nodeIds` or `treeIndices`.
+   */
+  filter?:
+    | AssetMappings3DAssetFilter
+    | AssetMappings3DNodeFilter
+    | AssetMappings3DTreeIndexFilter;
+}
+
 /**
  * Name of asset. Often referred to as tag.
  */

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -21,8 +21,8 @@
     "test-snippets": "yarn extract-snippets && yarn tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/sdk": "^3.0.0",
-    "@cognite/sdk-core": "^1.0.0"
+    "@cognite/sdk": "^4.0.0",
+    "@cognite/sdk-core": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This enables accessing endpoint https://docs.cognite.com/api/v1/#operation/filter3DAssetMappings from the SDK.