### PR TITLE
chore: drop cli to write config to simplify

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -51,13 +51,30 @@ it block other updates.
 
 ## Configuring type generation for a service
 
-```bash
-yarn codegen configure --package stable --service my-service
+Create a `codegen.json` file in the service directory (e.g.
+`packages/stable/src/api/documents/codegen.json`) using this
+template:
+
+```json
+{
+  "service": "SERVICE-NAME",
+  "filter": {
+    "serviceName": "SERVICE-NAME"
+  },
+  "inlinedSchemas": {
+    "autoNameRequest": true
+  }
+}
 ```
 
-This will generate a `codegen.json` file for the given service
-so types will be created on next run.
+Replace `SERVICE-NAME` with the approriate value, such as `documents`.
 
 The types extracted are based on the paths in the OpenAPI document
 that matches the name of the service. It is currently not possible
 to select individually paths other than this.
+
+Now you can generate types which should include types for your service. E.g:
+
+```bash
+yarn codegen generate-types --package stable
+```

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -1,6 +1,5 @@
 // Copyright 2022 Cognite AS
 import yargs, { CommandModule, Options } from 'yargs';
-import { createConfiguration } from './configuration';
 import { generateTypes } from './generate';
 import { updateSnapshot } from './snapshot';
 
@@ -33,29 +32,6 @@ const generateTypesCommand: CommandModule = {
   },
 };
 
-const configureCommand: CommandModule = {
-  command: 'configure',
-  describe: 'Create configuration file to enable type generation for a service',
-  builder: (yargs) =>
-    yargs
-      .option('package', packageOptions)
-      .option('service', {
-        describe: 'REST service to configure types for',
-        type: 'string',
-      })
-      .option('version', {
-        describe: 'Cognite API version (v1, playground)',
-        type: 'string',
-      }),
-  handler: async (argv) => {
-    await createConfiguration({
-      package: argv.package as string,
-      service: argv.service as string | undefined,
-      version: argv.version as string | undefined,
-    });
-  },
-};
-
 async function main(): Promise<void> {
   await yargs(process.argv.slice(2))
     .version(false)
@@ -64,7 +40,6 @@ async function main(): Promise<void> {
     .recommendCommands()
     .command(fetchLatestCommand)
     .command(generateTypesCommand)
-    .command(configureCommand)
     .demandCommand()
     .strict()
     .parse();


### PR DESCRIPTION
I suggest we don't have a CLI command to generate the configuration.

For package-specific configs there also needs to be files like `.eslintignore`.

For service-specific configs I think it's easier to keep a template for it, which can also help document what the various fields actually means. I think this demystifies the process, making it more understandable.