### PR TITLE
feat(annotations): add filter for annotation data

### DIFF
--- a/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
@@ -185,6 +185,20 @@ describe('Annotations API', () => {
     expect(items).toHaveLength(createdAnnotationIds.length);
   });
 
+  test('list annotations with data filter', async () => {
+    const items = await client.annotations
+      .list({
+        filter: {
+          ...fileFilter(annotatedFileId),
+          data: {
+            assetRef: { externalId: 'def' },
+          },
+        },
+      })
+      .autoPagingToArray();
+    expect(items).toHaveLength(1);
+  });
+
   test('update annotation', async () => {
     const listResponse = await client.annotations.retrieve([
       createdAnnotationIds[0],

--- a/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
@@ -10,10 +10,42 @@ import {
   AnnotationFilterProps,
 } from '@cognite/sdk-playground';
 
-// Variables to be used in the tests
-let ANNOTATED_FILE_ID: number;
-let ANNOTATIONS: AnnotationCreate[];
-let FILE_FILTER: AnnotationFilterProps;
+const ANNOTATED_FILE_EXTERNAL_ID =
+  'sdk-integration-tests-file-' + new Date().toISOString();
+const ANNOTATIONS: AnnotationCreate[] = [
+  {
+    annotatedResourceType: 'file',
+    annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
+    annotationType: 'diagrams.FileLink',
+    creatingApp: 'integration-tests',
+    creatingAppVersion: '0.0.1',
+    creatingUser: 'integration-tests',
+    status: 'suggested',
+    data: {
+      pageNumber: 7,
+      fileRef: { externalId: 'abc' },
+      textRegion: { xMin: 0, xMax: 0.1, yMin: 0, yMax: 0.2 },
+    },
+  },
+  {
+    annotatedResourceType: 'file',
+    annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
+    annotationType: 'diagrams.AssetLink',
+    creatingApp: 'integration-tests',
+    creatingAppVersion: '0.0.1',
+    creatingUser: 'integration-tests',
+    status: 'suggested',
+    data: {
+      pageNumber: 42,
+      assetRef: { externalId: 'def' },
+      textRegion: { xMax: 0.15, xMin: 0.1, yMax: 0.15, yMin: 0.1 },
+    },
+  },
+];
+const FILE_FILTER: AnnotationFilterProps = {
+  annotatedResourceType: 'file',
+  annotatedResourceIds: [{ externalId: ANNOTATED_FILE_EXTERNAL_ID }],
+};
 
 describe('Annotations API', () => {
   let client: CogniteClientPlayground;
@@ -24,47 +56,10 @@ describe('Annotations API', () => {
     client = setupLoggedInClient();
     stableClient = stableApiClientSetup();
 
-    const fileInfo = await stableClient.files.upload({
-      name: 'testfile.bin',
+    await stableClient.files.upload({
+      externalId: ANNOTATED_FILE_EXTERNAL_ID,
+      name: ANNOTATED_FILE_EXTERNAL_ID,
     });
-
-    // Set global variables
-    ANNOTATED_FILE_ID = fileInfo.id;
-    FILE_FILTER = {
-      annotatedResourceType: 'file',
-      annotatedResourceIds: [{ id: ANNOTATED_FILE_ID }],
-    };
-    ANNOTATIONS = [
-      {
-        annotatedResourceType: 'file',
-        annotatedResourceId: ANNOTATED_FILE_ID,
-        annotationType: 'diagrams.FileLink',
-        creatingApp: 'integration-tests',
-        creatingAppVersion: '0.0.1',
-        creatingUser: 'integration-tests',
-        status: 'suggested',
-        data: {
-          pageNumber: 7,
-          fileRef: { externalId: 'abc' },
-          textRegion: { xMin: 0, xMax: 0.1, yMin: 0, yMax: 0.2 },
-        },
-      },
-      {
-        annotatedResourceType: 'file',
-        annotatedResourceId: ANNOTATED_FILE_ID,
-        annotationType: 'diagrams.AssetLink',
-        creatingApp: 'integration-tests',
-        creatingAppVersion: '0.0.1',
-        creatingUser: 'integration-tests',
-        status: 'suggested',
-        data: {
-          pageNumber: 42,
-          assetRef: { externalId: 'def' },
-          textRegion: { xMax: 0.15, xMin: 0.1, yMax: 0.15, yMin: 0.1 },
-        },
-      },
-    ];
-
     const created = await client.annotations.create(ANNOTATIONS);
     created.forEach((annotation) =>
       createdAnnotationIds.push({ id: annotation.id })
@@ -75,7 +70,7 @@ describe('Annotations API', () => {
     await client.annotations.delete(createdAnnotationIds);
     await stableClient.files.delete([
       {
-        id: ANNOTATED_FILE_ID,
+        externalId: ANNOTATED_FILE_EXTERNAL_ID,
       },
     ]);
   });
@@ -88,7 +83,7 @@ describe('Annotations API', () => {
     };
     const partial: AnnotationCreate = {
       annotatedResourceType: 'file',
-      annotatedResourceId: ANNOTATED_FILE_ID,
+      annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
       annotationType: 'documents.ExtractedText',
       creatingApp: 'integration-tests',
       creatingAppVersion: '0.0.1',
@@ -129,7 +124,7 @@ describe('Annotations API', () => {
   test('create annotation, service is creating', async () => {
     const partial: AnnotationCreate = {
       annotatedResourceType: 'file',
-      annotatedResourceId: ANNOTATED_FILE_ID,
+      annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
       annotationType: 'documents.ExtractedText',
       creatingApp: 'integration-tests',
       creatingAppVersion: '0.0.1',

--- a/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
@@ -10,42 +10,10 @@ import {
   AnnotationFilterProps,
 } from '@cognite/sdk-playground';
 
-const ANNOTATED_FILE_EXTERNAL_ID =
-  'sdk-integration-tests-file-' + new Date().toISOString();
-const ANNOTATIONS: AnnotationCreate[] = [
-  {
-    annotatedResourceType: 'file',
-    annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
-    annotationType: 'diagrams.FileLink',
-    creatingApp: 'integration-tests',
-    creatingAppVersion: '0.0.1',
-    creatingUser: 'integration-tests',
-    status: 'suggested',
-    data: {
-      pageNumber: 7,
-      fileRef: { externalId: 'abc' },
-      textRegion: { xMin: 0, xMax: 0.1, yMin: 0, yMax: 0.2 },
-    },
-  },
-  {
-    annotatedResourceType: 'file',
-    annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
-    annotationType: 'diagrams.AssetLink',
-    creatingApp: 'integration-tests',
-    creatingAppVersion: '0.0.1',
-    creatingUser: 'integration-tests',
-    status: 'suggested',
-    data: {
-      pageNumber: 42,
-      assetRef: { externalId: 'def' },
-      textRegion: { xMax: 0.15, xMin: 0.1, yMax: 0.15, yMin: 0.1 },
-    },
-  },
-];
-const FILE_FILTER: AnnotationFilterProps = {
-  annotatedResourceType: 'file',
-  annotatedResourceIds: [{ externalId: ANNOTATED_FILE_EXTERNAL_ID }],
-};
+// Variables to be used in the tests
+let ANNOTATED_FILE_ID: number;
+let ANNOTATIONS: AnnotationCreate[];
+let FILE_FILTER: AnnotationFilterProps;
 
 describe('Annotations API', () => {
   let client: CogniteClientPlayground;
@@ -56,10 +24,47 @@ describe('Annotations API', () => {
     client = setupLoggedInClient();
     stableClient = stableApiClientSetup();
 
-    await stableClient.files.upload({
-      externalId: ANNOTATED_FILE_EXTERNAL_ID,
-      name: ANNOTATED_FILE_EXTERNAL_ID,
+    const fileInfo = await stableClient.files.upload({
+      name: 'testfile.bin',
     });
+
+    // Set global variables
+    ANNOTATED_FILE_ID = fileInfo.id;
+    FILE_FILTER = {
+      annotatedResourceType: 'file',
+      annotatedResourceIds: [{ id: ANNOTATED_FILE_ID }],
+    };
+    ANNOTATIONS = [
+      {
+        annotatedResourceType: 'file',
+        annotatedResourceId: ANNOTATED_FILE_ID,
+        annotationType: 'diagrams.FileLink',
+        creatingApp: 'integration-tests',
+        creatingAppVersion: '0.0.1',
+        creatingUser: 'integration-tests',
+        status: 'suggested',
+        data: {
+          pageNumber: 7,
+          fileRef: { externalId: 'abc' },
+          textRegion: { xMin: 0, xMax: 0.1, yMin: 0, yMax: 0.2 },
+        },
+      },
+      {
+        annotatedResourceType: 'file',
+        annotatedResourceId: ANNOTATED_FILE_ID,
+        annotationType: 'diagrams.AssetLink',
+        creatingApp: 'integration-tests',
+        creatingAppVersion: '0.0.1',
+        creatingUser: 'integration-tests',
+        status: 'suggested',
+        data: {
+          pageNumber: 42,
+          assetRef: { externalId: 'def' },
+          textRegion: { xMax: 0.15, xMin: 0.1, yMax: 0.15, yMin: 0.1 },
+        },
+      },
+    ];
+
     const created = await client.annotations.create(ANNOTATIONS);
     created.forEach((annotation) =>
       createdAnnotationIds.push({ id: annotation.id })
@@ -70,7 +75,7 @@ describe('Annotations API', () => {
     await client.annotations.delete(createdAnnotationIds);
     await stableClient.files.delete([
       {
-        externalId: ANNOTATED_FILE_EXTERNAL_ID,
+        id: ANNOTATED_FILE_ID,
       },
     ]);
   });
@@ -83,7 +88,7 @@ describe('Annotations API', () => {
     };
     const partial: AnnotationCreate = {
       annotatedResourceType: 'file',
-      annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
+      annotatedResourceId: ANNOTATED_FILE_ID,
       annotationType: 'documents.ExtractedText',
       creatingApp: 'integration-tests',
       creatingAppVersion: '0.0.1',
@@ -124,7 +129,7 @@ describe('Annotations API', () => {
   test('create annotation, service is creating', async () => {
     const partial: AnnotationCreate = {
       annotatedResourceType: 'file',
-      annotatedResourceExternalId: ANNOTATED_FILE_EXTERNAL_ID,
+      annotatedResourceId: ANNOTATED_FILE_ID,
       annotationType: 'documents.ExtractedText',
       creatingApp: 'integration-tests',
       creatingAppVersion: '0.0.1',

--- a/packages/playground/src/api/annotations/types.ts
+++ b/packages/playground/src/api/annotations/types.ts
@@ -69,4 +69,5 @@ export interface AnnotationFilterProps {
   linkedResourceType?: LinkedResourceType;
   linkedResourceIds?: IdEither[];
   status?: AnnotationStatus;
+  data?: AnnotationPayload;
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,7 +9,7 @@ This folder contains examples on how to use the SDK in different frameworks.
 
 ## Prerequisites
 
-- Clone this repository locally. See guide [here](https://help.github.com/en/articles/cloning-a-repository).
+- Clone this repository locally. See guide [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
 - Install NodeJS on your machine. You can download NodeJS [here](https://nodejs.org/en/download/).
 - Open one of the sample project directories in a terminal.
 - Install dependencies by running `npm install`, or with yarn `yarn`.


### PR DESCRIPTION
Adds support for filtering/querying annotations based on their annotation data. This is done by adding the `data` prop to `AnnotationFilterProps`. https://github.com/cognitedata/cognite-sdk-js/pull/782/commits/e46e9dfc757b01907c278748c2d89b7be5616b79

~Moreover, the integration tests for the annotations api are fixed. https://github.com/cognitedata/cognite-sdk-js/pull/782/commits/296f275dfa99f4313e9b7ebc54efc37168547aee~ Will revert changes after https://github.com/cognitedata/cognite-sdk-js/pull/781 is merged

Jira: [VIS-789](https://cognitedata.atlassian.net/browse/VIS-789)