### PR TITLE
feat(documents pipeline update): remove deprecated str support

### DIFF
--- a/packages/playground/src/__tests__/api/documentsApi.uint.spec.ts
+++ b/packages/playground/src/__tests__/api/documentsApi.uint.spec.ts
@@ -84,11 +84,11 @@ describe('Documents unit test', () => {
               TERMS: ['secret', 'confidential', 'sensitive'],
             },
             fieldMappings: {
-              title: 'TERMS',
+              title: ['TERMS'],
               sourceFile: {
-                name: 'TERMS',
-                content: 'TERMS',
-                directory: 'DIRECTORIES',
+                name: ['TERMS'],
+                content: ['TERMS'],
+                directory: ['DIRECTORIES'],
               },
             },
             sensitiveSecurityCategory: 345341343656745,
@@ -205,7 +205,7 @@ describe('Documents unit test', () => {
             },
             fieldMappings: {
               set: {
-                title: 'dsfsdf',
+                title: ['dsfsdf'],
               },
             },
             filterPasswords: {

--- a/packages/playground/src/__tests__/api/documentsApi.uint.spec.ts
+++ b/packages/playground/src/__tests__/api/documentsApi.uint.spec.ts
@@ -52,11 +52,11 @@ describe('Documents unit test', () => {
                   TERMS: ['secret', 'confidential', 'sensitive'],
                 },
                 fieldMappings: {
-                  title: 'TERMS',
+                  title: ['TERMS'],
                   sourceFile: {
-                    name: 'TERMS',
-                    content: 'TERMS',
-                    directory: 'DIRECTORIES',
+                    name: ['TERMS'],
+                    content: ['TERMS'],
+                    directory: ['DIRECTORIES'],
                   },
                 },
                 sensitiveSecurityCategory: 345341343656745,
@@ -174,7 +174,7 @@ describe('Documents unit test', () => {
                 },
                 fieldMappings: {
                   set: {
-                    title: 'dsfsdf',
+                    title: ['dsfsdf'],
                   },
                 },
                 filterPasswords: {

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -304,18 +304,18 @@ export interface SensitivityMatcher {
 }
 
 export interface DocumentsFieldMappings {
-  title?: string | string[];
-  author?: string | string[];
-  mimeType?: string | string[];
-  type?: string | string[];
+  title?: string[];
+  author?: string[];
+  mimeType?: string[];
+  type?: string[];
   labelsExternalIds?: string[];
   sourceFile?: DocumentsSourceFile;
 }
 
 export interface DocumentsSourceFile {
-  name?: string | string[];
-  directory?: string | string[];
-  content?: string | string[];
+  name?: string[];
+  directory?: string[];
+  content?: string[];
   metadata?: StringToStringArrayMap;
 }
 


### PR DESCRIPTION
BREAKING CHANGE: removes support for str values in certain fields when updating pipeline