### PR TITLE
chore(tests): remove bash retry

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,8 +53,7 @@ jobs:
         run: yarn build
 
       - name: Test/Codecov
-        # bash hack to rerun test suite, because of flaky integration tests
-        run: for i in {1..5}; do yarn test:codecov && break || sleep 5; done
+        run: yarn test:codecov
 
       - name: Codecov
         uses: codecov/codecov-action@v1.0.11
@@ -100,5 +99,4 @@ jobs:
         run: yarn build
 
       - name: Test
-        # bash hack to rerun test suite, because of flaky integration tests
-        run: for i in {1..5}; do yarn test && break || sleep 5; done
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "allsdk": "lerna run --ignore *-sample",
     "allsamples": "lerna run --scope *-sample",
     "clean": "lerna run clean && rm -rf docs/ coverage/",
-    "test": "for i in {1..3}; do yarn allsdk test --stream && break || sleep 5; done",
+    "test": "yarn allsdk test --stream",
     "test:codecov": "jest --config=jest.config.js --coverage=true",
     "lint": "yarn allsdk lint --stream",
     "lint:fix": "yarn allsdk lint:fix --stream",


### PR DESCRIPTION
There are some retry-setup in the test suite. That should be used/changed of the current retry isn't
good enough.