### PR TITLE
fix: move `@types/geojson` to dependencies

### DIFF
--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -25,9 +25,7 @@
   "dependencies": {
     "@cognite/sdk-core": "^4.8.1",
     "geojson": "^0.5.0",
-    "lodash": "^4.17.11"
-  },
-  "devDependencies": {
+    "lodash": "^4.17.11",
     "@types/geojson": "^7946.0.8"
   },
   "files": [


### PR DESCRIPTION
The `geojson` types are missing when we install the sdk package in other places. This should fix it.