### PR TITLE
chore: added filter slow method and test [release]

### DIFF
--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -109,6 +109,8 @@ const wells = await client.wells.filter(filter);
 
 #### _Filter wells without cursor (get ALL results sequentially):_
 
+Get wells from the well-service until `nextCursor` is empty. Due to performance issue in the well-service, this can take a long time. We don't recommend using this in a user interface where the user expects to see the results as fast as possible. Consider implementation your own pagination so that you can show part of the response as it arrives.
+
 ```ts
 import { WellFilter } from '@cognite/sdk-wells';
 

--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -107,6 +107,19 @@ const filter: WellFilter = {
 const wells = await client.wells.filter(filter);
 ```
 
+#### _Filter wells without cursor (get ALL results sequentially):_
+
+```ts
+import { WellFilter } from '@cognite/sdk-wells';
+
+const polygon = 'POLYGON ((0.0 0.0, 0.0 80.0, 80.0 80.0, 80.0 0.0, 0.0 0.0))';
+const filter: WellFilter = {
+  polygon: { wktGeometry: polygon, crs: 'epsg:4326' },
+  sources: ['edm'],
+};
+const wells = await client.wells.filterSlow(filter);
+```
+
 #### _Filter wells by geoJson polygon:_
 
 ```ts
@@ -265,7 +278,7 @@ const wellboreId: number = 870793324939646;
 const measurements: Measurement[] | undefined;
 measurements = await client.wellbores.getMeasurement(
   wellboreId,
-  MeasurementType.GammaRay,
+  MeasurementType.GammaRay
 );
 
 // lazy method to inspect data from measurement

--- a/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
@@ -105,15 +105,15 @@ describeIfCondition(
     });
 
     test('Get wellbores for a well id', async () => {
-      const well: Well | undefined = await client.wells.getById(2275887128760800);
+      const well: Well | undefined = await client.wells.getById(8091617722352417);
       expect(well).not.toBeUndefined();
       
       const wellbores: Wellbore[] | undefined = await client.wellbores.getFromWell(well!.id).then(response => response).catch(err => err);
 
       expect(wellbores).not.toBeUndefined();
-      const wellboreIds = [870793324939646, 1072803479704457, 8456650753594878]
+      const wellboreIds = ["WDL:Wellbore:dummy102", "wellbore:Platform WB 12.25 in OH", "wellbore:Platform WB 8.5 in OH"]
       wellboreIds.forEach(id => {
-        expect(wellbores!.map(wellbore => wellbore.id)).toContain(id)
+        expect(wellbores!.map(wellbore => wellbore.externalId)).toContain(id)
       });
     })
 

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -133,8 +133,8 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
     const wells = await client.wells.list();
     expect(wells).not.toBeUndefined();
     const retrievedWells = wells?.items.map(x => x.id)
-    if (wells?.cursor) {
-      const newWells = await client.wells.list(wells?.cursor)
+    if (wells?.nextCursor) {
+      const newWells = await client.wells.list(wells?.nextCursor)
       newWells?.items.forEach(element => {
         expect(retrievedWells).not.toContain(element.id)
       });

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -51,7 +51,7 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
     /* eslint-disable */
     expect(well?.id).toBe(wellId);
     /* eslint-enable */
-    expect(well?.waterDepth?.unit).toBe("m")
+    expect(well?.waterDepth?.unit).toBe("meter")
     expect(well?.waterDepth?.value).toBe(100.0)
   });
 
@@ -78,7 +78,8 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
 
   test('get by id - get wellbores', async () => {
     expect(client).not.toBeUndefined();
-    const wellId: number = 2275887128760800;
+    const wellId: number = 8091617722352417;
+
     const well: Well | undefined = await client.wells.getById(wellId)
 
     expect(well).not.toBeUndefined();
@@ -87,10 +88,7 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
     /* eslint-enable */
     const wellbores: Wellbore[] | undefined = await well?.wellbores()
     expect(wellbores).not.toBeUndefined();
-    const wellboreIds = [870793324939646, 1072803479704457, 8456650753594878]
-    wellboreIds.forEach(id => {
-      expect(wellbores!.map(wellbore => wellbore.id)).toContain(id)
-    });
+    expect(wellbores?.length).toBeGreaterThan(0)
   });
 
   test('get by id - 404 if well does not exist', async () => {
@@ -163,6 +161,19 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
       
     expect(wells).not.toBeUndefined();
     const retrievedNames = wells?.items.map(well => well.name)
+    const WdlNames = ["34/10-24", "34/10-8", "34/10-1"];
+    WdlNames.forEach(name => {
+     expect(retrievedNames).toContain(name)
+    });
+  });
+
+  test('filter with slow feature set to true', async () => {
+    expect(client).not.toBeUndefined();
+    const filter: WellFilter = {'stringMatching': '10'}
+    const wells: Well[] | undefined = await client.wells.filterSlow(filter);
+      
+    expect(wells).not.toBeUndefined();
+    const retrievedNames = wells?.map(well => well.name)
     const WdlNames = ["34/10-24", "34/10-8", "34/10-1"];
     WdlNames.forEach(name => {
      expect(retrievedNames).toContain(name)
@@ -282,7 +293,7 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
 
     expect(wells).not.toBeUndefined();
     const retrievedNames = wells?.items.map(well => well.externalId)
-    const WdlNames = ["well:34/10-1"];
+    const WdlNames = ["well:34/10-8"];
     WdlNames.forEach(name => {
       expect(retrievedNames).toContain(name)
     });
@@ -326,7 +337,7 @@ describeIfCondition('CogniteClient setup in wells - integration test', () => {
     expect(client).not.toBeUndefined();
     const quadrants = await client.wells.quadrants();
 
-    expect(quadrants).toContain("A")
+    expect(quadrants).toContain("8");
     expect(quadrants).toContain("B")
   });
 

--- a/packages/wells/src/client/api/wellsApi.ts
+++ b/packages/wells/src/client/api/wellsApi.ts
@@ -155,13 +155,10 @@ export class WellsAPI extends ConfigureAPI {
           break
         }
 
-        if (wellsChunk.items.length > 0) {
-          wells = wells.concat(wellsChunk.items)
-        }
+        wells = wells.concat(wellsChunk.items)
         
-      // update cursor and go again
-      cursor = wellsChunk.nextCursor
-      
+        // update cursor and go again
+        cursor = wellsChunk.nextCursor
       } while (cursor != undefined);
     return wells;
   }


### PR DESCRIPTION
[SDL-590] - Add 'slow' option to the javascript sdk for filtering wells

Turned out our cursoring of wells have never actually worked. The `cursor` field of `WellItems` should have been `nextCursor`, so it always ended up being undefined/null.

[SDL-590]: https://cognitedata.atlassian.net/browse/SDL-590