### PR TITLE
feat: add api version parameter to BaseCogniteClient [release]

### DIFF
--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -39,8 +39,8 @@ function setupClient(baseUrl: string = BASE_URL) {
   return new BaseCogniteClient({ appId: 'JS SDK integration tests', baseUrl });
 }
 
-function setupMockableClient() {
-  const client = setupClient(mockBaseUrl);
+function setupMockableClient(base?: BaseCogniteClient) {
+  const client = base || setupClient(mockBaseUrl);
   client.loginWithApiKey({
     project,
     apiKey,
@@ -749,6 +749,43 @@ describe('CogniteClient', () => {
         expect(silentLogin).toBe(false);
         expect(authenticated).toBe(false);
         expect(onNoProjectAvailable).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('api version', () => {
+      test('default', async () => {
+        const version = 'v1';
+        const client = setupMockableClient();
+
+        // @ts-ignore
+        const projectUrl = client.projectUrl;
+        expect(projectUrl).toEqual(`/api/${version}/projects/TEST_PROJECT`);
+      });
+
+      test('v1', async () => {
+        const version = 'v1';
+        const base = new BaseCogniteClient(
+          { appId: 'JS SDK unit tests', baseUrl: BASE_URL },
+          version
+        );
+        const v1Client = setupMockableClient(base);
+
+        // @ts-ignore
+        const projectUrl = v1Client.projectUrl;
+        expect(projectUrl).toEqual(`/api/${version}/projects/TEST_PROJECT`);
+      });
+
+      test('playground', async () => {
+        const version = 'playground';
+        const base = new BaseCogniteClient(
+          { appId: 'JS SDK unit tests', baseUrl: BASE_URL },
+          version
+        );
+        const playgroundClient = setupMockableClient(base);
+
+        // @ts-ignore
+        const projectUrl = playgroundClient.projectUrl;
+        expect(projectUrl).toEqual(`/api/${version}/projects/TEST_PROJECT`);
       });
     });
 

--- a/packages/core/src/__tests__/constants.spec.ts
+++ b/packages/core/src/__tests__/constants.spec.ts
@@ -1,11 +1,7 @@
 // Copyright 2020 Cognite AS
 
-import { API_VERSION, BASE_URL } from '../constants';
+import { BASE_URL } from '../constants';
 
 test('BASE_URL', () => {
   expect(BASE_URL).toMatchInlineSnapshot(`"https://api.cognitedata.com"`);
-});
-
-test('API_VERSION', () => {
-  expect(API_VERSION).toMatchInlineSnapshot(`"v1"`);
 });

--- a/packages/core/src/__tests__/utils.unit.spec.ts
+++ b/packages/core/src/__tests__/utils.unit.spec.ts
@@ -10,6 +10,8 @@ import {
   promiseEachInSequence,
   promiseAllAtOnce,
   isJson,
+  CogniteAPIVersion,
+  apiUrl,
 } from '../utils';
 
 describe('utils', () => {
@@ -21,6 +23,14 @@ describe('utils', () => {
     expect(projectUrl('my-special-tenønt')).toMatchInlineSnapshot(
       `"/api/v1/projects/my-special-ten%C3%B8nt"`
     );
+  });
+
+  test('api version constraints', () => {
+    const v1: CogniteAPIVersion = 'v1';
+    const playground: CogniteAPIVersion = 'playground';
+
+    expect(apiUrl(v1)).toEqual(`/api/${v1}`);
+    expect(apiUrl(playground)).toEqual(`/api/${playground}`);
   });
 
   test('convertToTimestampToDateTime', () => {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,8 +1,6 @@
 // Copyright 2020 Cognite AS
 
 /** @hidden */
-export const API_VERSION: string = 'v1';
-/** @hidden */
 export const DEFAULT_CLUSTER = 'api';
 /** @hidden */
 export const DEFAULT_DOMAIN = 'cognitedata.com';

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -3,7 +3,7 @@
 import isObject from 'lodash/isObject';
 import isArray from 'lodash/isArray';
 import isBuffer from 'is-buffer';
-import { API_VERSION, BASE_URL } from './constants';
+import { BASE_URL } from './constants';
 import { CogniteError } from './error';
 import { CogniteMultiError } from './multiError';
 import {
@@ -14,16 +14,23 @@ import {
 } from './baseCogniteClient';
 
 /** @hidden */
+export type CogniteAPIVersion = 'v1' | 'playground';
+
+/** @hidden */
 export function getBaseUrl(baseUrl?: string) {
   return baseUrl || BASE_URL;
 }
 
 /** @hidden */
-export const apiUrl = () => `/api/${API_VERSION}`;
+export const apiUrl = (apiVersion: CogniteAPIVersion = 'v1') =>
+  `/api/${apiVersion}`;
 
 /** @hidden */
-export function projectUrl(project: string) {
-  return `${apiUrl()}/projects/${encodeURIComponent(project)}`;
+export function projectUrl(
+  project: string,
+  apiVersion: CogniteAPIVersion = 'v1'
+) {
+  return `${apiUrl(apiVersion)}/projects/${encodeURIComponent(project)}`;
 }
 
 /** @hidden */


### PR DESCRIPTION
I'm interested in making a playground package, but I cannot do so as the `v1` version is hardcoded. This change allows package devs to specify api version as a constructor parameter for BaseCogniteClient. This change is backward compatible.

See example for playground implementation here: https://github.com/cognitedata/cognite-sdk-js/pull/611