### PR TITLE
chore: export ADFS auth class [release]

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ import * as TestUtils from './testUtils';
 export * from './types';
 
 export { CogniteAuthentication } from './authFlows/legacy';
+export { ADFS } from './authFlows/adfs';
 
 export { MetadataMap } from './metadata';
 export { BaseResourceAPI } from './baseResourceApi';


### PR DESCRIPTION
With v6+, apps are responsible for handling auth and there aren't any publicly available ADFS libraries.