### PR TITLE
feat: add wellbore source assets [release]

### DIFF
--- a/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
@@ -7,6 +7,7 @@ import { Measurement} from 'wells/src/client/model/Measurement';
 import { Well } from 'wells/src/client/model/Well';
 import { Wellbore } from 'wells/src/client/model/Wellbore';
 import { Survey, SurveyData } from 'wells/src/client/model/Survey';
+import { Asset } from 'wells/src/types';
 
 enum MeasurementType {
   GammaRay = 'GammaRay',
@@ -43,6 +44,27 @@ describeIfCondition(
       expect(trajectory).not.toBeUndefined();
       const data: SurveyData | undefined = await trajectory?.data();
       expect(data).not.toBeUndefined();
+    });
+
+    test('get source assets for wellbore', async () => {
+      expect(client).not.toBeUndefined();
+      const wellId: number = 8269456345006483;
+      const wellbore: Wellbore | undefined = await client.wellbores.getById(wellId)
+      const sources: Asset[] | undefined = await wellbore?.sourceAssets()
+      expect(sources).not.toBeUndefined();
+      expect(sources?.length).toBe(1);
+      const source = sources![0];
+      expect(source.externalId).toBe("EDM:Wellbore:vUUnhh02Jz")
+    });
+  
+    test('get source assets for wellbore of type EDM', async() => {
+      const wellId: number = 8269456345006483;
+      const wellbore: Wellbore | undefined = await client.wellbores.getById(wellId)
+      const sources = await wellbore?.sourceAssets("EDM")
+      expect(sources).not.toBeUndefined();
+      expect(sources?.length).toBe(1);
+      const source = sources![0];
+      expect(source.externalId).toBe("EDM:Wellbore:vUUnhh02Jz")
     });
 
     test('Succeed to get wellbore measurement for measurementType: GammaRay', async () => {

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -6,6 +6,7 @@ import { Well, WellItems } from 'wells/src/client/model/Well';
 import { Wellbore } from 'wells/src/client/model/Wellbore'
 import { WellFilter, MeasurementFilter, MeasurementFilters } from 'wells/src/client/model/WellFilter';
 import { GeoJson } from 'wells/src/client/model/GeoJson';
+import { Asset } from 'wells/src/types';
 
 enum MeasurementType {
   GammaRay = 'GammaRay',
@@ -39,6 +40,27 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
     /* eslint-disable */
     expect(well?.id).toBe(wellId);
     /* eslint-enable */
+  });
+
+  test('get source assets for well', async () => {
+    expect(client).not.toBeUndefined();
+    const wellId: number = 5432591169464385;
+    const well: Well | undefined = await client.wells.getById(wellId)
+    const sources: Asset[] | undefined = await well?.sourceAssets()
+    expect(sources).not.toBeUndefined();
+    expect(sources?.length).toBe(1);
+    const source = sources![0];
+    expect(source.externalId).toBe("EDM:Well:Qj2k7uJdSe")
+  });
+
+  test('get source assets for well of type EDM', async() => {
+    const wellId: number = 5432591169464385;
+    const well: Well | undefined = await client.wells.getById(wellId)
+    const sources: Asset[] | undefined = await well?.sourceAssets("EDM")
+    expect(sources).not.toBeUndefined();
+    expect(sources?.length).toBe(1);
+    const source = sources![0];
+    expect(source.externalId).toBe("EDM:Well:Qj2k7uJdSe")
   });
 
   test('get by id - get wellbores', async () => {

--- a/packages/wells/src/client/api/wellboresApi.ts
+++ b/packages/wells/src/client/api/wellboresApi.ts
@@ -6,6 +6,7 @@ import { Wellbore } from '../model/Wellbore';
 import { SurveysAPI } from './surveysApi';
 import HttpClientWithIntercept from '../httpClientWithIntercept';
 import { WellIds } from '../model/WellIds';
+import { Asset } from 'wells/src/types';
 
 export class WellboresAPI {
   private client?: HttpClientWithIntercept;
@@ -40,9 +41,26 @@ export class WellboresAPI {
       name: wellbore.name,
       externalId: wellbore.externalId,
       wellId: wellbore.wellId,
-      trajectory: async (): Promise<Survey | undefined>  => {return await this.surveys.getTrajectory(wellbore.id).then(response => response).catch(err => err)}
+      trajectory: async (): Promise<Survey | undefined>  => {return await this.surveys.getTrajectory(wellbore.id).then(response => response).catch(err => err)},
+      sourceAssets: async (source?:string): Promise<Asset[] | undefined>  => await this.getSources(wellbore.id, source)
     };
   }
+
+  private getSources = async (wellboreId: number, source?: string): Promise<Asset[] | undefined> => {
+    let basePath = `/wellbores/${wellboreId}/sources`
+    if (source !== undefined) {
+      basePath += "/" + source
+    }
+
+    const path: string = this.getPath(basePath);
+    // eslint-disable-next-line
+    return await this.client?.asyncGet<Asset[]>(path)
+      .then(response => response.data)
+      .catch(err => {
+        throw new HttpError(err.status, err.errorMessage, {})
+      })
+  }
+
 
   private addLazyMethodsForMeasurement = (measurement: Measurement): Measurement => {
     return <Measurement>{

--- a/packages/wells/src/client/api/wellsApi.ts
+++ b/packages/wells/src/client/api/wellsApi.ts
@@ -6,6 +6,7 @@ import { WellFilter, WellFilterAPI, PolygonFilterAPI } from '../model/WellFilter
 import { stringify as convertGeoJsonToWKT } from 'wkt';
 import { Cluster } from '../model/Cluster'
 import HttpClientWithIntercept from '../httpClientWithIntercept';
+import { Asset } from 'wells/src/types';
 
 export class WellsAPI {
   private client?: HttpClientWithIntercept;
@@ -92,8 +93,24 @@ export class WellsAPI {
       wellHead: well.wellHead,
       datum: well.datum,
       sources: well.sources,
-      wellbores: async (): Promise<Wellbore[] | undefined>  => {return await this.wellbores.getFromWell(well.id).then(response => response).catch(err => err)}
+      wellbores: async (): Promise<Wellbore[] | undefined>  => {return await this.wellbores.getFromWell(well.id).then(response => response).catch(err => err)},
+      sourceAssets: async (source?:string): Promise<Asset[] | undefined>  => await this.getSources(well.id, source)
     };
+  }
+
+  private getSources = async (wellId: number, source?: string): Promise<Asset[] | undefined> => {
+    let basePath = `/wells/${wellId}/sources`
+    if (source !== undefined) {
+      basePath += "/" + source
+    }
+
+    const path: string = this.getPath(basePath);
+    // eslint-disable-next-line
+    return await this.client?.asyncGet<Asset[]>(path)
+      .then(response => response.data)
+      .catch(err => {
+        throw new HttpError(err.status, err.errorMessage, {})
+      })
   }
 
   private addLazyToAllWellItems = (wellItems: WellItems): WellItems => {

--- a/packages/wells/src/client/model/Well.ts
+++ b/packages/wells/src/client/model/Well.ts
@@ -1,5 +1,6 @@
 import { WellHead } from './WellHead';
 import { Wellbore } from './Wellbore';
+import { Asset } from 'wells/src/types';
 
 // Customizable function that takes in CogniteClient and args, and return a promise of a well
 export type SearchWells = (args: any) => Promise<Well[]>;
@@ -96,6 +97,13 @@ export interface Well {
    * @memberof Wellbore
    */
   wellbores(): Promise<Wellbore[]>;
+  /**
+   * If the source parameter is set, it will only return source assets from that source system.
+   * The source parameter can for example be EDM, Diskos, Openworks, etc.
+   * @type {Promise<Asset[]>}
+   * @memberof Wellbore
+   */
+  sourceAssets(source?: string): Promise<Asset[]>;
 }
 
 export interface WellDatum {

--- a/packages/wells/src/client/model/Wellbore.ts
+++ b/packages/wells/src/client/model/Wellbore.ts
@@ -1,3 +1,4 @@
+import { Asset } from 'wells/src/types';
 import { Survey } from '../model/Survey';
 import { Well } from './Well';
 import { WellHead } from './WellHead';
@@ -58,4 +59,11 @@ export interface Wellbore {
    * @memberof Wellbore
    */
   getWellHeadLocation(): Promise<WellHead | undefined>;
+  /**
+   * If the source parameter is set, it will only return source assets from that source system.
+   * The source parameter can for example be EDM, Diskos, Openworks, etc.
+   * @type {Promise<Asset[]>}
+   * @memberof Wellbore
+   */
+  sourceAssets(source?: string): Promise<Asset[]>;
 }


### PR DESCRIPTION
[SDL-123]

Add well.sourceAssets() and wellbore.sourceAssets() functions. The
functions support a string parameter for `source` type, like `EDM`,
`Studio`, etc.

[SDL-123]: https://cognitedata.atlassian.net/browse/SDL-123