### PR TITLE
test: disable files data sets test in stable

### DIFF
--- a/packages/stable/src/__tests__/api/datasets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datasets.int.spec.ts
@@ -80,7 +80,7 @@ describe('data sets integration test', () => {
 
     expect(description).toEqual(updatedDescription);
   });
-  describe('files data sets', () => {
+  describe.skip('files data sets', () => {
     let dataSetId: CogniteInternalId;
     let file: FileInfo;
 


### PR DESCRIPTION
The travis build on the master branch after [PR533](https://github.com/cognitedata/cognite-sdk-js/pull/533) was merged.

The build fails because of a test in the stable package:
```
FAIL packages/stable/src/__tests__/api/datasets.int.spec.ts (61.767 s)
  ● data sets integration test › files data sets › upload

    File never marked as 'uploaded'

      223 |       await sleepPromise(DELAY_IN_MS);
      224 |     } while (retryCount < MAX_RETRIES);
    > 225 |     throw Error(`File never marked as 'uploaded'`);
          |           ^
      226 |   }
      227 | 
      228 |   private async getDownloadUrlsEndpoint(items: IdEither[]) {

      at FilesAPI.<anonymous> (packages/stable/src/api/files/filesApi.ts:225:11)
      at step (packages/stable/src/api/files/filesApi.ts:5754:19)
      at Object.next (packages/stable/src/api/files/filesApi.ts:5484:14)
      at fulfilled (packages/stable/src/api/files/filesApi.ts:5371:24)

  ● data sets integration test › files data sets › update

    TypeError: Cannot read property 'id' of undefined

      113 |     test('update', async () => {
      114 |       const [updated] = await client.files.update([
    > 115 |         { id: file.id, ...updateDataSetObject },
          |                    ^
      116 |       ]);
      117 | 
      118 |       expect(updated.dataSetId).toEqual(datasets[1].id);

      at packages/stable/src/__tests__/api/datasets.int.spec.ts:115:20
      at step (packages/stable/src/__tests__/api/datasets.int.spec.ts:45:23)
      at Object.next (packages/stable/src/__tests__/api/datasets.int.spec.ts:26:53)
      at packages/stable/src/__tests__/api/datasets.int.spec.ts:20:71
      at __awaiter (packages/stable/src/__tests__/api/datasets.int.spec.ts:16:12)
      at Object.<anonymous> (packages/stable/src/__tests__/api/datasets.int.spec.ts:113:20)
```
I was suggested to disable these tests.