### PR TITLE
fix: setting a field resolver to undefined [release]

### DIFF
--- a/packages/beta/src/api/templateGroups/templateInstancesApi.ts
+++ b/packages/beta/src/api/templateGroups/templateInstancesApi.ts
@@ -138,7 +138,10 @@ class TemplateInstanceCodec {
   ): { [K in string]: FieldResolver } {
     const mappedResolvers = toPairs(fieldResolvers).map(
       ([name, fieldResolver]) => {
-        if (!this.isFieldResolver(fieldResolver)) {
+        if (
+          fieldResolver !== undefined &&
+          !this.isFieldResolver(fieldResolver)
+        ) {
           // Auto-wrap objects, numbers etc. as ConstantResolver.
           return [name, new ConstantResolver(fieldResolver)];
         } else {


### PR DESCRIPTION
We should not auto wrap values that are undefined since a Constant Resolver with undefined value is not supported by the API. Instead we should just ignore undefined field resolvers.