### PR TITLE
feat(annotations): remove linked resource fields

### DIFF
--- a/packages/playground/src/api/annotations/types.ts
+++ b/packages/playground/src/api/annotations/types.ts
@@ -1,17 +1,14 @@
 // Copyright 2022 Cognite AS
 
 import {
-  CogniteExternalId,
   CogniteInternalId,
   FilterQuery,
   IdEither,
   InternalId,
   SetField,
-  SinglePatch,
 } from '@cognite/sdk';
 
 export type AnnotatedResourceType = 'file';
-export type LinkedResourceType = 'file' | 'asset';
 export type AnnotationStatus = 'suggested' | 'approved' | 'rejected';
 
 // TODO [CXT-463] Use annotation-types package definitions
@@ -36,9 +33,6 @@ export interface AnnotationSuggest {
   creatingAppVersion: string;
   creatingUser: string | null;
   data: AnnotationPayload;
-  linkedResourceType?: LinkedResourceType;
-  linkedResourceId?: CogniteInternalId;
-  linkedResourceExternalId?: CogniteExternalId;
 }
 
 export interface AnnotationChangeById extends InternalId, AnnotationUpdate {}
@@ -47,9 +41,6 @@ export interface AnnotationUpdate {
   update: {
     annotationType?: SetField<AnnotationType>;
     data?: SetField<AnnotationPayload>;
-    linkedResourceType?: SinglePatch<LinkedResourceType>;
-    linkedResourceId?: SinglePatch<CogniteInternalId>;
-    linkedResourceExternalId?: SinglePatch<CogniteExternalId>;
     status?: SetField<AnnotationStatus>;
   };
 }
@@ -69,8 +60,6 @@ export interface AnnotationFilterProps {
   creatingApp?: string;
   creatingAppVersion?: string;
   creatingUser?: string | null;
-  linkedResourceType?: LinkedResourceType;
-  linkedResourceIds?: IdEither[];
   status?: AnnotationStatus;
   data?: AnnotationPayload;
 }


### PR DESCRIPTION
This PR removes the linked resource fields for AnnotationsV2 since these fields has been removed in the API (the same functionality can be achieved by using the `data` field).