### PR TITLE
test: increase delay before retrieving model

### DIFF
--- a/packages/stable/src/__tests__/api/entityMatching.int.spec.ts
+++ b/packages/stable/src/__tests__/api/entityMatching.int.spec.ts
@@ -67,6 +67,10 @@ describe('context integration test', () => {
     });
 
     test('retrieve model', async () => {
+      // this test seem to be a bit unpredictable.
+      // I hope this delay may give the service some time
+      // to train the model before we try to retrieve it.
+      await new Promise(f => setTimeout(f, 60 * 1000)); // 1 minute
       await runTestWithRetryWhenFailing(async () => {
         const [result] = await client.entityMatching.retrieve([
           { externalId: modelExternalId },


### PR DESCRIPTION
entityMatching needs some extra time to train models. I've added a 1min delay, hoping this may fix it