### PR TITLE
fix(core): headers set by the sdk must respect case insensitive keys

### DIFF
--- a/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
+++ b/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
@@ -51,8 +51,8 @@ describe('basicHttpClient', () => {
         'application/json'
       );
       expect(lengthOfHttpHeaders(alteredEmptyHeaders)).toEqual(1);
-      expect('Accept' in alteredEmptyHeaders).toBeTruthy();
-      expect(alteredEmptyHeaders['Accept']).toEqual(mediaType);
+      expect('accept' in alteredEmptyHeaders).toBeTruthy();
+      expect(alteredEmptyHeaders['accept']).toEqual(mediaType);
     });
   });
 });

--- a/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
+++ b/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
@@ -24,7 +24,7 @@ describe('basicHttpClient', () => {
         'application/json'
       );
       expect(lengthOfHttpHeaders(alteredEmptyHeaders)).toEqual(1);
-      expect('accept' in alteredEmptyHeaders).toBeTruthy();
+      expect('Accept' in alteredEmptyHeaders).toBeTruthy();
     });
     test('not overwrite existing', () => {
       const mediaType = 'image/png';
@@ -51,8 +51,8 @@ describe('basicHttpClient', () => {
         'application/json'
       );
       expect(lengthOfHttpHeaders(alteredEmptyHeaders)).toEqual(1);
-      expect('accept' in alteredEmptyHeaders).toBeTruthy();
-      expect(alteredEmptyHeaders['accept']).toEqual(mediaType);
+      expect('Accept' in alteredEmptyHeaders).toBeTruthy();
+      expect(alteredEmptyHeaders['Accept']).toEqual(mediaType);
     });
   });
 });

--- a/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
+++ b/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
@@ -37,8 +37,8 @@ describe('basicHttpClient', () => {
         'application/json'
       );
       expect(lengthOfHttpHeaders(alteredEmptyHeaders)).toEqual(1);
-      expect('accept' in alteredEmptyHeaders).toBeTruthy();
-      expect(alteredEmptyHeaders['accept']).toEqual(mediaType);
+      expect('Accept' in alteredEmptyHeaders).toBeTruthy();
+      expect(alteredEmptyHeaders['Accept']).toEqual(mediaType);
     });
     test('to be case insensitive', () => {
       const mediaType = 'image/png';

--- a/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
+++ b/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
@@ -1,0 +1,58 @@
+// Copyright 2020 Cognite AS
+
+// @ts-ignore
+import {
+  headersWithDefaultField,
+  HttpHeaders,
+} from '../../httpClient/basicHttpClient';
+
+function lengthOfHttpHeaders(headers?: HttpHeaders): number {
+  let counter = 0;
+  for (const _ in headers) {
+    counter += 1;
+  }
+  return counter;
+}
+
+describe('basicHttpClient', () => {
+  describe('headersWithDefaultField', () => {
+    test('add missing', () => {
+      const emptyHeaders: HttpHeaders = {};
+      const alteredEmptyHeaders = headersWithDefaultField(
+        emptyHeaders,
+        'Accept',
+        'application/json'
+      );
+      expect(lengthOfHttpHeaders(alteredEmptyHeaders)).toEqual(1);
+      expect('accept' in alteredEmptyHeaders).toBeTruthy();
+    });
+    test('not overwrite existing', () => {
+      const mediaType = 'image/png';
+      const emptyHeaders: HttpHeaders = {
+        Accept: mediaType,
+      };
+      const alteredEmptyHeaders = headersWithDefaultField(
+        emptyHeaders,
+        'Accept',
+        'application/json'
+      );
+      expect(lengthOfHttpHeaders(alteredEmptyHeaders)).toEqual(1);
+      expect('accept' in alteredEmptyHeaders).toBeTruthy();
+      expect(alteredEmptyHeaders['accept']).toEqual(mediaType);
+    });
+    test('to be case insensitive', () => {
+      const mediaType = 'image/png';
+      const emptyHeaders: HttpHeaders = {
+        accept: mediaType,
+      };
+      const alteredEmptyHeaders = headersWithDefaultField(
+        emptyHeaders,
+        'Accept',
+        'application/json'
+      );
+      expect(lengthOfHttpHeaders(alteredEmptyHeaders)).toEqual(1);
+      expect('accept' in alteredEmptyHeaders).toBeTruthy();
+      expect(alteredEmptyHeaders['accept']).toEqual(mediaType);
+    });
+  });
+});

--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -225,12 +225,12 @@ export class BasicHttpClient {
   }
 }
 
-function lowercaseHeaders(headers: HttpHeaders): HttpHeaders {
-  const lowercaseHeaders: HttpHeaders = {};
+function lowercaseHeadersKeys(headers: HttpHeaders): string[] {
+  const keys: string[] = [];
   for (const key in headers) {
-    lowercaseHeaders[key.toLowerCase()] = headers[key];
+    keys.push(key.toLowerCase());
   }
-  return lowercaseHeaders;
+  return keys;
 }
 
 export function headersWithDefaultField(
@@ -238,12 +238,10 @@ export function headersWithDefaultField(
   fieldName: string,
   fieldValue: string
 ): HttpHeaders {
-  const lowerCaseFieldName = fieldName.toLowerCase();
-  const updatedHeaders = { ...lowercaseHeaders(headers) };
-  if (!(lowerCaseFieldName in updatedHeaders)) {
-    updatedHeaders[lowerCaseFieldName] = fieldValue;
+  if (!(fieldName.toLowerCase() in lowercaseHeadersKeys(headers))) {
+    headers[fieldName] = fieldValue;
   }
-  return updatedHeaders;
+  return headers;
 }
 
 export interface HttpRequest extends HttpRequestOptions {

--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -179,10 +179,11 @@ export class BasicHttpClient {
     request: HttpRequest
   ): Promise<HttpResponse<ResponseType>> {
     const url = this.constructUrl(request.path, request.params);
-    const headers: HttpHeaders = {
-      Accept: 'application/json',
-      ...request.headers,
-    };
+    const headers = headersWithDefaultField(
+      request.headers,
+      'Accept',
+      'application/json'
+    );
     let body = request.data;
     if (isJson(body)) {
       body = BasicHttpClient.transformRequestBody(body);
@@ -222,6 +223,27 @@ export class BasicHttpClient {
     }
     return BasicHttpClient.resolveUrl(this.baseUrl, url);
   }
+}
+
+function lowercaseHeaders(headers: HttpHeaders): HttpHeaders {
+  const lowercaseHeaders: HttpHeaders = {};
+  for (const key in headers) {
+    lowercaseHeaders[key.toLowerCase()] = headers[key];
+  }
+  return lowercaseHeaders;
+}
+
+export function headersWithDefaultField(
+  headers: HttpHeaders = {},
+  fieldName: string,
+  fieldValue: string
+): HttpHeaders {
+  const lowerCaseFieldName = fieldName.toLowerCase();
+  const updatedHeaders = { ...lowercaseHeaders(headers) };
+  if (!(lowerCaseFieldName in updatedHeaders)) {
+    updatedHeaders[lowerCaseFieldName] = fieldValue;
+  }
+  return updatedHeaders;
 }
 
 export interface HttpRequest extends HttpRequestOptions {

--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -238,7 +238,9 @@ export function headersWithDefaultField(
   fieldName: string,
   fieldValue: string
 ): HttpHeaders {
-  if (!(fieldName.toLowerCase() in lowercaseHeadersKeys(headers))) {
+  const lowercaseHeaders = lowercaseHeadersKeys(headers);
+  const lowercaseKey = fieldName.toLowerCase();
+  if (!lowercaseHeaders.includes(lowercaseKey)) {
     headers[fieldName] = fieldValue;
   }
   return headers;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@
 import * as Constants from './constants';
 import * as GraphUtils from './graphUtils';
 import * as TestUtils from './testUtils';
+
 export * from './types';
 
 export { MetadataMap } from './metadata';


### PR DESCRIPTION
I noticed that the "Accept" field is added when it is not already present in the request header. However, the check is case sensitive, while the http RFC states that the http header are case insensitive.

This causes the `application/json` to be added when a user specify `accept` and not `Accept`:
```ts

    nock(mockBaseUrl)
      .get(new RegExp('/documents/preview'))
      .matchHeader('Accept', 'image/png')
      .query({ documentId: 1 })
      .once()
      .reply(200);

await this.get<ResponseType>(uri, {
      responseType: HttpResponseType.ArrayBuffer,
      headers: {
        accept: 'image/png',
      },
    });
```

The above test will fail as the accept header contains both `image/png` and `application/json`.