### PR TITLE
feat: added support for variables and operationName for templates

### DIFF
--- a/packages/beta/src/__tests__/api/templateGraphQlApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/templateGraphQlApi.int.spec.ts
@@ -57,14 +57,18 @@ describe.skip('template group test', () => {
   });
 
   it('should run a GraphQL query', async () => {
-    const result = await client.templates.group(externalId).version(1)
-      .runQuery(`
+    const result = await client.templates
+      .group(externalId)
+      .version(1)
+      .runQuery({
+        query: `
       {
         testList {
           a
           b
         }
-      }`);
+      }`,
+      });
     expect(result.data.testList).toEqual([{ a: 10, b: 'test' }]);
   });
 });

--- a/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
+++ b/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
@@ -23,7 +23,7 @@ export class TemplateGraphQlApi extends BaseResourceAPI<any> {
     const res = await this.post(this.url(), {
       data: {
         query: graphQlParams.query,
-        variables: JSON.stringify(graphQlParams.variables),
+        variables: graphQlParams.variables,
         operationName: graphQlParams.operationName,
       },
     });

--- a/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
+++ b/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
@@ -15,16 +15,20 @@ export class TemplateGraphQlApi extends BaseResourceAPI<any> {
    * `});
    * ```
    */
-  runQuery = async <TVariables extends Record<string, unknown>>(graphQlParams: {
+  runQuery = async <TVariables extends Record<string, unknown>>({
+    query,
+    variables,
+    operationName,
+  }: {
     query: string;
     variables?: TVariables;
     operationName?: string;
   }): Promise<GraphQlResponse> => {
     const res = await this.post(this.url(), {
       data: {
-        query: graphQlParams.query,
-        variables: graphQlParams.variables,
-        operationName: graphQlParams.operationName,
+        query,
+        variables,
+        operationName,
       },
     });
     return res.data as GraphQlResponse;

--- a/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
+++ b/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
@@ -15,11 +15,18 @@ export class TemplateGraphQlApi extends BaseResourceAPI<any> {
    * `);
    * ```
    */
-  runQuery = (query: string): Promise<GraphQlResponse> => {
-    return this.post(this.url(), {
+  runQuery = async <TVariables extends Record<string, unknown>>(
+    query: string,
+    variables?: TVariables,
+    operationName?: string
+  ): Promise<GraphQlResponse> => {
+    const res = await this.post(this.url(), {
       data: {
         query,
+        variables: JSON.stringify(variables),
+        operationName,
       },
-    }).then(res => res.data as GraphQlResponse);
+    });
+    return res.data as GraphQlResponse;
   };
 }

--- a/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
+++ b/packages/beta/src/api/templateGroups/templateGraphQlApi.ts
@@ -8,23 +8,23 @@ export class TemplateGraphQlApi extends BaseResourceAPI<any> {
    * [Run a GraphQL query](https://pr-1202.specs.preview.cogniteapp.com/v1.json.html#operation/postApiV1ProjectsProjectTemplategroupsExternalidVersionsVersionGraphql)
    *
    * ```js
-   * client.templates.group("myGroup").versions(1).runQuery(`
+   * client.templates.group("myGroup").versions(1).runQuery({ query: `
    *   wellList {
    *     name
    *   }
-   * `);
+   * `});
    * ```
    */
-  runQuery = async <TVariables extends Record<string, unknown>>(
-    query: string,
-    variables?: TVariables,
-    operationName?: string
-  ): Promise<GraphQlResponse> => {
+  runQuery = async <TVariables extends Record<string, unknown>>(graphQlParams: {
+    query: string;
+    variables?: TVariables;
+    operationName?: string;
+  }): Promise<GraphQlResponse> => {
     const res = await this.post(this.url(), {
       data: {
-        query,
-        variables: JSON.stringify(variables),
-        operationName,
+        query: graphQlParams.query,
+        variables: JSON.stringify(graphQlParams.variables),
+        operationName: graphQlParams.operationName,
       },
     });
     return res.data as GraphQlResponse;

--- a/packages/beta/src/cogniteClient.ts
+++ b/packages/beta/src/cogniteClient.ts
@@ -65,11 +65,13 @@ export default class CogniteClient extends CogniteClientCleaned {
                   `${baseGroupUrl}/instances`
                 )
               ),
-              runQuery: async <TVariables extends Record<string, unknown>>(
-                query: string,
-                variables?: TVariables,
-                operationName?: string
-              ) => graphQlApi.runQuery(query, variables, operationName),
+              runQuery: async <
+                TVariables extends Record<string, unknown>
+              >(graphQlParams: {
+                query: string;
+                variables?: TVariables;
+                operationName?: string;
+              }) => graphQlApi.runQuery(graphQlParams),
               views: accessApi(
                 this.apiFactory(ViewsApi, `${baseGroupUrl}/views`)
               ),

--- a/packages/beta/src/cogniteClient.ts
+++ b/packages/beta/src/cogniteClient.ts
@@ -65,7 +65,11 @@ export default class CogniteClient extends CogniteClientCleaned {
                   `${baseGroupUrl}/instances`
                 )
               ),
-              runQuery: (query: string) => graphQlApi.runQuery(query),
+              runQuery: async <TVariables extends Record<string, unknown>>(
+                query: string,
+                variables?: TVariables,
+                operationName?: string
+              ) => graphQlApi.runQuery(query, variables, operationName),
               views: accessApi(
                 this.apiFactory(ViewsApi, `${baseGroupUrl}/views`)
               ),


### PR DESCRIPTION
Added support for variables and operation name to the templates graphql. This will make it possible to use codegen to generate and compiletime check queries.

So need to be able to pass in the variables and the operationName through the sdk.