### PR TITLE
feat(adfs): add auth flow for adfs

### DIFF
--- a/packages/core/src/__tests__/adfs.unit.spec.ts
+++ b/packages/core/src/__tests__/adfs.unit.spec.ts
@@ -1,0 +1,81 @@
+import nock from 'nock';
+import ADFS from '../adfs';
+
+describe('ADFS', () => {
+  const cluster = 'test-cluster';
+  const mockBaseUrl = `https://${cluster}.cognitedata.com`;
+  const authority = 'https://adfs.test.com/adfs';
+  const clientId = 'adfsClientId';
+  const requestParams = {
+    cluster,
+    clientId,
+  };
+  const authTokens = {
+    idToken: 'idToken',
+    accessToken: 'accessToken',
+    expiresIn: '3600',
+  };
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '');
+    nock.cleanAll();
+  });
+
+  describe('login', () => {
+    let adfsClient: ADFS;
+    const { location } = window;
+
+    beforeAll(() => {
+      delete window.location;
+      window.location = {
+        ...location,
+        hostname: 'localhost',
+        href: 'https://localhost',
+      };
+    });
+
+    beforeEach(() => {
+      adfsClient = new ADFS({ authority, requestParams });
+    });
+
+    afterAll(() => {
+      window.location = location;
+    });
+
+    test('should redirect to specific url', () => {
+      adfsClient.login();
+
+      expect(window.location.href).toMatchInlineSnapshot(
+        `"https://adfs.test.com/adfs?client_id=adfsClientId&scope=user_impersonation IDENTITY&response_mode=fragment&response_type=id_token token&resource=${mockBaseUrl}&redirect_uri=https://localhost"`
+      );
+    });
+  });
+  describe('handle redirect', () => {
+    let adfsClient: ADFS;
+
+    beforeEach(() => {
+      adfsClient = new ADFS({ authority, requestParams });
+      window.history.pushState({}, '', '');
+    });
+
+    test('should parse token from redirected url', () => {
+      const { expiresIn, accessToken, idToken } = authTokens;
+      window.history.pushState(
+        {},
+        '',
+        `/some/random/path#access_token=${accessToken}&id_token=${idToken}&expires_in=${expiresIn}&random=123`
+      );
+      const token = adfsClient.handleLoginRedirect();
+
+      expect(token).toEqual({ ...authTokens, expiresIn: Number(expiresIn) });
+      expect(window.location.href).toMatchInlineSnapshot(
+        `"https://localhost/some/random/path#random=123"`
+      );
+    });
+    test('should return null if no token in URL', () => {
+      const token = adfsClient.handleLoginRedirect();
+
+      expect(token).toEqual(null);
+    });
+  });
+});

--- a/packages/core/src/adfs.ts
+++ b/packages/core/src/adfs.ts
@@ -48,9 +48,11 @@ const adfsRequestParamsMapping: ADFSRequestParamsMapping = {
   resource: 'resource',
 };
 
-const ACCESS_TOKEN = 'accessToken';
-const ID_TOKEN = 'idToken';
-const EXPIRES_IN = 'expiresIn';
+const ACCESS_TOKEN = 'access_token';
+const ID_TOKEN = 'id_token';
+const EXPIRES_IN = 'expires_in';
+const TOKEN_TYPE = 'token_type';
+const SCOPE = 'scope';
 const ERROR = 'error';
 
 class ADFS {
@@ -71,12 +73,25 @@ class ADFS {
     window.location.href = url;
   }
 
-  // todo: validate token
   public handleLoginRedirect(): ADFSToken | null {
     try {
-      const token = extractADFSToken(window.location.search);
+      const url = window.location.href;
 
-      clearParametersFromUrl(ACCESS_TOKEN, ID_TOKEN, EXPIRES_IN);
+      const index = url.indexOf('#');
+
+      if (index === -1 || url.length <= index + 1) {
+        return null;
+      }
+
+      const token = extractADFSToken(url.substring(index + 1, url.length));
+
+      clearParametersFromUrl(
+        ACCESS_TOKEN,
+        ID_TOKEN,
+        EXPIRES_IN,
+        SCOPE,
+        TOKEN_TYPE
+      );
       this.token = token;
 
       return token;
@@ -88,6 +103,7 @@ class ADFS {
     return null;
   }
 
+  // todo: validate token
   public getCDFToken(): string | null {
     return this.token ? this.token.accessToken : null;
   }
@@ -128,8 +144,8 @@ class ADFS {
 
   private getADFSQueryParamString(params: ADFSQueryParams): string {
     return Object.entries(params).reduce((result, [key, value]) => {
-      return `?${result}${result.length ? '&' : ''}${key}=${value}`;
-    }, '');
+      return `${result}${result.length > 1 ? '&' : ''}${key}=${value}`;
+    }, '?');
   }
 }
 

--- a/packages/core/src/adfs.ts
+++ b/packages/core/src/adfs.ts
@@ -139,7 +139,7 @@ export class ADFS {
     let token: ADFSToken | null = null;
 
     try {
-      token = await silentLoginViaIframe(
+      token = await silentLoginViaIframe<ADFSToken | null>(
         `${url}&prompt=none`,
         extractADFSToken,
         LOGIN_IFRAME_NAME

--- a/packages/core/src/adfs.ts
+++ b/packages/core/src/adfs.ts
@@ -11,7 +11,6 @@ export interface ADFSConfig {
 export interface ADFSRequestParams {
   cluster: string;
   clientId: string;
-  scope: string;
 }
 export interface ADFSQueryParams {
   client_id: string;
@@ -115,11 +114,11 @@ class ADFS {
   private getADFSQueryParams({
     cluster,
     clientId,
-    scope,
   }: ADFSRequestParams): ADFSQueryParams {
     const responseMode = 'fragment';
     const responseType = 'id_token token';
     const resource = `https://${cluster}.cognitedata.com`;
+    const scope = `user_impersonation IDENTITY`;
     const redirectUri = window.location.href;
     const params = {
       clientId,

--- a/packages/core/src/adfs.ts
+++ b/packages/core/src/adfs.ts
@@ -52,11 +52,10 @@ const ID_TOKEN = 'id_token';
 const EXPIRES_IN = 'expires_in';
 const TOKEN_TYPE = 'token_type';
 const SCOPE = 'scope';
-const ERROR = 'error';
 
 class ADFS {
-  private authority: string;
-  private queryParams: ADFSQueryParams;
+  private readonly authority: string;
+  private readonly queryParams: ADFSQueryParams;
   private token: ADFSToken | null = null;
 
   constructor({ authority, requestParams }: ADFSConfig) {
@@ -95,14 +94,12 @@ class ADFS {
 
       return token;
     } catch (e) {
-      clearParametersFromUrl(ERROR);
       console.error(e);
     }
 
     return null;
   }
 
-  // todo: validate token
   public getCDFToken(): string | null {
     return this.token ? this.token.accessToken : null;
   }
@@ -153,12 +150,7 @@ export function extractADFSToken(query: string): ADFSToken | null {
     [ACCESS_TOKEN]: accessToken,
     [ID_TOKEN]: idToken,
     [EXPIRES_IN]: expiresIn,
-    [ERROR]: error,
   } = parse(query);
-
-  if (error) {
-    throw error;
-  }
 
   if (isString(accessToken) && isString(idToken)) {
     return {

--- a/packages/core/src/adfs.ts
+++ b/packages/core/src/adfs.ts
@@ -1,0 +1,159 @@
+// Copyright 2020 Cognite AS
+
+import { parse } from 'query-string';
+import isString from 'lodash/isString';
+import { clearParametersFromUrl } from './utils';
+
+export interface ADFSConfig {
+  authority: string;
+  requestParams: ADFSRequestParams;
+}
+export interface ADFSRequestParams {
+  cluster: string;
+  clientId: string;
+  scope: string;
+}
+export interface ADFSQueryParams {
+  client_id: string;
+  scope: string;
+  redirect_uri: string;
+  response_mode: string;
+  response_type: string;
+  resource: string;
+}
+export interface ADFSToken {
+  accessToken: string;
+  idToken: string;
+  expiresIn: number;
+}
+interface ADFSRequestParamsWithDefaults {
+  clientId: string;
+  scope: string;
+  redirectUri: string;
+  responseMode: string;
+  responseType: string;
+  resource: string;
+}
+
+type ADFSRequestParamsMapping = {
+  [key in keyof ADFSRequestParamsWithDefaults]: keyof ADFSQueryParams
+};
+
+const adfsRequestParamsMapping: ADFSRequestParamsMapping = {
+  clientId: 'client_id',
+  scope: 'scope',
+  redirectUri: 'redirect_uri',
+  responseMode: 'response_mode',
+  responseType: 'response_type',
+  resource: 'resource',
+};
+
+const ACCESS_TOKEN = 'accessToken';
+const ID_TOKEN = 'idToken';
+const EXPIRES_IN = 'expiresIn';
+const ERROR = 'error';
+
+class ADFS {
+  private authority: string;
+  private queryParams: ADFSQueryParams;
+  private token: ADFSToken | null = null;
+
+  constructor({ authority, requestParams }: ADFSConfig) {
+    this.authority = authority;
+    this.queryParams = this.getADFSQueryParams(requestParams);
+  }
+
+  public async login(): Promise<void> {
+    const url = `${this.authority}${this.getADFSQueryParamString(
+      this.queryParams
+    )}`;
+
+    window.location.href = url;
+  }
+
+  // todo: validate token
+  public handleLoginRedirect(): ADFSToken | null {
+    try {
+      const token = extractADFSToken(window.location.search);
+
+      clearParametersFromUrl(ACCESS_TOKEN, ID_TOKEN, EXPIRES_IN);
+      this.token = token;
+
+      return token;
+    } catch (e) {
+      clearParametersFromUrl(ERROR);
+      console.error(e);
+    }
+
+    return null;
+  }
+
+  public getAccessToken() {
+    return this.token && this.token.accessToken;
+  }
+
+  public getIdToken() {
+    return this.token && this.token.idToken;
+  }
+
+  private getADFSQueryParams({
+    cluster,
+    clientId,
+    scope,
+  }: ADFSRequestParams): ADFSQueryParams {
+    const responseMode = 'fragment';
+    const responseType = 'id_token token';
+    const resource = `https://${cluster}.cognitedata.com`;
+    const redirectUri = window.location.href;
+    const params = {
+      clientId,
+      scope,
+      responseMode,
+      responseType,
+      resource,
+      redirectUri,
+    };
+    return Object.entries(params).reduce<ADFSQueryParams>(
+      (result, [key, value]) => {
+        const param =
+          adfsRequestParamsMapping[key as keyof ADFSRequestParamsWithDefaults];
+
+        result[param] = value;
+
+        return result;
+      },
+      {} as ADFSQueryParams
+    );
+  }
+
+  private getADFSQueryParamString(params: ADFSQueryParams): string {
+    return Object.entries(params).reduce((result, [key, value]) => {
+      return `?${result}${result.length ? '&' : ''}${key}=${value}`;
+    }, '');
+  }
+}
+
+export function extractADFSToken(query: string): ADFSToken | null {
+  const {
+    [ACCESS_TOKEN]: accessToken,
+    [ID_TOKEN]: idToken,
+    [EXPIRES_IN]: expiresIn,
+    [ERROR]: error,
+  } = parse(query);
+
+  if (error) {
+    throw error;
+  }
+
+  if (isString(accessToken) && isString(idToken)) {
+    return {
+      accessToken,
+      idToken,
+      expiresIn: Number(expiresIn),
+    };
+  }
+
+  return null;
+}
+
+export default ADFS;

--- a/packages/core/src/adfs.ts
+++ b/packages/core/src/adfs.ts
@@ -74,7 +74,7 @@ export class ADFS {
         resolve(token.accessToken);
       }
 
-      const url = `${this.authority}${this.getADFSQueryParamString(
+      const url = `${this.authority}?${this.getADFSQueryParamString(
         this.queryParams
       )}`;
 
@@ -132,15 +132,15 @@ export class ADFS {
    * (using implicit grant flow)
    */
   private async acquireTokenSilently(): Promise<ADFSToken | null> {
-    const url = `${this.authority}${this.getADFSQueryParamString(
+    const url = `${this.authority}?prompt=none&${this.getADFSQueryParamString(
       this.queryParams
-    )}&prompt=none`;
+    )}`;
 
     let token: ADFSToken | null = null;
 
     try {
       token = await silentLoginViaIframe<ADFSToken | null>(
-        `${url}&prompt=none`,
+        url,
         extractADFSToken,
         LOGIN_IFRAME_NAME
       );
@@ -188,7 +188,7 @@ export class ADFS {
   private getADFSQueryParamString(params: ADFSQueryParams): string {
     return Object.entries(params).reduce((result, [key, value]) => {
       return `${result}${result.length > 1 ? '&' : ''}${key}=${value}`;
-    }, '?');
+    }, '');
   }
 }
 

--- a/packages/core/src/adfs.ts
+++ b/packages/core/src/adfs.ts
@@ -88,12 +88,12 @@ class ADFS {
     return null;
   }
 
-  public getAccessToken() {
-    return this.token && this.token.accessToken;
+  public getCDFToken(): string | null {
+    return this.token ? this.token.accessToken : null;
   }
 
-  public getIdToken() {
-    return this.token && this.token.idToken;
+  public getIdToken(): string | null {
+    return this.token ? this.token.idToken : null;
   }
 
   private getADFSQueryParams({

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -5,10 +5,10 @@ import isFunction from 'lodash/isFunction';
 import { CDFHttpClient } from './httpClient/cdfHttpClient';
 import {
   bearerString,
+  clearParametersFromUrl,
   isLocalhost,
   isSameProject,
   isUsingSSL,
-  removeQueryParameterFromUrl,
 } from './utils';
 import { CogniteLoginError } from './loginError';
 import { AUTHORIZATION_HEADER } from './constants';
@@ -194,14 +194,6 @@ function extractTokensFromUrl() {
     clearParametersFromUrl(ERROR_PARAM, ERROR_DESCRIPTION_PARAM);
     throw err;
   }
-}
-
-function clearParametersFromUrl(...params: string[]): void {
-  let url = window.location.href;
-  params.forEach(param => {
-    url = removeQueryParameterFromUrl(url, param);
-  });
-  window.history.replaceState(null, '', url);
 }
 
 function onAuthenticateWithRedirect(login: OnAuthenticateLoginObject) {

--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -556,14 +556,10 @@ export default class BaseCogniteClient {
 
     let token = await this.handleAzureADLoginRedirect(azureAdClient);
 
-    if (token) {
-      const isTokenValid = await this.validateAccessToken(token);
+    if (token && !(await this.validateAccessToken(token))) {
+      token = null;
 
-      if (!isTokenValid) {
-        token = null;
-
-        onNoProjectAvailable();
-      }
+      onNoProjectAvailable();
     }
 
     const authenticate = async () => {
@@ -616,14 +612,10 @@ export default class BaseCogniteClient {
 
     let token = await this.handleADFSLoginRedirect(adfsClient);
 
-    if (token) {
-      const isTokenValid = await this.validateAccessToken(token);
+    if (token && !(await this.validateAccessToken(token))) {
+      token = null;
 
-      if (!isTokenValid) {
-        token = null;
-
-        onNoProjectAvailable();
-      }
+      onNoProjectAvailable();
     }
 
     const authenticate = async () => {

--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -344,7 +344,7 @@ export default class BaseCogniteClient {
     if (this.azureAdClient) {
       const token = await this.azureAdClient.getCDFToken();
 
-      if (token && !(await this.validateAzureADAccessToken(token))) {
+      if (token && !(await this.validateAccessToken(token))) {
         return null;
       }
 
@@ -356,7 +356,7 @@ export default class BaseCogniteClient {
     } else if (this.adfsClient) {
       const token = this.adfsClient.getCDFToken();
 
-      if (token && !(await this.validateAzureADAccessToken(token))) {
+      if (token && !(await this.validateAccessToken(token))) {
         return null;
       }
 
@@ -547,7 +547,7 @@ export default class BaseCogniteClient {
     let token = await this.handleAzureADLoginRedirect(azureAdClient);
 
     if (token) {
-      const isTokenValid = await this.validateAzureADAccessToken(token);
+      const isTokenValid = await this.validateAccessToken(token);
 
       if (!isTokenValid) {
         token = null;
@@ -575,7 +575,7 @@ export default class BaseCogniteClient {
         }
       }
 
-      if (!(await this.validateAzureADAccessToken(cdfAccessToken))) {
+      if (!(await this.validateAccessToken(cdfAccessToken))) {
         onNoProjectAvailable();
 
         return false;
@@ -607,7 +607,7 @@ export default class BaseCogniteClient {
     let token = await this.handleADFSLoginRedirect(adfsClient);
 
     if (token) {
-      const isTokenValid = await this.validateAzureADAccessToken(token);
+      const isTokenValid = await this.validateAccessToken(token);
 
       if (!isTokenValid) {
         token = null;
@@ -627,7 +627,7 @@ export default class BaseCogniteClient {
           return false;
         }
       } else {
-        if (!(await this.validateAzureADAccessToken(cdfAccessToken))) {
+        if (!(await this.validateAccessToken(cdfAccessToken))) {
           onNoProjectAvailable();
 
           return false;
@@ -743,7 +743,7 @@ export default class BaseCogniteClient {
     }
   }
 
-  protected async validateAzureADAccessToken(token: string): Promise<boolean> {
+  protected async validateAccessToken(token: string): Promise<boolean> {
     try {
       const response = await this.httpClient.get<any>('/api/v1/token/inspect', {
         headers: { [AUTHORIZATION_HEADER]: bearerString(token) },

--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -244,6 +244,16 @@ export default class BaseCogniteClient {
    *   clientId: '[CLIENT_ID]', // client id of your AzureAD application
    *   tenantId: '[TENANT_ID]', // tenant id of your AzureAD tenant. Will be set to 'common' if not provided
    * });
+   *
+   * // you also have ability to sign in using ADFS
+   * client.loginWithOAuth({
+   *   authority: https://example.com/adfs/oauth2/authorize,
+   *   requestParams: {
+   *     cluster: 'cluster-name',
+   *     clientId: 'adfs-client-id',
+   *   },
+   * });
+   *
    * // after sign in you can do calls with the client
    * (async () => {
    *   await client.authenticate();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,4 +62,5 @@ export {
   AzureADSingInFlow,
   AzureADSignInRequestParams,
 } from './aad';
+export { ADFSRequestParams } from './adfs';
 export { TestUtils, Constants, GraphUtils };

--- a/packages/core/src/loginUtils.ts
+++ b/packages/core/src/loginUtils.ts
@@ -125,14 +125,17 @@ export function loginWithPopup(
 export async function silentLoginViaIframe<TokenType>(
   url: string,
   extractor: (query: string) => TokenType,
-  iframeName: string = LOGIN_IFRAME_NAME
+  iframeName: string = LOGIN_IFRAME_NAME,
+  locationPart: 'hash' | 'search' = 'hash'
 ): Promise<TokenType> {
   return new Promise<TokenType>((resolve, reject) => {
     const iframe = createInvisibleIframe(url, iframeName);
 
     iframe.onload = () => {
       try {
-        const authTokens = extractor(iframe.contentWindow!.location.hash);
+        const authTokens = extractor(
+          iframe.contentWindow!.location[locationPart]
+        );
         if (authTokens === null) {
           throw Error('Failed to login silently');
         }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -52,8 +52,8 @@ export function removeQueryParameterFromUrl(
   parameter: string
 ): string {
   return url
-    .replace(new RegExp('[?&]' + parameter + '=[^&#]*(#.*)?$'), '$1')
-    .replace(new RegExp('([?&])' + parameter + '=[^&]*&'), '$1');
+    .replace(new RegExp('[?#&]' + parameter + '=[^&#]*(#.*)?$'), '$1')
+    .replace(new RegExp('([?#&])' + parameter + '=[^&]*&'), '$1');
 }
 
 /** @hidden */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -200,6 +200,26 @@ export function generatePopupWindow(url: string, name: string) {
 }
 
 /** @hidden */
+export function createInvisibleIframe(
+  url: string,
+  name: string
+): HTMLIFrameElement {
+  const iframe = document.createElement('iframe');
+  iframe.name = name;
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframe.style.border = '0';
+  iframe.style.border = 'none';
+  iframe.style.visibility = 'hidden';
+
+  iframe.setAttribute('id', name);
+  iframe.setAttribute('aria-hidden', 'true');
+
+  iframe.src = url;
+  return iframe;
+}
+
+/** @hidden */
 export function isUsingSSL() {
   return isBrowser() && location.protocol.toLowerCase() === 'https:';
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -8,6 +8,7 @@ import { CogniteError } from './error';
 import { CogniteMultiError } from './multiError';
 import {
   OAuthLoginForAADOptions,
+  OAuthLoginForADFSOptions,
   OAuthLoginForCogniteOptions,
   OAuthLoginOptions,
 } from './baseCogniteClient';
@@ -220,4 +221,11 @@ export function isOAuthWithAADOptions(
   options: OAuthLoginOptions
 ): options is OAuthLoginForAADOptions {
   return ['clientId', 'cluster'].every(key => key in options);
+}
+
+/** @hidden **/
+export function isOAuthWithADFSOptions(
+  options: OAuthLoginOptions
+): options is OAuthLoginForADFSOptions {
+  return ['authority', 'requestParams'].every(key => key in options);
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -37,6 +37,14 @@ export function isBrowser() {
   );
 }
 
+export function clearParametersFromUrl(...params: string[]): void {
+  let url = window.location.href;
+  params.forEach(param => {
+    url = removeQueryParameterFromUrl(url, param);
+  });
+  window.history.replaceState(null, '', url);
+}
+
 /** @hidden */
 export function removeQueryParameterFromUrl(
   url: string,

--- a/samples/react/authentication-adfs/.gitignore
+++ b/samples/react/authentication-adfs/.gitignore
@@ -1,0 +1,24 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+yarn.lock

--- a/samples/react/authentication-adfs/README.md
+++ b/samples/react/authentication-adfs/README.md
@@ -1,0 +1,31 @@
+## Prerequisite
+
+Make sure you have read the [prerequisite-guide](../../README.md#prerequisite) before continuing.
+
+## Install
+
+Go to this folder in your terminal and run:
+
+`$ npm install`
+
+or with yarn:
+
+`$ yarn`
+
+## Add .env file with content
+
+```
+REACT_APP_PROJECT=projectName
+REACT_APP_CLUSTER=clusterName
+REACT_APP_CLIENT_ID=azureAdApplicationID
+REACT_APP_TENANT_ID=azureAdTenatID
+```
+
+## Start example
+
+`$ npm start`
+
+or with yarn:
+
+`$ yarn start`
+

--- a/samples/react/authentication-adfs/README.md
+++ b/samples/react/authentication-adfs/README.md
@@ -17,8 +17,8 @@ or with yarn:
 ```
 REACT_APP_PROJECT=projectName
 REACT_APP_CLUSTER=clusterName
-REACT_APP_CLIENT_ID=azureAdApplicationID
-REACT_APP_TENANT_ID=azureAdTenatID
+REACT_APP_CLIENT_ID=adfsApplicationID
+REACT_APP_AUTHORITY=adfsURL
 ```
 
 ## Start example

--- a/samples/react/authentication-adfs/package.json
+++ b/samples/react/authentication-adfs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@cognite/sdk": "^4",
+    "@cognite/sdk": "../../packages/stable",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.2"

--- a/samples/react/authentication-adfs/package.json
+++ b/samples/react/authentication-adfs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@cognite/sdk": "../../packages/stable",
+    "@cognite/sdk": "^4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.2"

--- a/samples/react/authentication-adfs/public/index.html
+++ b/samples/react/authentication-adfs/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Azure AD auth flow"
+    />
+    <title>Sample app</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/samples/react/authentication-adfs/src/App.js
+++ b/samples/react/authentication-adfs/src/App.js
@@ -1,0 +1,89 @@
+import { useState, useEffect } from 'react';
+import { CogniteClient } from '@cognite/sdk';
+
+const project = process.env.REACT_APP_PROJECT;
+const cluster = process.env.REACT_APP_CLUSTER;
+const clientId = process.env.REACT_APP_CLIENT_ID;
+const authority = process.env.REACT_APP_AUTHORITY;
+const scope = process.env.REACT_APP_SCOPE;
+
+const renderAssetsInTable = (assets) => {
+  return (
+    <table>
+      <tbody>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+      {assets.map(asset => (
+        <tr key={asset.id}>
+          <td>{asset.name}</td>
+          <td>{asset.description}</td>
+        </tr>
+      ))}
+      </tbody>
+    </table>
+  );
+}
+
+const client = new CogniteClient({appId: 'sample-app-id'});
+
+function App() {
+  const [assets, setAssets] = useState([]);
+  const [isInit, setIsInit] = useState(false);
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  const fetchRootAssets = async () => {
+    if (client === null) return;
+    // fetch the first 10 (maximum) assets
+    const assets = await client.assets
+      .list()
+      .autoPagingToArray({ limit: 10 });
+    setAssets(assets);
+  };
+
+  const authenticate = async () => {
+    if (client === null) return;
+
+    const result = await client.authenticate();
+
+    if (result) {
+      client.setProject(project);
+      setIsSignedIn(true);
+    }
+  }
+  const onNoProjectAvailable = () => {
+    console.log('Unfortunately, your token has no access to any project in the selected cluster');
+  }
+
+  useEffect(() => {
+    const login = async (client) => {
+      const result = await client.loginWithOAuth({
+        authority,
+        requestParams: {
+          cluster,
+          clientId,
+          scope
+        },
+        onNoProjectAvailable
+      });
+
+      client.setProject(project);
+
+      setIsInit(true);
+      setIsSignedIn(result);
+    }
+
+    login(client);
+  }, []);
+
+  return (
+    <div>
+      <button disabled={!isInit || isSignedIn} onClick={authenticate}><h1>Authenticate</h1></button>
+      <button disabled={!isInit || !isSignedIn} onClick={fetchRootAssets}><h1>Click here to fetch assets from Cognite</h1></button>
+      {assets && renderAssetsInTable(assets)}
+    </div>
+  );
+}
+
+export default App;

--- a/samples/react/authentication-adfs/src/App.js
+++ b/samples/react/authentication-adfs/src/App.js
@@ -5,7 +5,6 @@ const project = process.env.REACT_APP_PROJECT;
 const cluster = process.env.REACT_APP_CLUSTER;
 const clientId = process.env.REACT_APP_CLIENT_ID;
 const authority = process.env.REACT_APP_AUTHORITY;
-const scope = process.env.REACT_APP_SCOPE;
 
 const renderAssetsInTable = (assets) => {
   return (
@@ -63,7 +62,6 @@ function App() {
         requestParams: {
           cluster,
           clientId,
-          scope
         },
         onNoProjectAvailable
       });

--- a/samples/react/authentication-adfs/src/index.js
+++ b/samples/react/authentication-adfs/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);

--- a/samples/react/authentication-with-popup/package.json
+++ b/samples/react/authentication-with-popup/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@cognite/sdk": "^2",
+    "@cognite/sdk": "^4",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-scripts": "3.4.1"

--- a/samples/react/authentication/package.json
+++ b/samples/react/authentication/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@cognite/sdk": "^2",
+    "@cognite/sdk": "^4",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-scripts": "3.4.1"


### PR DESCRIPTION
Add ADFS authentication flow support.

Silent token refresh not perfect at the moment (cause implicit grant flow is used for token acquiring). It is done by an invisible iframe like suggested in [docs](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-openid-connect-oauth-flows-scenarios#refresh-tokens), but it can be blocked by the browser because of `X-Frame-Options` header. It can be configured on the ADFS server.