### PR TITLE
fix(timeseries): synthetic/query is a retryable endpoint

### DIFF
--- a/packages/stable/src/retryValidator.ts
+++ b/packages/stable/src/retryValidator.ts
@@ -22,6 +22,7 @@ const ENDPOINTS_TO_RETRY: EndpointList = {
     '/timeseries/data/list',
     '/timeseries/data/latest',
     '/timeseries/data/delete',
+    '/timeseries/synthetic/query',
   ],
 };
 


### PR DESCRIPTION
We are facing `429 Too Many Requests` on BestDay when fetching datapoints. We have too many assets and for each of them we need to fetch related timeseries and then related datapoints. We are already fetching in batches, but the synthetic timeseries endpoint only allows us to batch up to 10 external ids per request.

This list of retryable endpoints was shared in this [Slack thread](https://cognitedata.slack.com/archives/C01819WEKST/p1607512254349300) and I noticed the synthetic was not there.

So I thought adding it to the list might probably help on alleviating the problem.

Let me know if this makes sense.