### PR TITLE
feat: add parameter support in vision extract

### DIFF
--- a/packages/playground/src/__tests__/api/visionApi.int.spec.ts
+++ b/packages/playground/src/__tests__/api/visionApi.int.spec.ts
@@ -15,7 +15,8 @@ describe('Vision API', () => {
 
     extractJob = await playgroundClient.vision.extract(
       ['TextDetection'],
-      [{ fileId: TEST_IMAGE_ID }]
+      [{ fileId: TEST_IMAGE_ID }],
+      { textDetectionParameters: { threshold: 0.4 } }
     );
   });
 
@@ -28,6 +29,10 @@ describe('Vision API', () => {
     expect(extractJob.items).toEqual([
       { fileId: TEST_IMAGE_ID, fileExternalId: 'vision_extract_test_image' },
     ]);
+    expect(extractJob.parameters).toBeDefined();
+    expect(extractJob.parameters!.textDetectionParameters).toEqual({
+      threshold: 0.4,
+    });
   });
 
   describe('retrieve extract job', () => {
@@ -65,7 +70,9 @@ describe('Vision API', () => {
       // we care in the following checks is that the *data structure* is
       // correctly filled.
       expect(result.parameters).toBeDefined();
-      expect(result.parameters!.textDetectionParameters).toBeDefined();
+      expect(result.parameters!.textDetectionParameters).toEqual({
+        threshold: 0.4,
+      });
 
       expect(result.items?.length).toBeGreaterThan(0);
       const resultItem = result.items![0];

--- a/packages/playground/src/api/vision/visionApi.ts
+++ b/packages/playground/src/api/vision/visionApi.ts
@@ -8,6 +8,7 @@ import {
   VisionExtractFeature,
   FileReference,
   JobStatus,
+  FeatureParameters,
 } from '../../types';
 
 const JOB_COMPLETE_STATES: JobStatus[] = ['Completed', 'Failed'];
@@ -17,16 +18,17 @@ export class VisionAPI extends BaseResourceAPI<VisionExtractGetResponse> {
    * [Extract features from image](https://docs.cognite.com/api/playground/#tag/Vision/operation/postVisionExtract)
    *
    * ```js
-   * const response = await client.vision.extract(["TextDetection"], [{id: 1234}]);
+   * const response = await client.vision.extract(["TextDetection"], [{id: 1234}], {textDetectionParameters: {threshold: 0.4}});
    * ```
    */
   public extract = async (
     features: VisionExtractFeature[],
-    ids: FileReference[]
+    ids: FileReference[],
+    parameters?: FeatureParameters
   ): Promise<VisionExtractPostResponse> => {
     const path = this.url('extract');
     const response = await this.post<VisionExtractPostResponse>(path, {
-      data: { features: features, items: ids },
+      data: { features: features, items: ids, parameters: parameters },
     });
     return this.addToMapAndReturn(response.data, response);
   };


### PR DESCRIPTION
This work adds support for providing feature parameters to the `client.vision.extract` function.

Jira ticket: [VIS-1041](https://cognitedata.atlassian.net/browse/VIS-1041)