### PR TITLE
fix(core): re-export project name from sdk

### DIFF
--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -75,7 +75,7 @@ export default class BaseCogniteClient {
    */
   private previousToken: string | undefined;
   private readonly getToken: () => Promise<string>;
-  private readonly project: string;
+  readonly project: string;
 
   /**
    * Create a new SDK client


### PR DESCRIPTION
This was removed without thinking too much about it here
https://github.com/cognitedata/cognite-sdk-js/pull/687/files#diff-f5cf019b59561cc0e0fe4b68ec004735f2cb7505a75e27446073658358dac20cL219.
But it's really convenient to expose this state through the SDK to avoid having to pass the project
to non-app code that want to use the SDK. Example
https://github.com/cognitedata/sdk-react-query-hooks/blob/master/src/api.ts#L4.