### PR TITLE
fix: use `type` field instead of instanceOf

### DIFF
--- a/packages/stable/src/api/templates/templateInstancesApi.ts
+++ b/packages/stable/src/api/templates/templateInstancesApi.ts
@@ -254,12 +254,12 @@ class TemplateInstanceCodec {
     }
   }
 
-  static isFieldResolver(fieldResolver: FieldResolver | {}) {
+  static isFieldResolver(fieldResolver: any) {
     return (
-      fieldResolver instanceof ConstantResolver ||
-      fieldResolver instanceof RawResolver ||
-      fieldResolver instanceof SyntheticTimeSeriesResolver ||
-      fieldResolver instanceof ViewResolver
+      fieldResolver.type === 'constant' ||
+      fieldResolver.type === 'raw' ||
+      fieldResolver.type === 'syntheticTimeSeries' ||
+      fieldResolver.type === 'view'
     );
   }
 }


### PR DESCRIPTION
The instanceOf approach is prone to errors if mismatching SDK versions are used at the same time.