### PR TITLE
chore: wellbore ids in npt filter [release]

### DIFF
--- a/packages/wells/README.md
+++ b/packages/wells/README.md
@@ -466,6 +466,7 @@ duration: how long did the event last in **hours**
 measuredDepth: add what depth the event occur
 nptCodes: what npt codes are associated to the event
 nptCodeDetail: what npt code details are associated to the event
+wellboreIds: what wellbore ids are associated to the event
 
 ```ts
 import { NPT, NPTFilter, LengthUnitEnum } from '@cognite/sdk-wells';
@@ -474,6 +475,7 @@ const filter: NPTFilter = {
   measuredDepth: { min: 1800.0, max: 3000.0, unit: LengthUnitEnum.METER }, // filter on measured depth range that npt events took place
   nptCodes: ['FJSB', 'GSLB'], // filter on npt events that match on any of the codes
   nptCodeDetails: ['SLSN', 'OLSF'], // filter on npt events that match on any of the code details
+  wellboreIds: [9241931069132, 304913581314133], // filter on npt events that are associated to wellbore ids
 };
 
 const cursor = 'some-cursor'; // optional

--- a/packages/wells/src/__tests__/integration/events.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/events.int.spec.ts
@@ -116,15 +116,28 @@ describeIfCondition('CogniteClient setup in surveys - integration test', () => {
     expect(intersection.length).toBe(expected.size);
   });
 
+  test('List all NPT by wellbore ids', async () => {
+    const filter: NPTFilter = {wellboreIds: [8620912644845543, 8269456345006483]};
+    const nptEvents: NPTItems = await client.events.listNPT(filter)
+    const actual = new Set(nptEvents.items.map(npt => npt.sourceEventExternalId));
+    const expected = new Set(['m2rmk', 'h2rmk', 'YTX8R'])
+    const intersection = [...actual].filter(x => expected.has(x!));
+    expect(intersection.length).toBe(expected.size);
+  });
+
   test('List all NPT codes', async () => {
     const nptCodes: string[] = await client.events.nptCodes();
-    expect(nptCodes).not.toBeUndefined();
-    expect(nptCodes).toContain('ABCD');
+    const actual = new Set(nptCodes);
+    const expected = new Set(['FJSB', 'GSLB', 'XSLC'])
+    const intersection = [...actual].filter(x => expected.has(x!));
+    expect(intersection.length).toBe(expected.size);
   });
 
   test('List all NPT Detail codes', async () => {
-    const nptCodes: string[] = await client.events.nptDetailCodes();
-    expect(nptCodes).not.toBeUndefined();
-    expect(nptCodes).toContain('EFG');
+    const nptDetailCodes: string[] = await client.events.nptDetailCodes();
+    const actual = new Set(nptDetailCodes);
+    const expected = new Set(["OLSF", "SLSN", "ZJST"])
+    const intersection = [...actual].filter(x => expected.has(x!));
+    expect(intersection.length).toBe(expected.size);
   });
 });

--- a/packages/wells/src/__tests__/integration/events.int.spec.ts
+++ b/packages/wells/src/__tests__/integration/events.int.spec.ts
@@ -119,25 +119,25 @@ describeIfCondition('CogniteClient setup in surveys - integration test', () => {
   test('List all NPT by wellbore ids', async () => {
     const filter: NPTFilter = {wellboreIds: [8620912644845543, 8269456345006483]};
     const nptEvents: NPTItems = await client.events.listNPT(filter)
-    const actual = new Set(nptEvents.items.map(npt => npt.sourceEventExternalId));
+    const actual = nptEvents.items.map(npt => npt.sourceEventExternalId);
     const expected = new Set(['m2rmk', 'h2rmk', 'YTX8R'])
-    const intersection = [...actual].filter(x => expected.has(x!));
+    const intersection = actual.filter(x => expected.has(x!));
     expect(intersection.length).toBe(expected.size);
   });
 
   test('List all NPT codes', async () => {
     const nptCodes: string[] = await client.events.nptCodes();
-    const actual = new Set(nptCodes);
+    const actual = nptCodes;
     const expected = new Set(['FJSB', 'GSLB', 'XSLC'])
-    const intersection = [...actual].filter(x => expected.has(x!));
+    const intersection = actual.filter(x => expected.has(x!));
     expect(intersection.length).toBe(expected.size);
   });
 
   test('List all NPT Detail codes', async () => {
     const nptDetailCodes: string[] = await client.events.nptDetailCodes();
-    const actual = new Set(nptDetailCodes);
+    const actual = nptDetailCodes;
     const expected = new Set(["OLSF", "SLSN", "ZJST"])
-    const intersection = [...actual].filter(x => expected.has(x!));
+    const intersection = actual.filter(x => expected.has(x!));
     expect(intersection.length).toBe(expected.size);
   });
 });

--- a/packages/wells/src/client/api/eventsApi.ts
+++ b/packages/wells/src/client/api/eventsApi.ts
@@ -27,7 +27,7 @@ export class EventsAPI extends ConfigureAPI {
     const path: string = `/${this.project}/events/nptcodes`;
 
     return await this.client
-      .asyncPost<string[]>(path, {})
+      .asyncGet<string[]>(path)
       .then(response => response.data)
       .catch(err => {
         throw new HttpError(err.status, err.data.error.message, {});
@@ -42,7 +42,7 @@ export class EventsAPI extends ConfigureAPI {
     const path: string = `/${this.project}/events/nptdetailcodes`;
 
     return await this.client
-      .asyncPost<string[]>(path, {})
+      .asyncGet<string[]>(path)
       .then(response => response.data)
       .catch(err => {
         throw new HttpError(err.status, err.data.error.message, {});

--- a/packages/wells/src/client/model/NPTFilter.ts
+++ b/packages/wells/src/client/model/NPTFilter.ts
@@ -21,4 +21,9 @@ export interface NPTFilter {
    * @memberof NPTFilter
    */
   nptCodeDetails?: string[];
+  /**
+   * @type {number[]}
+   * @memberof NPTFilter
+   */
+  wellboreIds?: number[];
 }

--- a/packages/wells/src/constants.ts
+++ b/packages/wells/src/constants.ts
@@ -10,7 +10,7 @@ export const OPERATOR = 'Operator';
 export const BLOCK = 'Block';
 /** @hidden */
 export const COGDEV_BASE_URL =
-  'https://well-service.cognitedata-production.cognite.ai';
+  'http://well-service.cognitedata-production.cognite.ai';
 /** @hidden */
 export const BLUEFIELD_BASE_URL = 'https://well-service.bluefield.cognite.ai';
 /** @hidden */


### PR DESCRIPTION
changing `POST /events/nptcodes` and `POST /events/nptdetailcodes` to being GET requests. Also add wellbore ids to npt filtering.

relies on https://github.com/cognitedata/well-service/pull/272 being merged