### PR TITLE
feat(annotations): support for suggest endpoint

### DIFF
--- a/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/playground/src/__tests__/api/annotationsApi.int.spec.ts
@@ -7,6 +7,7 @@ import { setupLoggedInClient as stableApiClientSetup } from '../../../../stable/
 import {
   AnnotationChangeById,
   AnnotationCreate,
+  AnnotationSuggest,
   AnnotationFilterProps,
 } from '@cognite/sdk-playground';
 
@@ -124,6 +125,30 @@ describe('Annotations API', () => {
     expect(annotationData.textRegion.yMin).toEqual(data.textRegion.yMin);
     expect(annotationData.textRegion.yMax).toEqual(data.textRegion.yMax);
     expect(annotationData.extractedText).toEqual(data.extractedText);
+
+    await client.annotations.delete([{ id: annotation.id }]);
+  });
+
+  test('suggest annotation', async () => {
+    const data = {
+      pageNumber: 7,
+      textRegion: { xMin: 0, xMax: 0.1, yMin: 0, yMax: 0.2 },
+      extractedText: 'i am your father',
+    };
+    const partial: AnnotationSuggest = {
+      annotatedResourceType: 'file',
+      annotatedResourceId: annotatedFileId,
+      annotationType: 'documents.ExtractedText',
+      creatingApp: 'integration-tests',
+      creatingAppVersion: '0.0.1',
+      creatingUser: 'integration-tests',
+      data,
+    };
+    const created = await client.annotations.suggest([partial]);
+
+    expect(created).toHaveLength(1);
+    const annotation = created[0];
+    expect(annotation.status).toEqual('suggested');
 
     await client.annotations.delete([{ id: annotation.id }]);
   });

--- a/packages/playground/src/api/annotations/annotationsApi.ts
+++ b/packages/playground/src/api/annotations/annotationsApi.ts
@@ -9,6 +9,7 @@ import {
 import {
   AnnotationChangeById,
   AnnotationCreate,
+  AnnotationSuggest,
   AnnotationFilterRequest,
   AnnotationModel,
 } from './types';
@@ -22,11 +23,22 @@ export class AnnotationsAPI extends BaseResourceAPI<AnnotationModel> {
     return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
   }
 
+  protected get suggestUrl() {
+    return this.url('suggest');
+  }
+
   /**
    * [Create annotations](https://docs.cognite.com/api/playground/#operation/annotationsCreate)
    */
   public create = (items: AnnotationCreate[]) => {
     return this.createEndpoint(items);
+  };
+
+  /**
+   * [Suggest annotations](https://docs.cognite.com/api/playground/#operation/annotationsSuggest)
+   */
+  public suggest = (items: AnnotationSuggest[]) => {
+    return this.createEndpoint(items, this.suggestUrl);
   };
 
   /**

--- a/packages/playground/src/api/annotations/types.ts
+++ b/packages/playground/src/api/annotations/types.ts
@@ -46,7 +46,7 @@ export interface AnnotationChangeById extends InternalId, AnnotationUpdate {}
 
 export interface AnnotationUpdate {
   update: {
-    annotationType?: SetField<AnnotationPayload>;
+    annotationType?: SetField<AnnotationType>;
     data?: SetField<AnnotationPayload>;
     linkedResourceType?: SinglePatch<LinkedResourceType>;
     linkedResourceId?: SinglePatch<CogniteInternalId>;

--- a/packages/playground/src/api/annotations/types.ts
+++ b/packages/playground/src/api/annotations/types.ts
@@ -24,7 +24,11 @@ export interface AnnotationModel extends AnnotationCreate {
   lastUpdatedTime: Date;
 }
 
-export interface AnnotationCreate {
+export interface AnnotationCreate extends AnnotationSuggest {
+  status: AnnotationStatus;
+}
+
+export interface AnnotationSuggest {
   annotatedResourceType: AnnotatedResourceType;
   annotatedResourceId?: CogniteInternalId;
   annotatedResourceExternalId?: CogniteExternalId;
@@ -36,7 +40,6 @@ export interface AnnotationCreate {
   linkedResourceType?: LinkedResourceType;
   linkedResourceId?: CogniteInternalId;
   linkedResourceExternalId?: CogniteExternalId;
-  status: AnnotationStatus;
 }
 
 export interface AnnotationChangeById extends InternalId, AnnotationUpdate {}

--- a/packages/playground/src/api/annotations/types.ts
+++ b/packages/playground/src/api/annotations/types.ts
@@ -68,6 +68,7 @@ export interface AnnotationFilterProps {
   annotatedResourceIds: IdEither[];
   annotationType?: AnnotationType;
   creatingApp?: string;
+  creatingAppVersion?: string;
   creatingUser?: string | null;
   linkedResourceType?: LinkedResourceType;
   linkedResourceIds?: IdEither[];

--- a/packages/playground/src/api/annotations/types.ts
+++ b/packages/playground/src/api/annotations/types.ts
@@ -30,8 +30,7 @@ export interface AnnotationCreate extends AnnotationSuggest {
 
 export interface AnnotationSuggest {
   annotatedResourceType: AnnotatedResourceType;
-  annotatedResourceId?: CogniteInternalId;
-  annotatedResourceExternalId?: CogniteExternalId;
+  annotatedResourceId: CogniteInternalId;
   annotationType: AnnotationType;
   creatingApp: string;
   creatingAppVersion: string;


### PR DESCRIPTION
- Added support for the new `/suggest` endpoint on the Annotations API
- Added a new interface `AnnotationSuggest` for it, which does not contain the `status` field as it is implicitly set to "suggested"
- Have the `AnnotationCreate` interface derive from `AnnotationSuggest``