### PR TITLE
test: remove duplicate testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x]
 
     env:
       COGNITE_PROJECT: cognitesdk-js


### PR DESCRIPTION
Right now both the "lint" job and the "tests" job execute tests for node 14.x. Updated the workflow to only run node 14.x for the "lint" job, while the "tests" executes 10.x and 12.x.