### PR TITLE
fix: skip npm whoami from release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,6 @@ jobs:
           git config --global user.name "Cognite CICD"
           git remote set-url origin "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" > /dev/null 2>&1
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-          npm whoami
         env:
           NPM_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
           GITHUB_TOKEN: ${{secrets.GH_LERNA_TOKEN}} # Temporary fix to make lerna able to push the new versions commit to master


### PR DESCRIPTION
We get 403 from the `npm whoami` command. The command is just informative and will not affect deployment.

See the failing github action run [here](https://github.com/cognitedata/cognite-sdk-js/actions/runs/3359945014/jobs/5568955939).

[Slack thread](https://cognitedata.slack.com/archives/C6KNJCEEA/p1667212429356979).