### PR TITLE
feat: add custom login flow method [release]

### DIFF
--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -104,9 +104,9 @@ export class BasicHttpClient {
     return this.baseUrl;
   }
 
-  public setCluster(cluster: string) {
+  public setCluster = (cluster: string) => {
     this.baseUrl = `https://${cluster}.${DEFAULT_DOMAIN}`;
-  }
+  };
 
   public get<ResponseType>(path: string, options: HttpRequestOptions = {}) {
     return this.request<ResponseType>({

--- a/packages/core/src/httpClient/cdfHttpClient.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.ts
@@ -68,9 +68,9 @@ export class CDFHttpClient extends RetryableHttpClient {
     return this;
   }
 
-  public setBearerToken(token: string) {
+  public setBearerToken = (token: string) => {
     this.setDefaultHeader(AUTHORIZATION_HEADER, bearerString(token));
-  }
+  };
 
   public set401ResponseHandler(handler: Response401Handler) {
     this.response401Handler = handler;


### PR DESCRIPTION
with this PR we can do this:

```typescript
    await sdk.loginWithCustom(async (callbacks) => {
      return await new OidcClientCredentials(
        {} as any, // fill in  whatever required stuff is needed for this to work
        callbacks
      ).init();
    })
```

where callbacks is 

```typescript
    type Callbacks = {
        setCluster: (s: string) => void;
        setBearerToken: (s: string) => void;
        validateAccessToken: (s: string) => Promise<boolean>;
    }
```

this way we keep server side nodejs oidc impls outside js sdk 