### PR TITLE
test: do not run tests for irrelevant packages

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,4 +99,4 @@ jobs:
         run: yarn build
 
       - name: Test
-        run: yarn test
+        run: yarn test --since master

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
         run: yarn build
 
       - name: Test/Codecov
-        run: yarn test:codecov --findRelatedTests
+        run: yarn test:codecov
 
       - name: Codecov
         uses: codecov/codecov-action@v1.0.11

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,4 +99,4 @@ jobs:
         run: yarn build
 
       - name: Test
-        run: yarn test --since master
+        run: yarn test --since origin/master

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,6 +80,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
         run: yarn build
 
       - name: Test/Codecov
-        run: yarn test:codecov
+        run: yarn test:codecov --since origin/master
 
       - name: Codecov
         uses: codecov/codecov-action@v1.0.11

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
         run: yarn build
 
       - name: Test/Codecov
-        run: yarn test:codecov --since origin/master
+        run: yarn test:codecov --findRelatedTests
 
       - name: Codecov
         uses: codecov/codecov-action@v1.0.11


### PR DESCRIPTION
Yarn allows us to inject some lerna parameters. I figured we could add `--since master` to only run tests for packages that differ from the master branch. Say I'm adding something to beta, this change will then only validate the tests for the beta packages instead of core, stable, wells, etc.

A change in core will still trigger tests for all packages, as core is a dependency.

However, for the codecov all tests for all packages are still executed.

Added fetch-depth due to: https://github.com/actions/checkout/issues/118#issuecomment-743979327