### PR TITLE
fix: override auth header while retrying

### DIFF
--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -239,10 +239,7 @@ describe('CogniteClient', () => {
           });
 
         let tokenCount = 0;
-        const mockGetToken = jest.fn(async () => {
-          await sleepPromise(100);
-          return `test-token${tokenCount++}`;
-        });
+        const mockGetToken = jest.fn(async () => `test-token${tokenCount++}`);
 
         const client = new BaseCogniteClient({
           project,

--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -160,7 +160,8 @@ export class BasicHttpClient {
 
   protected async postRequest<T>(
     response: HttpResponse<T>,
-    _: HttpRequest // eslint-disable-line
+    _: HttpRequest, // eslint-disable-line
+    __: HttpRequest // eslint-disable-line
   ): Promise<HttpResponse<T>> {
     const requestIsOk = BasicHttpClient.validateStatusCode(response.status);
     if (!requestIsOk) {
@@ -215,7 +216,7 @@ export class BasicHttpClient {
   protected async request<ResponseType>(request: HttpRequest) {
     const mutatedRequest = await this.preRequest(request);
     const rawResponse = await this.rawRequest<ResponseType>(mutatedRequest);
-    return this.postRequest(rawResponse, mutatedRequest);
+    return this.postRequest(rawResponse, request, mutatedRequest);
   }
 
   private constructUrl(path: string, params: HttpQueryParams = {}) {

--- a/packages/core/src/httpClient/cdfHttpClient.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.ts
@@ -98,10 +98,11 @@ export class CDFHttpClient extends RetryableHttpClient {
 
   protected async postRequest<T>(
     response: HttpResponse<T>,
-    request: RetryableHttpRequest
+    request: RetryableHttpRequest,
+    mutatedRequest: RetryableHttpRequest
   ): Promise<HttpResponse<T>> {
     try {
-      return await super.postRequest(response, request);
+      return await super.postRequest(response, request, mutatedRequest);
     } catch (err) {
       if (
         err.status === 401 &&
@@ -111,7 +112,7 @@ export class CDFHttpClient extends RetryableHttpClient {
         return new Promise((resolvePromise, rejectPromise) => {
           const retry = () => resolvePromise(this.request(request));
           const reject = () => rejectPromise(err);
-          this.response401Handler(err, request, retry, reject);
+          this.response401Handler(err, mutatedRequest, retry, reject);
         });
       }
       throw handleErrorResponse(err);

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -64,9 +64,10 @@ export class RetryableHttpClient extends BasicHttpClient {
 
   protected async postRequest<T>(
     response: HttpResponse<T>,
-    request: RetryableHttpRequest
+    request: RetryableHttpRequest,
+    mutatedRequest: RetryableHttpRequest
   ): Promise<HttpResponse<T>> {
-    return super.postRequest<T>(response, request);
+    return super.postRequest<T>(response, request, mutatedRequest);
   }
 
   protected async rawRequest<ResponseType>(


### PR DESCRIPTION
Latest change to this line caused a regression: https://github.com/cognitedata/cognite-sdk-js/blob/9797d780e1e20705e7ffaa6767e0e271e6360239/packages/core/src/httpClient/basicHttpClient.ts#L218

Updated tokens are not used on retries for 401s now.

Because now we are passing `mutatedRequest` to `postRequest`, not all the default headers are applied properly. For us, the important one is the authorization header. Here we keep using the old authorization header on retries of because of this ordering: https://github.com/cognitedata/cognite-sdk-js/blob/9797d780e1e20705e7ffaa6767e0e271e6360239/packages/core/src/httpClient/basicHttpClient.ts#L172-L177

I'm not sure if we should change this to other way - then we wouldn't be able to override default headers. So I went with adding another parameter to `postRequest` for keeping both the original request and the mutated version. Open to suggestions to clean it up.