### PR TITLE
feat(annotations): add filter for annotation data

### DIFF
--- a/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
@@ -185,6 +185,20 @@ describe('Annotations API', () => {
     expect(items).toHaveLength(createdAnnotationIds.length);
   });
 
+  test('list annotations with data filter', async () => {
+    const items = await client.annotations
+      .list({
+        filter: {
+          ...fileFilter(annotatedFileId),
+          data: {
+            assetRef: { externalId: 'def' },
+          },
+        },
+      })
+      .autoPagingToArray();
+    expect(items).toHaveLength(1);
+  });
+
   test('update annotation', async () => {
     const listResponse = await client.annotations.retrieve([
       createdAnnotationIds[0],

--- a/packages/playground/src/api/annotations/types.ts
+++ b/packages/playground/src/api/annotations/types.ts
@@ -69,4 +69,5 @@ export interface AnnotationFilterProps {
   linkedResourceType?: LinkedResourceType;
   linkedResourceIds?: IdEither[];
   status?: AnnotationStatus;
+  data?: AnnotationPayload;
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,7 +9,7 @@ This folder contains examples on how to use the SDK in different frameworks.
 
 ## Prerequisites
 
-- Clone this repository locally. See guide [here](https://help.github.com/en/articles/cloning-a-repository).
+- Clone this repository locally. See guide [here](https://www.tutorialspoint.com/how-to-clone-a-github-repository).
 - Install NodeJS on your machine. You can download NodeJS [here](https://nodejs.org/en/download/).
 - Open one of the sample project directories in a terminal.
 - Install dependencies by running `npm install`, or with yarn `yarn`.


### PR DESCRIPTION
Adds support for filtering/querying annotations based on their annotation data. This is done by adding the `data` prop to `AnnotationFilterProps`. https://github.com/cognitedata/cognite-sdk-js/pull/783/commits/21fd2443fcbc0694a18b03eddab654b2e329d71e

Jira: [VIS-789](https://cognitedata.atlassian.net/browse/VIS-789)