### PR TITLE
fix(core): remove slash suffix from uris [release]

### DIFF
--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -68,7 +68,7 @@ export class BasicHttpClient {
   private static resolveUrl(baseUrl: string, path: string) {
     const trimmedBaseUrl = baseUrl.replace(/\/$/, '');
     const pathWithPrefix = (path[0] === '/' ? '' : '/') + path;
-    return trimmedBaseUrl + pathWithPrefix;
+    return trimmedBaseUrl + pathWithPrefix.replace(/\/+$/, '');
   }
 
   private defaultHeaders: HttpHeaders = {};

--- a/packages/core/src/httpClient/basicHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/basicHttpClient.unit.spec.ts
@@ -203,6 +203,11 @@ describe('BasicHttpClient', () => {
       const path = BasicHttpClient.resolveUrl('', 'test');
       expect(path).toEqual('/test');
     });
+    test('should support multiple segments', async () => {
+      // @ts-ignore
+      const path = BasicHttpClient.resolveUrl('', 'test/te/st///');
+      expect(path).toEqual('/test/te/st');
+    });
     test('should do nothing with valid uri', async () => {
       // @ts-ignore
       const path = BasicHttpClient.resolveUrl('', '/test');

--- a/packages/core/src/httpClient/basicHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/basicHttpClient.unit.spec.ts
@@ -191,4 +191,22 @@ describe('BasicHttpClient', () => {
       await customClient.get('/abc');
     });
   });
+
+  describe('resolveUrl', () => {
+    test('should remove path trailing slashes', async () => {
+      // @ts-ignore
+      const path = BasicHttpClient.resolveUrl('', '/test///');
+      expect(path).toEqual('/test');
+    });
+    test('should add uri slash prefix', async () => {
+      // @ts-ignore
+      const path = BasicHttpClient.resolveUrl('', 'test');
+      expect(path).toEqual('/test');
+    });
+    test('should do nothing with valid uri', async () => {
+      // @ts-ignore
+      const path = BasicHttpClient.resolveUrl('', '/test');
+      expect(path).toEqual('/test');
+    });
+  });
 });


### PR DESCRIPTION
Sometimes the requests urls ends with `/`. This becomes a problem when using GET parameters:
`https://api.cognitedata.com/api/playground/projects/cognitesdk-js/documents/feedback/?status=CREATED`

While `/documents/feedback/?status=CREATED` responds with a 404, `/documents/feedback?status=CREATED` responds with an expected 200 status code. 

![image](https://user-images.githubusercontent.com/7851860/128005818-6b4a221a-58e1-4856-ae23-dec54ca9b178.png)
![image](https://user-images.githubusercontent.com/7851860/128005851-658c6bc3-7a59-4d74-a5ad-25e09724b2fe.png)
