### PR TITLE
chore: remove commitlint requirement

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -138,9 +138,6 @@ jobs:
       - name: Install 🔧
         run: yarn install --frozen-lockfile
 
-        # tests pushed git commits
-      - uses: wagoid/commitlint-github-action@v3
-
       - name: validateDocLinks
         run: yarn validateDocLinks
 


### PR DESCRIPTION
I notice that pull requests commit naming require commitlint to pass or they will be blocked. Given we merge the PR into master, I'm not sure what value it adds. I suggest removing it and only enforcing the PR title to be commitlint compliant.