### PR TITLE
chore: remove redundant codeowner statement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 * @cognitedata/cdf-user-experience @cognitedata/devx-externals
 /packages/wells/ @cognitedata/subsurface-data
-/packages/beta/src/api/documents @cognite/grep


### PR DESCRIPTION
This did not help the grep team approve their own contributions to the sdk. Removing it since it had no effect.