### PR TITLE
chore: update default behavior of yarn

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.frozen-lockfile true


### PR DESCRIPTION
The `yarn` or `yarn install` command should not mutate the lock file, simply install the dependencies.