### PR TITLE
fix: ensure response ordering matches request when chunking a request

### DIFF
--- a/packages/core/src/__tests__/utils.unit.spec.ts
+++ b/packages/core/src/__tests__/utils.unit.spec.ts
@@ -103,6 +103,15 @@ describe('utils', () => {
       ).resolves.toEqual(['a', 'b', 'c']);
     });
 
+    test('promiseAllAtOnce: keep ordering', async () => {
+      const data = [100, 50, 10];
+      const promiser = async (sleepInMs: number) => {
+        await sleepPromise(sleepInMs);
+        return sleepInMs;
+      };
+      await expect(promiseAllAtOnce(data, promiser)).resolves.toEqual(data);
+    });
+
     test('promiseEachInSequence', async () => {
       expect(
         await promiseEachInSequence([], (input) => Promise.resolve(input))

--- a/packages/stable/src/__tests__/api/events.int.spec.ts
+++ b/packages/stable/src/__tests__/api/events.int.spec.ts
@@ -129,15 +129,16 @@ describe('Events integration test', () => {
     test('descending', async () => {
       await client.events.list({ sort: { endTime: SortOrder.DESC } });
     });
-    test('multiple props not supported', async () => {
+    test('multiple props supported', async () => {
       await expect(
         client.events.list({
+          limit: 1,
           sort: {
             startTime: 'asc',
             lastUpdatedTime: 'desc',
           },
         })
-      ).rejects.toThrowError();
+      ).resolves.toBeDefined();
     });
   });
 


### PR DESCRIPTION
See this [Slack thread](https://cognitedata.slack.com/archives/C6KNJCEEA/p1663773050949699) for context.

We had a bug when performing a request to the API and the SDK decides to chunk the request into smaller requests. The problem is that we were not guaranteed that the response order matched the input order.