### PR TITLE
fix: remove test files in published packages

### DIFF
--- a/packages/beta/package.json
+++ b/packages/beta/package.json
@@ -25,6 +25,9 @@
     "@cognite/sdk": "^5.3.1",
     "@cognite/sdk-core": "^3.2.3"
   },
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "@types/is-buffer": "^2.0.0"
   }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -25,6 +25,9 @@
     "@cognite/sdk": "^5.3.1",
     "@cognite/sdk-core": "^3.2.3"
   },
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -25,6 +25,9 @@
     "@cognite/sdk-core": "^3.2.3",
     "lodash": "^4.17.11"
   },
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -24,6 +24,9 @@
     "@cognite/sdk": "^4.0.0",
     "@cognite/sdk-core": "^2.0.0"
   },
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
closes #415 

"files" acts as a whitelist. I believe we only really need the dist folder and not all the configuration, tests, etc. 
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files