### PR TITLE
chore: try to fix the detached head error on release [release]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,8 +66,8 @@ jobs:
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs
 
-      - name: Fetch HEAD after doc publish
-        run: git checkout HEAD^
+      - name: Reattach HEAD after doc publish
+        run: git checkout "${GITHUB_REF:11}"
 
       - name: Lerna version
         run: yarn lerna version --conventional-commits --create-release github --no-private --yes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@ on:
       - 'release-*'
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -33,9 +32,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Reattach HEAD
-        run: git checkout "${GITHUB_REF:11}"
-
 
       - name: Cache node_modules
         id: cache-modules
@@ -69,6 +65,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs
+
+      - name: Fetch HEAD after doc publish
+        run: git checkout HEAD^
 
       - name: Lerna version
         run: yarn lerna version --conventional-commits --create-release github --no-private --yes


### PR DESCRIPTION
Seems like the publish of doc sets the checkout in a detached moode, so trying to checkout HEAD before doing Lerna version

![image](https://user-images.githubusercontent.com/21117/123749474-c3c3c780-d8b5-11eb-9856-4b4ade2d64c5.png)
