### PR TITLE
fix: use case-insensitive lookup for http header

### DIFF
--- a/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
+++ b/packages/core/src/__tests__/httpClient/basicHttpClient.unit.spec.ts
@@ -1,10 +1,8 @@
 // Copyright 2020 Cognite AS
 
 // @ts-ignore
-import {
-  headersWithDefaultField,
-  HttpHeaders,
-} from '../../httpClient/basicHttpClient';
+import { headersWithDefaultField } from '../../httpClient/basicHttpClient';
+import { HttpHeaders } from '../../httpClient/httpHeaders';
 
 function lengthOfHttpHeaders(headers?: HttpHeaders): number {
   let counter = 0;

--- a/packages/core/src/authFlows/legacy.ts
+++ b/packages/core/src/authFlows/legacy.ts
@@ -13,7 +13,8 @@ import {
 } from '../utils';
 import { CogniteLoginError } from '../loginError';
 import { AUTHORIZATION_HEADER } from '../constants';
-import { HttpCall, HttpHeaders } from '../httpClient/basicHttpClient';
+import { HttpCall } from '../httpClient/basicHttpClient';
+import { HttpHeaders } from '../httpClient/httpHeaders';
 import * as LoginUtils from '../loginUtils';
 import {
   ACCESS_TOKEN_PARAM,

--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -11,11 +11,8 @@ import {
   X_CDF_SDK_HEADER,
   API_KEY_HEADER,
 } from './constants';
-import {
-  HttpHeaders,
-  HttpRequestOptions,
-  HttpResponse,
-} from './httpClient/basicHttpClient';
+import { HttpRequestOptions, HttpResponse } from './httpClient/basicHttpClient';
+import { HttpHeaders } from './httpClient/httpHeaders';
 import { CDFHttpClient } from './httpClient/cdfHttpClient';
 import { MetadataMap } from './metadata';
 import {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -16,7 +16,7 @@ export const X_CDF_APP_HEADER = 'x-cdp-app';
 /** @hidden */
 export const X_CDF_SDK_HEADER = 'x-cdp-sdk';
 /** @hidden */
-export const X_REQUEST_ID = 'X-Request-Id';
+export const X_REQUEST_ID = 'x-request-id';
 
 /** @hidden */
 export const LOCAL_STORAGE_PREFIX = '@cognite/sdk:';

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -1,6 +1,7 @@
 // Copyright 2020 Cognite AS
 import { X_REQUEST_ID } from './constants';
 import { HttpError } from './httpClient/httpError';
+import { getHeaderField } from './httpClient/httpHeaders';
 
 export class CogniteError extends Error {
   public status: number;
@@ -74,7 +75,7 @@ export function handleErrorResponse(err: HttpError) {
     message = err.data.error.message;
     missing = err.data.error.missing;
     extra = err.data.error.extra;
-    requestId = (err.headers || {})[X_REQUEST_ID];
+    requestId = getHeaderField(err.headers || {}, X_REQUEST_ID);
   } catch (_) {
     throw err;
   }

--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -5,6 +5,7 @@ import { stringify } from 'query-string';
 import { isJson } from '../utils';
 import { HttpError } from './httpError';
 import { DEFAULT_DOMAIN } from '../constants';
+import { HttpHeaders } from './httpHeaders';
 
 export class BasicHttpClient {
   private static validateStatusCode(status: number) {
@@ -292,10 +293,6 @@ export const HttpResponseType = {
 
 export interface HttpQueryParams {
   [key: string]: any;
-}
-
-export interface HttpHeaders {
-  [key: string]: string;
 }
 
 type ResponseHandler<ResponseType> = (res: Response) => Promise<ResponseType>;

--- a/packages/core/src/httpClient/cdfHttpClient.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.ts
@@ -9,12 +9,8 @@ import {
 } from '../constants';
 import { handleErrorResponse } from '../error';
 import { bearerString, isJson } from '../utils';
-import {
-  HttpHeaders,
-  HttpQueryParams,
-  HttpRequest,
-  HttpResponse,
-} from './basicHttpClient';
+import { HttpQueryParams, HttpRequest, HttpResponse } from './basicHttpClient';
+import { HttpHeaders } from './httpHeaders';
 import { HttpError } from './httpError';
 import { RetryableHttpClient } from './retryableHttpClient';
 import { RetryValidator } from './retryValidator';

--- a/packages/core/src/httpClient/httpError.ts
+++ b/packages/core/src/httpClient/httpError.ts
@@ -1,5 +1,5 @@
 // Copyright 2020 Cognite AS
-import { HttpHeaders } from './basicHttpClient';
+import { HttpHeaders } from './httpHeaders';
 
 export class HttpError extends Error {
   /** @hidden */

--- a/packages/core/src/httpClient/httpHeaders.ts
+++ b/packages/core/src/httpClient/httpHeaders.ts
@@ -1,0 +1,3 @@
+export interface HttpHeaders {
+  [key: string]: string;
+}

--- a/packages/core/src/httpClient/httpHeaders.ts
+++ b/packages/core/src/httpClient/httpHeaders.ts
@@ -1,3 +1,19 @@
 export interface HttpHeaders {
   [key: string]: string;
 }
+
+/** @hidden */
+export function getHeaderField(
+  headers: HttpHeaders,
+  key: string
+): string | undefined {
+  const lowercaseKey = key.toLowerCase();
+
+  for (const headerKey in headers) {
+    if (headerKey.toLowerCase() == lowercaseKey) {
+      return headers[headerKey];
+    }
+  }
+
+  return undefined;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,12 +22,12 @@ export { CogniteLoginError } from './loginError';
 export { HttpError } from './httpClient/httpError';
 export {
   HttpResponse,
-  HttpHeaders,
   HttpResponseType,
   HttpQueryParams,
   HttpRequestOptions,
   HttpMethod,
 } from './httpClient/basicHttpClient';
+export { HttpHeaders } from './httpClient/httpHeaders';
 export {
   createUniversalRetryValidator,
   createRetryValidator,


### PR DESCRIPTION
Given that the rfc states http header keys are to be case-insensitive, we should not be using direct map lookup.

I also noticed the x-request-id seem to be lowercase in responses, and updated it as such. Though the new lookup function should fix any case-sensitive issues.