### PR TITLE
feat(core): don't check if its https if its not a browser

### DIFF
--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -26,6 +26,7 @@ import {
   isOAuthWithCogniteOptions,
   isUsingSSL,
   projectUrl,
+  isBrowser,
 } from './utils';
 import { version } from '../package.json';
 import {
@@ -277,7 +278,7 @@ export default class BaseCogniteClient {
       throw Error('`loginWithOAuth` is missing parameter `options`');
     }
 
-    if (!isUsingSSL()) {
+    if (isBrowser() && !isUsingSSL()) {
       console.warn(
         'You should use SSL (https) when you login with OAuth since CDF only allows redirecting back to an HTTPS site'
       );


### PR DESCRIPTION
In air-api in application-services I have thousand of thousands of requests that push "You should use SSL (https) when you login with OAuth since CDF only allows redirecting back to an HTTPS site" to the error logs in Stackdriver in production. It's pretty much a useless warning (that sadly is picked up with severity ERROR by Stackdriver). But the problem is, why should it be there? When there is no browser? So, the isBrowser was added to avoid "null pointer exceptions". This change is making sure its never called unless its a browser. specifically where it tries to log the statement above. 

I assume the function isUsingSSL is used other places, so I don't touch it.