### PR TITLE
feat: document preview endpoints [release]

### DIFF
--- a/packages/beta/src/__tests__/api/documentsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/documentsApi.int.spec.ts
@@ -43,7 +43,6 @@ describe.skip('documents api', () => {
     expect(documents.items.length).toEqual(1);
     const document = documents.items[0];
 
-    await client.documents.preview.document(document.id, mediaTypePDF);
     await client.documents.preview.documentAsPdf(document.id);
     await client.documents.preview.documentAsImage(document.id, 0);
   });

--- a/packages/beta/src/__tests__/api/documentsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/documentsApi.int.spec.ts
@@ -34,4 +34,17 @@ describe.skip('documents api', () => {
     const response = await client.documents.pipelines.list();
     expect(response.items.length).toBeGreaterThan(0);
   });
+  test('fetch preview', async () => {
+    const mediaTypePDF = 'application/pdf';
+    const documents = await client.documents.list({
+      limit: 1,
+      filter: { mimeType: { equals: mediaTypePDF } },
+    });
+    expect(documents.items.length).toEqual(1);
+    const document = documents.items[0];
+
+    await client.documents.preview.document(document.id, mediaTypePDF);
+    await client.documents.preview.documentAsPdf(document.id);
+    await client.documents.preview.documentAsImage(document.id, 0);
+  });
 });

--- a/packages/beta/src/__tests__/api/documentsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/documentsApi.int.spec.ts
@@ -21,7 +21,7 @@ describe.skip('documents api', () => {
   });
   test('list documents, by size', async () => {
     const response = await client.documents.list({
-      filter: { size: { min: 10, max: 900533317 } },
+      filter: { size: { min: 10, max: 9005383317 } },
       limit: 1,
     });
     expect(response.items.length).toEqual(1);
@@ -40,10 +40,30 @@ describe.skip('documents api', () => {
       limit: 1,
       filter: { mimeType: { equals: mediaTypePDF } },
     });
-    expect(documents.items.length).toEqual(1);
+    if (documents.items.length == 0) {
+      return;
+    }
     const document = documents.items[0];
 
-    await client.documents.preview.documentAsPdf(document.id);
     await client.documents.preview.documentAsImage(document.id, 0);
+    const resp = await client.documents.preview.documentAsPdf(document.id);
+
+    expect(resp.byteLength).toBeGreaterThan(5); // %PDF-
+    const frontSlice = resp.slice(0, 4);
+    expect(frontSlice).toEqual([0x25, 0x50, 0x44, 0x46, 0x2d]);
+  });
+  test('fetch temporary link', async () => {
+    const mediaTypePDF = 'application/pdf';
+    const documents = await client.documents.list({
+      limit: 1,
+      filter: { mimeType: { equals: mediaTypePDF } },
+    });
+    if (documents.items.length == 0) {
+      return;
+    }
+    const document = documents.items[0];
+
+    const resp = await client.documents.preview.temporaryLink(document.id);
+    expect(resp.temporaryLink).toBeDefined();
   });
 });

--- a/packages/beta/src/__tests__/api/documentsApi.unit.spec.ts
+++ b/packages/beta/src/__tests__/api/documentsApi.unit.spec.ts
@@ -244,7 +244,7 @@ describe('Documents unit test', () => {
     };
 
     const prev = client.documents.preview;
-    expect(prev.buildPreviewURI(1)).toEqual(
+    expect(prev.buildPreviewURI(1, 'image/png')).toEqual(
       base('/preview/?documentId=1&page=0')
     );
     expect(prev.buildPreviewURI(4, 'application/pdf')).toEqual(

--- a/packages/beta/src/__tests__/api/documentsApi.unit.spec.ts
+++ b/packages/beta/src/__tests__/api/documentsApi.unit.spec.ts
@@ -273,7 +273,7 @@ describe('Documents unit test', () => {
       .query({ documentId: 1, page: 0 })
       .once()
       .reply(200);
-    await client.documents.preview.documentAsImage(1);
+    await client.documents.preview.documentAsImage(1, 0);
   });
 
   test('document preview temporary link', async () => {

--- a/packages/beta/src/__tests__/api/documentsApi.unit.spec.ts
+++ b/packages/beta/src/__tests__/api/documentsApi.unit.spec.ts
@@ -243,17 +243,17 @@ describe('Documents unit test', () => {
       return `/api/v1/projects/${project}/documents${path}`;
     };
 
-    const prev = client.documents.preview;
-    expect(prev.buildPreviewURI(1, 'image/png')).toEqual(
+    const preview = client.documents.preview;
+    expect(preview.buildPreviewURI(1, 'image/png')).toEqual(
       base('/preview/?documentId=1&page=0')
     );
-    expect(prev.buildPreviewURI(4, 'application/pdf')).toEqual(
+    expect(preview.buildPreviewURI(4, 'application/pdf')).toEqual(
       base('/preview/?documentId=4')
     );
-    expect(prev.buildPreviewURI(4, 'image/png')).toEqual(
+    expect(preview.buildPreviewURI(4, 'image/png')).toEqual(
       base('/preview/?documentId=4&page=0')
     );
-    expect(prev.buildPreviewURI(4, 'image/png', 2)).toEqual(
+    expect(preview.buildPreviewURI(4, 'image/png', 2)).toEqual(
       base('/preview/?documentId=4&page=2')
     );
   });

--- a/packages/beta/src/api/documents/documentsApi.ts
+++ b/packages/beta/src/api/documents/documentsApi.ts
@@ -16,6 +16,7 @@ import {
 } from '../../types';
 import { FeedbackAPI } from './feedbackApi';
 import { PipelinesAPI } from './pipelinesApi';
+import { PreviewAPI } from './previewApi';
 
 export interface DocumentsAggregatesResponse<T> extends ItemsWrapper<T> {
   aggregates?: DocumentsAggregate[];
@@ -24,11 +25,13 @@ export interface DocumentsAggregatesResponse<T> extends ItemsWrapper<T> {
 export class DocumentsAPI extends BaseResourceAPI<Document> {
   private readonly feedbackAPI: FeedbackAPI;
   private readonly pipelinesAPI: PipelinesAPI;
+  private readonly previewAPI: PreviewAPI;
 
   constructor(...args: [string, CDFHttpClient, MetadataMap]) {
     super(...args);
 
     this.feedbackAPI = new FeedbackAPI(args[0] + '/feedback', args[1], args[2]);
+    this.previewAPI = new PreviewAPI(args[0] + '/preview', args[1], args[2]);
     this.pipelinesAPI = new PipelinesAPI(
       args[0] + '/pipelines',
       args[1],
@@ -54,6 +57,10 @@ export class DocumentsAPI extends BaseResourceAPI<Document> {
 
   public get feedback() {
     return this.feedbackAPI;
+  }
+
+  public get preview() {
+    return this.previewAPI;
   }
 
   private async searchDocuments<ResponseType>(

--- a/packages/beta/src/api/documents/previewApi.ts
+++ b/packages/beta/src/api/documents/previewApi.ts
@@ -7,20 +7,15 @@ import { DocumentId, DocumentPreviewTemporaryLink } from '../../types';
 import Any = jasmine.Any;
 
 export class PreviewAPI extends BaseResourceAPI<Any> {
-  public document = (
+  public documentAsPdf = (id: DocumentId): Promise<ArrayBuffer> => {
+    return this.previewEndpoint<ArrayBuffer>(id, 'application/pdf');
+  };
+
+  public documentAsImage = (
     id: DocumentId,
-    accepts: acceptsType = 'image/png',
-    page: number = 0
+    page: number
   ): Promise<ArrayBuffer> => {
-    return this.previewEndpoint<ArrayBuffer>(id, accepts, page);
-  };
-
-  public documentAsPdf = (id: DocumentId): Promise<Any> => {
-    return this.previewEndpoint<Any>(id, 'application/pdf');
-  };
-
-  public documentAsImage = (id: DocumentId, page: number = 0): Promise<Any> => {
-    return this.previewEndpoint<Any>(id, 'image/png', page);
+    return this.previewEndpoint<ArrayBuffer>(id, 'image/png', page);
   };
 
   public temporaryLink = (

--- a/packages/beta/src/api/documents/previewApi.ts
+++ b/packages/beta/src/api/documents/previewApi.ts
@@ -26,7 +26,7 @@ export class PreviewAPI extends BaseResourceAPI<Any> {
 
   public buildPreviewURI = (
     id: DocumentId,
-    accepts: acceptsType,
+    accepts: AcceptsType,
     page: number = 0
   ): string => {
     let uri = `${this.url()}?documentId=${id.toString()}`;
@@ -39,7 +39,7 @@ export class PreviewAPI extends BaseResourceAPI<Any> {
 
   private async previewEndpoint<ResponseType>(
     id: DocumentId,
-    accepts: acceptsType,
+    accepts: AcceptsType,
     page: number = 0
   ): Promise<ResponseType> {
     const uri = this.buildPreviewURI(id, accepts, page);
@@ -65,4 +65,4 @@ export class PreviewAPI extends BaseResourceAPI<Any> {
   }
 }
 
-export type acceptsType = 'application/pdf' | 'image/png';
+export type AcceptsType = 'application/pdf' | 'image/png';

--- a/packages/beta/src/api/documents/previewApi.ts
+++ b/packages/beta/src/api/documents/previewApi.ts
@@ -26,7 +26,7 @@ export class PreviewAPI extends BaseResourceAPI<Any> {
 
   public buildPreviewURI = (
     id: DocumentId,
-    accepts: acceptsType = 'image/png',
+    accepts: acceptsType,
     page: number = 0
   ): string => {
     let uri = `${this.url()}?documentId=${id.toString()}`;
@@ -39,7 +39,7 @@ export class PreviewAPI extends BaseResourceAPI<Any> {
 
   private async previewEndpoint<ResponseType>(
     id: DocumentId,
-    accepts: acceptsType = 'image/png',
+    accepts: acceptsType,
     page: number = 0
   ): Promise<ResponseType> {
     const uri = this.buildPreviewURI(id, accepts, page);

--- a/packages/beta/src/api/documents/previewApi.ts
+++ b/packages/beta/src/api/documents/previewApi.ts
@@ -1,0 +1,73 @@
+// Copyright 2020 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import { HttpResponseType } from '@cognite/sdk-core';
+
+import { DocumentId, DocumentPreviewTemporaryLink } from '../../types';
+import Any = jasmine.Any;
+
+export class PreviewAPI extends BaseResourceAPI<Any> {
+  public document = (
+    id: DocumentId,
+    accepts: acceptsType = 'image/png',
+    page: number = 0
+  ): Promise<ArrayBuffer> => {
+    return this.previewEndpoint<ArrayBuffer>(id, accepts, page);
+  };
+
+  public documentAsPdf = (id: DocumentId): Promise<Any> => {
+    return this.previewEndpoint<Any>(id, 'application/pdf');
+  };
+
+  public documentAsImage = (id: DocumentId, page: number = 0): Promise<Any> => {
+    return this.previewEndpoint<Any>(id, 'image/png', page);
+  };
+
+  public temporaryLink = (
+    documentId: DocumentId
+  ): Promise<DocumentPreviewTemporaryLink> => {
+    return this.temporaryLinkEndpoint<DocumentPreviewTemporaryLink>(documentId);
+  };
+
+  public buildPreviewURI = (
+    id: DocumentId,
+    accepts: acceptsType = 'image/png',
+    page: number = 0
+  ): string => {
+    let uri = `${this.url()}?documentId=${id.toString()}`;
+    if (accepts == 'image/png') {
+      uri += `&page=${page.toString()}`;
+    }
+
+    return uri;
+  };
+
+  private async previewEndpoint<ResponseType>(
+    id: DocumentId,
+    accepts: acceptsType = 'image/png',
+    page: number = 0
+  ): Promise<ResponseType> {
+    const uri = this.buildPreviewURI(id, accepts, page);
+    const response = await this.get<ResponseType>(uri, {
+      responseType: HttpResponseType.ArrayBuffer,
+      headers: {
+        accepts: accepts,
+      },
+    });
+
+    return response.data;
+  }
+
+  private async temporaryLinkEndpoint<ResponseType>(
+    documentId: DocumentId
+  ): Promise<ResponseType> {
+    const response = await this.get<ResponseType>(this.url('temporaryLink'), {
+      params: {
+        documentId: documentId,
+      },
+    });
+    return response.data;
+  }
+}
+
+export type acceptsType = 'application/pdf' | 'image/png';

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -441,6 +441,10 @@ export interface DocumentFeedback {
   status: FeedbackStatus;
 }
 
+export interface DocumentPreviewTemporaryLink {
+  temporaryLink: string;
+}
+
 export type Source =
   | EventsSource
   | AssetsSource


### PR DESCRIPTION
Endpoints for the document preview service found under /documents:
 - https://cognitedata.atlassian.net/browse/SBS-3717

