### PR TITLE
fix: allows CDF authentication from localhost via http

### DIFF
--- a/packages/core/src/login.ts
+++ b/packages/core/src/login.ts
@@ -19,6 +19,7 @@ import {
   getBaseUrl,
   isSameProject,
   isUsingSSL,
+  isLocalhost,
   promiseCache,
   removeQueryParameterFromUrl,
 } from './utils';
@@ -313,7 +314,7 @@ export function createAuthenticateFunction(options: CreateAuthFunctionOptions) {
         }
       };
 
-      if (isUsingSSL()) {
+      if (isUsingSSL() || isLocalhost()) {
         const tokens = await Login.loginSilently(httpClient, {
           baseUrl,
           project,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -204,3 +204,8 @@ export function createInvisibleIframe(
 export function isUsingSSL() {
   return isBrowser() && location.protocol.toLowerCase() === 'https:';
 }
+
+/** @hidden */
+export function isLocalhost() {
+  return isBrowser() && location.hostname === 'localhost';
+}


### PR DESCRIPTION
I was developing on localhost over HTTP, which is supported by our api, and it didn't say anywhere in the documentation that it didn't for the sdk, just that using https was in the guide.

It seems that the sdk didn't support non-ssl connections as it had a isUsingSsl conditional around the login, so the user(me) was hitting redirect loops. This in turn increases the payloads in the /login call, until it hit 431( Response header fields too large).

As I see it, the quick fix would be to remove the conditional, which is what I've suggested for now.

If someone with more knowledge about this codebase can confirm that this will work, that would be great, seeing as it has only been handling https for a while.