### PR TITLE
feat: show warning on sdk-core version mismatch

### DIFF
--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -276,7 +276,7 @@ export default class BaseCogniteClient {
   }
 
   protected get version() {
-    return `${version}-core`;
+    return version
   }
 
   protected apiFactory = <ApiType>(

--- a/packages/stable/src/cogniteClient.ts
+++ b/packages/stable/src/cogniteClient.ts
@@ -3,9 +3,11 @@ import {
   accessApi,
   apiUrl,
   BaseCogniteClient,
+  ClientOptions,
   RetryValidator,
 } from '@cognite/sdk-core';
-import { version } from '../package.json';
+import { CogniteAPIVersion } from '@cognite/sdk-core/src/utils';
+import { version, dependencies } from '../package.json';
 import { AssetMappings3DAPI } from './api/3d/assetMappings3DApi';
 import { Files3DAPI } from './api/3d/files3DApi';
 import { Models3DAPI } from './api/3d/models3DApi';
@@ -172,12 +174,31 @@ export default class CogniteClient extends BaseCogniteClient {
   private geospatialApi?: GeospatialAPI;
   private documentsApi?: DocumentsAPI;
 
+  constructor(options: ClientOptions, apiVersion: CogniteAPIVersion = 'v1') {
+    super(options, apiVersion);
+    this.checkCoreVersionMatch();
+  }
+
   protected get version() {
     return version;
   }
 
+  protected get coreVersion() {
+    // @ts-ignore linter is complaining even though version is protected and can be accessed
+    return super.version;
+  }
+
   protected getRetryValidator(): RetryValidator {
     return retryValidator;
+  }
+
+  private checkCoreVersionMatch() {
+    // check if sdk-core version matches with the one in the dependencies
+    if (!dependencies['@cognite/sdk-core'].includes(this.coreVersion)) {
+      console.warn(
+        `VERSION MISMATCH! \n The resolved @cognite/sdk-core version ${this.coreVersion} doesn't match the required version ${dependencies['@cognite/sdk-core']} from @cognite/sdk. This might lead to unexpected behavior and bugs.`
+      );
+    }
   }
 
   protected initAPIs() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8166,6 +8166,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+geojson@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/geojson/-/geojson-0.5.0.tgz#3cd6c96399be65b56ee55596116fe9191ce701c0"
+  integrity sha1-PNbJY5m+ZbVu5VWWEW/pGRznAcA=
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
Depending on the repository where `@cognite/sdk` is used it can happen that it resolves to an older `@cognite/sdk-core` version and it's really hard to debug or know what's going on. This way we will at least see a warning telling us that the resolved version is wrong.