### PR TITLE
chore: uncomment asset type import

### DIFF
--- a/packages/wells/package.json
+++ b/packages/wells/package.json
@@ -22,7 +22,6 @@
     "test-snippets": "yarn extract-snippets && yarn tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/geospatial-sdk-js": "^0.0.5",
     "@cognite/sdk": "^4.0.3",
     "@cognite/sdk-core": "^2.1.2",
     "wkt": "^0.1.1"

--- a/packages/wells/src/__tests__/integration/casings.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/casings.int.spec.ts
@@ -2,7 +2,6 @@ import { setupLoggedInClient } from '../testUtils';
 import CogniteWellsClient from 'wells/src/client/cogniteWellsClient';
 import { Sequence, SequenceData } from 'wells/src/client/model/Sequence';
 import { Wellbore } from 'wells/src/client/model/Wellbore';
-//import { Well } from 'wells/src/client/model/Well';
 
 // suggested solution/hack for conditional tests: https://github.com/facebook/jest/issues/3652#issuecomment-385262455
 const describeIfCondition =

--- a/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wellbores.int.spec.ts
@@ -7,7 +7,7 @@ import { Measurement} from 'wells/src/client/model/Measurement';
 import { Well } from 'wells/src/client/model/Well';
 import { Wellbore } from 'wells/src/client/model/Wellbore';
 import { Survey, SurveyData } from 'wells/src/client/model/Survey';
-import { Asset } from 'wells/src/types';
+import { Asset } from '@cognite/sdk';
 
 enum MeasurementType {
   GammaRay = 'GammaRay',

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -7,7 +7,8 @@ import { Wellbore } from 'wells/src/client/model/Wellbore'
 import { LengthRange } from 'wells/src/client/model/LengthRange';
 import { WellFilter, MeasurementFilter, MeasurementFilters } from 'wells/src/client/model/WellFilter';
 import { GeoJson } from 'wells/src/client/model/GeoJson';
-import { Asset } from 'wells/src/types';
+// import { Asset } from 'wells/src/types';
+import { Asset } from '@cognite/sdk';
 import { DateRange } from 'wells/src/client/model/DateRange';
 
 enum LengthUnitEnum {

--- a/packages/wells/src/__tests__/integration/wells.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/wells.int.spec.ts
@@ -7,7 +7,6 @@ import { Wellbore } from 'wells/src/client/model/Wellbore'
 import { LengthRange } from 'wells/src/client/model/LengthRange';
 import { WellFilter, MeasurementFilter, MeasurementFilters } from 'wells/src/client/model/WellFilter';
 import { GeoJson } from 'wells/src/client/model/GeoJson';
-// import { Asset } from 'wells/src/types';
 import { Asset } from '@cognite/sdk';
 import { DateRange } from 'wells/src/client/model/DateRange';
 

--- a/packages/wells/src/client/api/wellboresApi.ts
+++ b/packages/wells/src/client/api/wellboresApi.ts
@@ -5,7 +5,6 @@ import { Survey, SurveyData } from '../model/Survey';
 import { Wellbore } from '../model/Wellbore';
 import { SurveysAPI } from './surveysApi';
 import { WellIds } from '../model/WellIds';
-// import { Asset } from 'wells/src/types';
 import { Sequence, SequenceData, SequenceDataRequest } from '../model/Sequence';
 import { ConfigureAPI } from '../baseWellsClient';
 import { Asset } from '@cognite/sdk';

--- a/packages/wells/src/client/api/wellboresApi.ts
+++ b/packages/wells/src/client/api/wellboresApi.ts
@@ -5,9 +5,10 @@ import { Survey, SurveyData } from '../model/Survey';
 import { Wellbore } from '../model/Wellbore';
 import { SurveysAPI } from './surveysApi';
 import { WellIds } from '../model/WellIds';
-import { Asset } from 'wells/src/types';
+// import { Asset } from 'wells/src/types';
 import { Sequence, SequenceData, SequenceDataRequest } from '../model/Sequence';
 import { ConfigureAPI } from '../baseWellsClient';
+import { Asset } from '@cognite/sdk';
 
 export class WellboresAPI extends ConfigureAPI {
   private _surveysSDK?: SurveysAPI;

--- a/packages/wells/src/client/api/wellsApi.ts
+++ b/packages/wells/src/client/api/wellsApi.ts
@@ -4,7 +4,6 @@ import { Wellbore } from '../model/Wellbore';
 import { WellboresAPI } from '../api/wellboresApi'
 import { WellFilter, WellFilterAPI, PolygonFilterAPI } from '../model/WellFilter';
 import { stringify as convertGeoJsonToWKT } from 'wkt';
-// import { Asset } from 'wells/src/types';
 import { ConfigureAPI } from '../baseWellsClient';
 import { Asset } from '@cognite/sdk';
 

--- a/packages/wells/src/client/api/wellsApi.ts
+++ b/packages/wells/src/client/api/wellsApi.ts
@@ -4,8 +4,9 @@ import { Wellbore } from '../model/Wellbore';
 import { WellboresAPI } from '../api/wellboresApi'
 import { WellFilter, WellFilterAPI, PolygonFilterAPI } from '../model/WellFilter';
 import { stringify as convertGeoJsonToWKT } from 'wkt';
-import { Asset } from 'wells/src/types';
+// import { Asset } from 'wells/src/types';
 import { ConfigureAPI } from '../baseWellsClient';
+import { Asset } from '@cognite/sdk';
 
 export class WellsAPI extends ConfigureAPI {
   private _wellboresSDK?: WellboresAPI;

--- a/packages/wells/src/client/model/Well.ts
+++ b/packages/wells/src/client/model/Well.ts
@@ -1,6 +1,5 @@
 import { Wellhead } from './wellhead';
 import { Wellbore } from './Wellbore';
-// import { Asset } from 'wells/src/types';
 import { Asset } from '@cognite/sdk';
 import { DoubleWithUnit } from './DoubleWithUnit';
 

--- a/packages/wells/src/client/model/Well.ts
+++ b/packages/wells/src/client/model/Well.ts
@@ -1,6 +1,7 @@
 import { Wellhead } from './wellhead';
 import { Wellbore } from './Wellbore';
-import { Asset } from 'wells/src/types';
+// import { Asset } from 'wells/src/types';
+import { Asset } from '@cognite/sdk';
 import { DoubleWithUnit } from './DoubleWithUnit';
 
 // Customizable function that takes in CogniteClient and args, and return a promise of a well

--- a/packages/wells/src/client/model/Wellbore.ts
+++ b/packages/wells/src/client/model/Wellbore.ts
@@ -1,4 +1,5 @@
-import { Asset } from 'wells/src/types';
+// import { Asset } from 'wells/src/types';
+import { Asset } from '@cognite/sdk';
 import { Survey } from '../model/Survey';
 import { Sequence } from './Sequence';
 import { Well } from './Well';

--- a/packages/wells/src/client/model/Wellbore.ts
+++ b/packages/wells/src/client/model/Wellbore.ts
@@ -1,4 +1,3 @@
-// import { Asset } from 'wells/src/types';
 import { Asset } from '@cognite/sdk';
 import { Survey } from '../model/Survey';
 import { Sequence } from './Sequence';

--- a/packages/wells/src/types.ts
+++ b/packages/wells/src/types.ts
@@ -1,5 +1,0 @@
-// Copyright 2020 Cognite AS
-
-// export * from '@cognite/sdk';
-// This file is here mostly to allow apis to import { ... } from '../../types';
-// Overriding types should probably be done in their respective API endpoint files, where possible

--- a/packages/wells/src/types.ts
+++ b/packages/wells/src/types.ts
@@ -1,5 +1,5 @@
 // Copyright 2020 Cognite AS
 
-export * from '@cognite/sdk';
+// export * from '@cognite/sdk';
 // This file is here mostly to allow apis to import { ... } from '../../types';
 // Overriding types should probably be done in their respective API endpoint files, where possible


### PR DESCRIPTION
Tried to create a separate nodejs typescript project, but wouldn't compile due to us having `export * @cognite/sdk` in the `/src/types.ts` file. Compiles now after deleting the file and importing `Asset` directly from the SDK. Also removed geospatial as dependecy.