### PR TITLE
chore: use GH_LERNA_TOKEN for lerna version [release]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,12 +26,13 @@ jobs:
         run: yarn build
 
   publish:
-    if: ${{ contains(github.event.commits[0].message, '[release]') }}
+    if: ${{ contains(github.event.commits[0].message, '[release]') && !contains(github.event.commits[0].message, '[skip-ci]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache node_modules
         id: cache-modules

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,8 @@ jobs:
         run: git checkout "${GITHUB_REF:11}"
 
       - name: Lerna version
+        env:
+          GH_TOKEN: ${{ secrets.GH_LERNA_TOKEN }}
         run: yarn lerna version --conventional-commits --create-release github --no-private --yes
 
       - name: Lerna Publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Lerna version
         env:
-          GH_TOKEN: ${{ secrets.GH_LERNA_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_LERNA_TOKEN }} # Temporary fix to make lerna able to push the new versions commit to master
         run: yarn lerna version --conventional-commits --create-release github --no-private --yes
 
       - name: Lerna Publish


### PR DESCRIPTION
Lerna version is updating the master branch on release, and the master branch is protected so it fails making the release commit. So adding a temporary admin token to make Lerna able to push to master