### PR TITLE
feat: allow overriding retry validator at request level

### DIFF
--- a/packages/core/src/baseCogniteClient.ts
+++ b/packages/core/src/baseCogniteClient.ts
@@ -8,7 +8,7 @@ import {
   X_CDF_SDK_HEADER,
   API_KEY_HEADER,
 } from './constants';
-import { HttpRequestOptions, HttpResponse } from './httpClient/basicHttpClient';
+import { HttpResponse } from './httpClient/basicHttpClient';
 import { HttpHeaders } from './httpClient/httpHeaders';
 import { CDFHttpClient } from './httpClient/cdfHttpClient';
 import { MetadataMap } from './metadata';
@@ -27,6 +27,7 @@ import {
 } from './httpClient/retryValidator';
 import { verifyOptionsRequiredFields } from './loginUtils';
 import { CredentialsAuth, ClientCredentials } from './credentialsAuth';
+import { RetryableHttpRequestOptions } from './httpClient/retryableHttpClient';
 export interface ClientOptions {
   /** App identifier (ex: 'FileExtractor') */
   appId: string;
@@ -293,7 +294,7 @@ export default class BaseCogniteClient {
    * const response = await client.get('/api/v1/projects/{project}/assets', { params: { limit: 50 }});
    * ```
    */
-  public get = <T = any>(path: string, options?: HttpRequestOptions) =>
+  public get = <T = any>(path: string, options?: RetryableHttpRequestOptions) =>
     this.httpClient.get<T>(path, options);
 
   /**
@@ -306,7 +307,7 @@ export default class BaseCogniteClient {
    * const response = await client.put('someUrl');
    * ```
    */
-  public put = <T = any>(path: string, options?: HttpRequestOptions) =>
+  public put = <T = any>(path: string, options?: RetryableHttpRequestOptions) =>
     this.httpClient.put<T>(path, options);
 
   /**
@@ -320,8 +321,10 @@ export default class BaseCogniteClient {
    * const response = await client.post('/api/v1/projects/{project}/assets', { data: { items: assets } });
    * ```
    */
-  public post = <T = any>(path: string, options?: HttpRequestOptions) =>
-    this.httpClient.post<T>(path, options);
+  public post = <T = any>(
+    path: string,
+    options?: RetryableHttpRequestOptions
+  ) => this.httpClient.post<T>(path, options);
 
   /**
    * Basic HTTP method for DELETE
@@ -332,8 +335,10 @@ export default class BaseCogniteClient {
    * const response = await client.delete('someUrl');
    * ```
    */
-  public delete = <T = any>(path: string, options?: HttpRequestOptions) =>
-    this.httpClient.delete<T>(path, options);
+  public delete = <T = any>(
+    path: string,
+    options?: RetryableHttpRequestOptions
+  ) => this.httpClient.delete<T>(path, options);
 
   /**
    * Basic HTTP method for PATCH
@@ -344,8 +349,10 @@ export default class BaseCogniteClient {
    * const response = await client.patch('someUrl');
    * ```
    */
-  public patch = <T = any>(path: string, options?: HttpRequestOptions) =>
-    this.httpClient.patch<T>(path, options);
+  public patch = <T = any>(
+    path: string,
+    options?: RetryableHttpRequestOptions
+  ) => this.httpClient.patch<T>(path, options);
 
   protected initAPIs() {
     // will be overritten by subclasses
@@ -391,5 +398,5 @@ export default class BaseCogniteClient {
   }
 }
 
-export type BaseRequestOptions = HttpRequestOptions;
+export type BaseRequestOptions = RetryableHttpRequestOptions;
 export type Response = HttpResponse<any>;

--- a/packages/core/src/httpClient/cdfHttpClient.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.ts
@@ -158,7 +158,7 @@ export class CDFHttpClient extends RetryableHttpClient {
 
 type Response401Handler = (
   err: HttpError,
-  request: HttpRequest,
+  request: RetryableHttpRequest,
   retry: () => void,
   reject: () => void
 ) => void;

--- a/packages/core/src/httpClient/cdfHttpClient.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.ts
@@ -9,10 +9,13 @@ import {
 } from '../constants';
 import { handleErrorResponse } from '../error';
 import { bearerString, isJson } from '../utils';
-import { HttpQueryParams, HttpRequest, HttpResponse } from './basicHttpClient';
+import { HttpQueryParams, HttpResponse } from './basicHttpClient';
 import { HttpHeaders } from './httpHeaders';
 import { HttpError } from './httpError';
-import { RetryableHttpClient } from './retryableHttpClient';
+import {
+  RetryableHttpClient,
+  RetryableHttpRequest,
+} from './retryableHttpClient';
 import { RetryValidator } from './retryValidator';
 
 export class CDFHttpClient extends RetryableHttpClient {
@@ -69,7 +72,9 @@ export class CDFHttpClient extends RetryableHttpClient {
     this.response401Handler = handler;
   }
 
-  protected async preRequest(request: HttpRequest): Promise<HttpRequest> {
+  protected async preRequest(
+    request: RetryableHttpRequest
+  ): Promise<RetryableHttpRequest> {
     const headersWithDefaultHeaders = this.populateDefaultHeaders(
       request.headers
     );
@@ -86,14 +91,14 @@ export class CDFHttpClient extends RetryableHttpClient {
     };
   }
 
-  protected async request<ResponseType>(request: HttpRequest) {
+  protected async request<ResponseType>(request: RetryableHttpRequest) {
     request.headers = this.enrichWithOneTimeHeaders(request.headers);
     return super.request<ResponseType>(request);
   }
 
   protected async postRequest<T>(
     response: HttpResponse<T>,
-    request: HttpRequest
+    request: RetryableHttpRequest
   ): Promise<HttpResponse<T>> {
     try {
       return await super.postRequest(response, request);

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -16,7 +16,7 @@ export type RetryValidator = (
 /** @hidden */
 export type EndpointList = { [key in HttpMethod]?: string[] };
 
-const DEFAULT_MAX_RETRY_ATTEMPTS = 5;
+export const DEFAULT_MAX_RETRY_ATTEMPTS = 5;
 
 export const createRetryValidator = (
   endpointsToRetry: EndpointList,

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -16,11 +16,11 @@ export type RetryValidator = (
 /** @hidden */
 export type EndpointList = { [key in HttpMethod]?: string[] };
 
-export const DEFAULT_MAX_RETRY_ATTEMPTS = 5;
+export const MAX_RETRY_ATTEMPTS = 5;
 
 export const createRetryValidator = (
   endpointsToRetry: EndpointList,
-  maxRetries: number = DEFAULT_MAX_RETRY_ATTEMPTS
+  maxRetries: number = MAX_RETRY_ATTEMPTS
 ): RetryValidator => {
   const universalRetryValidator = createUniversalRetryValidator(maxRetries);
   return (
@@ -46,7 +46,7 @@ export const createRetryValidator = (
 };
 
 export const createUniversalRetryValidator =
-  (maxRetries: number = DEFAULT_MAX_RETRY_ATTEMPTS): RetryValidator =>
+  (maxRetries: number = MAX_RETRY_ATTEMPTS): RetryValidator =>
   (request, response, retryCount) => {
     if (retryCount >= maxRetries) {
       return false;

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -3,11 +3,12 @@
 import inRange from 'lodash/inRange';
 import some from 'lodash/some';
 
-import { HttpMethod, HttpRequest, HttpResponse } from './basicHttpClient';
+import { HttpMethod, HttpResponse } from './basicHttpClient';
+import { RetryableHttpRequest } from './retryableHttpClient';
 
 /** @hidden */
 export type RetryValidator = (
-  request: HttpRequest,
+  request: RetryableHttpRequest,
   response: HttpResponse<any>,
   retryCount: number
 ) => boolean;
@@ -23,7 +24,7 @@ export const createRetryValidator = (
 ): RetryValidator => {
   const universalRetryValidator = createUniversalRetryValidator(maxRetries);
   return (
-    request: HttpRequest,
+    request: RetryableHttpRequest,
     response: HttpResponse<any>,
     retryCount: number
   ) => {

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -63,9 +63,9 @@ export class RetryableHttpClient extends BasicHttpClient {
 
   protected async postRequest<T>(
     response: HttpResponse<T>,
-    _: RetryableHttpRequest // eslint-disable-line
+    request: RetryableHttpRequest
   ): Promise<HttpResponse<T>> {
-    return super.postRequest<T>(response, _);
+    return super.postRequest<T>(response, request);
   }
 
   protected async rawRequest<ResponseType>(

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -1,6 +1,11 @@
 // Copyright 2020 Cognite AS
 import { sleepPromise } from '../utils';
-import { BasicHttpClient, HttpRequest, HttpResponse } from './basicHttpClient';
+import {
+  BasicHttpClient,
+  HttpRequest,
+  HttpRequestOptions,
+  HttpResponse,
+} from './basicHttpClient';
 import { RetryValidator } from './retryValidator';
 
 export class RetryableHttpClient extends BasicHttpClient {
@@ -15,14 +20,70 @@ export class RetryableHttpClient extends BasicHttpClient {
     super(baseUrl);
   }
 
+  public get<ResponseType>(
+    path: string,
+    options: RetryableHttpRequestOptions = {}
+  ) {
+    return super.get<ResponseType>(path, options);
+  }
+
+  public post<ResponseType>(
+    path: string,
+    options: RetryableHttpRequestOptions = {}
+  ) {
+    return super.post<ResponseType>(path, options);
+  }
+
+  public put<ResponseType>(
+    path: string,
+    options: RetryableHttpRequestOptions = {}
+  ) {
+    return super.put<ResponseType>(path, options);
+  }
+
+  public delete<ResponseType>(
+    path: string,
+    options: RetryableHttpRequestOptions = {}
+  ) {
+    return super.delete<ResponseType>(path, options);
+  }
+
+  public patch<ResponseType>(
+    path: string,
+    options: RetryableHttpRequestOptions = {}
+  ) {
+    return super.patch<ResponseType>(path, options);
+  }
+
+  protected async preRequest(
+    request: RetryableHttpRequest
+  ): Promise<RetryableHttpRequest> {
+    return super.preRequest(request);
+  }
+
+  protected async postRequest<T>(
+    response: HttpResponse<T>,
+    _: RetryableHttpRequest // eslint-disable-line
+  ): Promise<HttpResponse<T>> {
+    return super.postRequest<T>(response, _);
+  }
+
   protected async rawRequest<ResponseType>(
-    request: HttpRequest
+    request: RetryableHttpRequest
   ): Promise<HttpResponse<ResponseType>> {
     let retryCount = 0;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const response = await super.rawRequest<ResponseType>(request);
-      const shouldRetry = this.retryValidator(request, response, retryCount);
+
+      const retryValidator =
+        typeof request.retryValidator === 'function'
+          ? request.retryValidator
+          : this.retryValidator;
+
+      const shouldRetry =
+        request.retryValidator !== false &&
+        retryValidator(request, response, retryCount);
       if (!shouldRetry) {
         return response;
       }
@@ -31,4 +92,18 @@ export class RetryableHttpClient extends BasicHttpClient {
       retryCount++;
     }
   }
+
+  protected async request<ResponseType>(request: RetryableHttpRequest) {
+    return super.request<ResponseType>(request);
+  }
 }
+
+export type RetryableHttpRequest = HttpRequest &
+  HttpRequestRetryValidatorOptions;
+
+export type RetryableHttpRequestOptions = HttpRequestOptions &
+  HttpRequestRetryValidatorOptions;
+
+type HttpRequestRetryValidatorOptions = {
+  retryValidator?: false | RetryValidator;
+};

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -7,6 +7,7 @@ import {
   HttpResponse,
 } from './basicHttpClient';
 import { MAX_RETRY_ATTEMPTS, RetryValidator } from './retryValidator';
+import isFunction from 'lodash/isFunction';
 
 export class RetryableHttpClient extends BasicHttpClient {
   private static calculateRetryDelayInMs(retryCount: number) {
@@ -76,10 +77,9 @@ export class RetryableHttpClient extends BasicHttpClient {
     while (true) {
       const response = await super.rawRequest<ResponseType>(request);
 
-      const retryValidator =
-        typeof request.retryValidator === 'function'
-          ? request.retryValidator
-          : this.retryValidator;
+      const retryValidator = isFunction(request.retryValidator)
+        ? request.retryValidator
+        : this.retryValidator;
 
       const shouldRetry =
         retryCount < MAX_RETRY_ATTEMPTS &&

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -6,7 +6,7 @@ import {
   HttpRequestOptions,
   HttpResponse,
 } from './basicHttpClient';
-import { DEFAULT_MAX_RETRY_ATTEMPTS, RetryValidator } from './retryValidator';
+import { MAX_RETRY_ATTEMPTS, RetryValidator } from './retryValidator';
 
 export class RetryableHttpClient extends BasicHttpClient {
   private static calculateRetryDelayInMs(retryCount: number) {
@@ -82,7 +82,7 @@ export class RetryableHttpClient extends BasicHttpClient {
           : this.retryValidator;
 
       const shouldRetry =
-        retryCount < DEFAULT_MAX_RETRY_ATTEMPTS &&
+        retryCount < MAX_RETRY_ATTEMPTS &&
         request.retryValidator !== false &&
         retryValidator(request, response, retryCount);
       if (!shouldRetry) {

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -6,7 +6,7 @@ import {
   HttpRequestOptions,
   HttpResponse,
 } from './basicHttpClient';
-import { RetryValidator } from './retryValidator';
+import { DEFAULT_MAX_RETRY_ATTEMPTS, RetryValidator } from './retryValidator';
 
 export class RetryableHttpClient extends BasicHttpClient {
   private static calculateRetryDelayInMs(retryCount: number) {
@@ -82,6 +82,7 @@ export class RetryableHttpClient extends BasicHttpClient {
           : this.retryValidator;
 
       const shouldRetry =
+        retryCount < DEFAULT_MAX_RETRY_ATTEMPTS &&
         request.retryValidator !== false &&
         retryValidator(request, response, retryCount);
       if (!shouldRetry) {

--- a/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
@@ -41,4 +41,27 @@ describe('RetryableHttpClient', () => {
       );
     }
   });
+
+  test('respect when a boolean is passed as retryValidator', async () => {
+    const scope = nock(baseUrl).get('/').times(1).reply(401);
+    try {
+      const promise = client.get('/', { retryValidator: false });
+      await promise;
+    } catch (err) {
+      expect(err.status).toBe(401);
+    }
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test('respect when a function is passed as retryValidator', async () => {
+    const scope = nock(baseUrl).get('/').times(2).reply(401);
+    try {
+      await client.get('/', {
+        retryValidator: (_, __, retryCount) => retryCount < 1,
+      });
+    } catch (err) {
+      expect(err.status).toBe(401);
+    }
+    expect(scope.isDone()).toBe(true);
+  });
 });


### PR DESCRIPTION
[DX-907](https://cognitedata.atlassian.net/browse/DX-907?atlOrigin=eyJpIjoiNzU0MmY3ZTZiZjNkNDYyY2E3NTZkMGIzYmUyNzExZGIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

In brief, the motivation is allowing to override retry behavior at the request level. Slack thread can be checked for more background.

In the PR, I extended the http request options with a field called `retryValidator`. It can be either a function or a boolean with the value `false`. If it is `false`, we don't retry at all. If it is a function, we call it to decide whether retry or not. Else, we use the default retry validator.

There are a few ways we can go for the solution. I went with the generic solution to include extra options for requests inside the `BasicHttpClient`. However, I wouldn't say I'm too happy with it. We need to pass the extra props for retry validator basically everywhere.

Instead of extending `BasicCogniteClient` to add retry functionality, we can implement this inside that class with an option to disable globally (which is actually the idea with `RetryableHttpClient` in the end as well). This might be one alternative.