### PR TITLE
feat(documents)!: update pipelines request/response [skip-ci]

### DIFF
--- a/packages/playground/src/__tests__/api/documentsApi.uint.spec.ts
+++ b/packages/playground/src/__tests__/api/documentsApi.uint.spec.ts
@@ -52,11 +52,11 @@ describe('Documents unit test', () => {
                   TERMS: ['secret', 'confidential', 'sensitive'],
                 },
                 fieldMappings: {
-                  title: 'TERMS',
+                  title: ['TERMS'],
                   sourceFile: {
-                    name: 'TERMS',
-                    content: 'TERMS',
-                    directory: 'DIRECTORIES',
+                    name: ['TERMS'],
+                    content: ['TERMS'],
+                    directory: ['DIRECTORIES'],
                   },
                 },
                 sensitiveSecurityCategory: 345341343656745,
@@ -84,11 +84,11 @@ describe('Documents unit test', () => {
               TERMS: ['secret', 'confidential', 'sensitive'],
             },
             fieldMappings: {
-              title: 'TERMS',
+              title: ['TERMS'],
               sourceFile: {
-                name: 'TERMS',
-                content: 'TERMS',
-                directory: 'DIRECTORIES',
+                name: ['TERMS'],
+                content: ['TERMS'],
+                directory: ['DIRECTORIES'],
               },
             },
             sensitiveSecurityCategory: 345341343656745,

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -254,19 +254,19 @@ export interface SensitivityMatcher {
 }
 
 export interface DocumentsFieldMappings {
-  title?: string[];
-  author?: string[];
-  mimeType?: string[];
-  type?: string[];
+  title?: string | string[];
+  author?: string | string[];
+  mimeType?: string | string[];
+  type?: string | string[];
   labelsExternalIds?: string[];
   sourceFile?: DocumentsSourceFile;
 }
 
 export interface DocumentsSourceFile {
-  name?: string[];
-  directory?: string[];
-  content?: string[];
-  metadata?: StringToStringArrayMap;
+  name?: string | string[];
+  directory?: string | string[];
+  content?: string | string[];
+  metadata?: StringToStringMap | StringToStringArrayMap;
 }
 
 export type StringToStringArrayMap = {

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -254,19 +254,19 @@ export interface SensitivityMatcher {
 }
 
 export interface DocumentsFieldMappings {
-  title?: string | string[];
-  author?: string | string[];
-  mimeType?: string | string[];
-  type?: string | string[];
+  title?: string[];
+  author?: string[];
+  mimeType?: string[];
+  type?: string[];
   labelsExternalIds?: string[];
   sourceFile?: DocumentsSourceFile;
 }
 
 export interface DocumentsSourceFile {
-  name?: string | string[];
-  directory?: string | string[];
-  content?: string | string[];
-  metadata?: StringToStringMap | StringToStringArrayMap;
+  name?: string[];
+  directory?: string[];
+  content?: string[];
+  metadata?: StringToStringArrayMap;
 }
 
 export type StringToStringArrayMap = {

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -75,14 +75,6 @@ export interface DocumentsSourceFileFilter {
   size?: Range<number>;
 }
 
-export interface DocumentsPipeline {
-  externalId: CogniteExternalId;
-  sensitivityMatcher?: SensitivityMatcher;
-  classifier?: {
-    trainingLabels: LabelList[];
-  };
-}
-
 export interface ExternalDocumentsSearch {
   filter?: DocumentsFilter;
   search?: DocumentsSearch;
@@ -243,9 +235,12 @@ export interface DocumentsRequestFilter {
 export interface DocumentsPipeline {
   externalId: string;
   sensitivityMatcher?: SensitivityMatcher;
-  classifier?: {
-    trainingLabels: LabelList[];
-  };
+  classifier?: DocumentsPipelineClassifier;
+}
+
+export interface DocumentsPipelineClassifier {
+  trainingLabels: LabelList[];
+  activeClassifierId?: number;
 }
 
 export type LabelList = ExternalId;
@@ -255,23 +250,23 @@ export interface SensitivityMatcher {
   fieldMappings?: DocumentsFieldMappings;
   sensitiveSecurityCategory?: number;
   restrictToSources?: string[];
-}
-
-export interface DocumentsFieldMappings {
-  title?: string;
-  author?: string;
-  mimeType?: string;
-  type?: string;
-  labelsExternalIds?: string[];
-  sourceFile?: DocumentsSourceFile;
   filterPasswords?: boolean;
 }
 
+export interface DocumentsFieldMappings {
+  title?: string[];
+  author?: string[];
+  mimeType?: string[];
+  type?: string[];
+  labelsExternalIds?: string[];
+  sourceFile?: DocumentsSourceFile;
+}
+
 export interface DocumentsSourceFile {
-  name?: string;
-  directory?: string;
-  content?: string;
-  metadata?: StringToStringMap;
+  name?: string[];
+  directory?: string[];
+  content?: string[];
+  metadata?: StringToStringArrayMap;
 }
 
 export type StringToStringArrayMap = {


### PR DESCRIPTION
BREAKING CHANGE: pipeline config now takes an array of strings for field mappings and the metadata in document source

https://cognitedata.atlassian.net/browse/SBS-4181