### PR TITLE
fix: adfs login when iframe doesn't work by storing tokens

### DIFF
--- a/packages/core/src/authFlows/__tests__/adfs.unit.spec.ts
+++ b/packages/core/src/authFlows/__tests__/adfs.unit.spec.ts
@@ -21,6 +21,7 @@ describe('ADFS', () => {
   beforeEach(() => {
     window.history.pushState({}, '', '');
     nock.cleanAll();
+    sessionStorage.clear();
   });
 
   describe('login', () => {
@@ -123,6 +124,7 @@ describe('ADFS', () => {
         });
 
       const cdfTokenAfterLogin = await adfsClient.login();
+      sessionStorage.clear(); // force silent login
       const updatedCdfToken = await adfsClient.getCDFToken();
 
       expect(silentLogin).toHaveBeenCalledTimes(2);
@@ -143,6 +145,7 @@ describe('ADFS', () => {
         );
 
       const cdfTokenAfterLogin = await adfsClient.login();
+      sessionStorage.clear();
       const updatedCdfToken = await adfsClient.getCDFToken();
 
       expect(silentLogin).toHaveBeenCalledTimes(2);

--- a/packages/core/src/authFlows/adfs.ts
+++ b/packages/core/src/authFlows/adfs.ts
@@ -99,7 +99,7 @@ export class ADFS {
         SCOPE,
         TOKEN_TYPE
       );
-      this.token = token;
+      this.setToken(token);
 
       return token;
     } catch (e) {
@@ -132,11 +132,14 @@ export class ADFS {
    * (using implicit grant flow)
    */
   private async acquireTokenSilently(): Promise<ADFSToken | null> {
+    let token = this.getToken();
+    if (token) {
+      return token;
+    }
+
     const url = `${this.authority}?prompt=none&${this.getADFSQueryParamString(
       this.queryParams
     )}`;
-
-    let token: ADFSToken | null = null;
 
     try {
       token = await silentLoginViaIframe<ADFSToken | null>(
@@ -149,7 +152,7 @@ export class ADFS {
     }
 
     if (token) {
-      this.token = token;
+      this.setToken(token);
     }
 
     return token;
@@ -188,6 +191,39 @@ export class ADFS {
     return Object.entries(params).reduce((result, [key, value]) => {
       return `${result}${result.length > 1 ? '&' : ''}${key}=${value}`;
     }, '');
+  }
+
+  private getSessionKey(): string {
+    return this.authority + JSON.stringify(this.queryParams);
+  }
+
+  private setToken(token: ADFSToken | null) {
+    this.token = token;
+    const sessionKey = this.getSessionKey();
+    if (token) {
+      sessionStorage.setItem(sessionKey, JSON.stringify(token));
+    } else {
+      sessionStorage.removeItem(sessionKey);
+    }
+  }
+
+  private getToken(): ADFSToken | null {
+    const sessionKey = this.getSessionKey();
+    const value = sessionStorage.getItem(sessionKey);
+    if (!value) {
+      return null;
+    }
+    try {
+      const token = JSON.parse(value) as ADFSToken;
+      if (token.expiresIn >= Date.now()) {
+        throw new Error(`token expired ${token.expiresIn}`);
+      }
+      return token;
+    } catch (err) {
+      console.error(err);
+      sessionStorage.removeItem(sessionKey);
+      return null;
+    }
   }
 }
 

--- a/packages/core/src/authFlows/adfs.ts
+++ b/packages/core/src/authFlows/adfs.ts
@@ -238,7 +238,7 @@ export function extractADFSToken(query: string): ADFSToken | null {
     return {
       accessToken,
       idToken,
-      expiresIn: Date.now() + Number(expiresIn),
+      expiresIn: Date.now() + Number(expiresIn) * 1000,
     };
   }
 


### PR DESCRIPTION
Aramco login to Fusion today. They are using ADFS2016 as their IdP. The problem is that iFrames are blocked. Therefore silent login doesn't work (and is currently used to retrieve tokens in Fusion when we don't persist them). This PR persists tokens to `sessionStorage` to avoid relying on silent logins.