### PR TITLE
feat(alpha): monitoring tasks api

### DIFF
--- a/packages/alpha/README.md
+++ b/packages/alpha/README.md
@@ -21,4 +21,4 @@ The CogniteClientAlpha can be initialized/configured in the same manner as the o
 
 ## Documentation
 
- - here [cognitedata.github.io/cognite-sdk-js/alpha](https://cognitedata.github.io/cognite-sdk-js/alpha/classes/_alpha_src_cogniteclient_.cogniteclientalpha.html)
+[cognitedata.github.io/cognite-sdk-js/alpha](https://cognitedata.github.io/cognite-sdk-js/alpha/classes/_alpha_src_cogniteclient_.cogniteclientalpha.html)

--- a/packages/alpha/README.md
+++ b/packages/alpha/README.md
@@ -21,4 +21,4 @@ The CogniteClientAlpha can be initialized/configured in the same manner as the o
 
 ## Documentation
 
- - contact engineering the team
+ - here [cognitedata.github.io/cognite-sdk-js/alpha](https://cognitedata.github.io/cognite-sdk-js/alpha/classes/_alpha_src_cogniteclient_.cogniteclientalpha.html)

--- a/packages/alpha/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/alertsApi.int.spec.ts
@@ -139,4 +139,13 @@ describe('alerts api', () => {
     ]);
     expect(response).toEqual({});
   });
+
+  itif(client)('delete channel', async () => {
+    const response = await client!.alerts.deleteChannels([
+      {
+        externalId: channelExternalId,
+      },
+    ]);
+    expect(response).toEqual({});
+  });
 });

--- a/packages/alpha/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Cognite AS
+// Copyright 2022 Cognite AS
 
 import { Channel } from 'alpha/src/types';
 import CogniteClientAlpha from '../../cogniteClient';

--- a/packages/alpha/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -1,0 +1,95 @@
+// Copyright 2020 Cognite AS
+
+import CogniteClientAlpha from '../../cogniteClient';
+import {
+  CLIENT_ID,
+  CLIENT_SECRET,
+  setupLoggedInClient,
+  TEST_PROJECT,
+} from '../testUtils';
+
+type SessionsResponse = {
+  items: [{ nonce: string; status: string }]
+}
+
+const itif = (condition: any) => (condition ? it : it.skip);
+
+describe('monitoring tasks api', () => {
+  const client: CogniteClientAlpha | null = setupLoggedInClient();
+  const ts = Date.now();
+  const monitoringTaskExternalId = `test_mt_${ts}`;
+  const channelExternalId = `test_channel_${ts}`;
+  const sessionsApi = `/api/v1/projects/${TEST_PROJECT}/sessions`
+
+  itif(client)('create monitoring task', async () => {
+    const sessionsRes = await client!.post<SessionsResponse>(
+      sessionsApi,
+      {
+        data: {
+          items: [
+            {
+              clientId: CLIENT_ID,
+              clientSecret: CLIENT_SECRET,
+            },
+          ],
+        },
+      }
+    );
+    const [channel] = await client!.alerts.createChannels([
+      {
+        externalId: channelExternalId,
+        name: channelExternalId,
+        description: 'test',
+      },
+    ]);
+    const response = await client!.monitoringTasks.create([
+      {
+        externalId: monitoringTaskExternalId,
+        channelId: channel.id,
+        interval: 5 * 60 * 1000,
+        nonce: sessionsRes?.data?.items[0]?.nonce,
+        modelExternalId: 'air-upper-threshold',
+        overlap: 1000 * 60,
+        parameters: {
+          threshold: 50.1,
+          timeseriesExternalId: 'test_functions',
+          granularity: '1m',
+        },
+      },
+    ]);
+    expect(response.length).toBe(1);
+    expect(response[0].externalId).toBe(monitoringTaskExternalId);
+  });
+
+  itif(client)('list all monitoring tasks', async () => {
+    const response = await client!.monitoringTasks.list({
+      filter: {},
+    });
+    expect(response.items.length).toBeGreaterThan(0);
+  });
+
+  itif(client)('list created monitoring task', async () => {
+    const response = await client!.monitoringTasks.list({
+      filter: { externalIds: [monitoringTaskExternalId] },
+    });
+    expect(response.items.length).toBeGreaterThan(0);
+  });
+
+  itif(client)('delete monitoring task', async () => {
+    const response = await client!.monitoringTasks.delete([
+      {
+        externalId: monitoringTaskExternalId,
+      },
+    ]);
+    expect(response).toEqual({});
+  });
+
+  itif(client)('delete channel', async () => {
+    const response = await client!.alerts.deleteChannels([
+      {
+        externalId: channelExternalId,
+      },
+    ]);
+    expect(response).toEqual({});
+  });
+});

--- a/packages/alpha/src/__tests__/testUtils.ts
+++ b/packages/alpha/src/__tests__/testUtils.ts
@@ -3,23 +3,23 @@ import CogniteClient from '../cogniteClient';
 import { name } from '../../package.json';
 import { ConfidentialClientApplication } from '@azure/msal-node';
 
-const project = process.env.COGNITE_PROJECT_ALERTS_API!;
-const clientId = process.env.COGNITE_CLIENT_ID_ALERTS_API!;
-const clientSecret = process.env.COGNITE_CLIENT_SECRET_ALERTS_API!;
+export const TEST_PROJECT = process.env.COGNITE_PROJECT_ALERTS_API!;
+export const CLIENT_ID = process.env.COGNITE_CLIENT_ID_ALERTS_API!;
+export const CLIENT_SECRET = process.env.COGNITE_CLIENT_SECRET_ALERTS_API!;
 const azureTenant = process.env.COGNITE_TENANT_ID_ALERTS_API!;
 
 export function setupLoggedInClient() {
-  if (project && clientId && clientSecret && azureTenant) {
+  if (TEST_PROJECT && CLIENT_ID && CLIENT_SECRET && azureTenant) {
     const pca = new ConfidentialClientApplication({
       auth: {
-        clientId,
-        clientSecret,
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
         authority: `https://login.microsoftonline.com/${azureTenant}`,
       },
     });
 
     const client = new CogniteClient({
-      project,
+      project: TEST_PROJECT,
       baseUrl: 'https://azure-dev.cognitedata.com',
       appId: `JS SDK integration tests (${name})`,
       getToken: () =>

--- a/packages/alpha/src/api/alerts/alertsApi.ts
+++ b/packages/alpha/src/api/alerts/alertsApi.ts
@@ -1,3 +1,5 @@
+// Copyright 2022 Cognite AS
+
 import { BaseResourceAPI, CDFHttpClient, MetadataMap } from '@cognite/sdk-core';
 import { IdEither } from '@cognite/sdk';
 import {

--- a/packages/alpha/src/api/alerts/channelsApi.ts
+++ b/packages/alpha/src/api/alerts/channelsApi.ts
@@ -1,3 +1,5 @@
+// Copyright 2022 Cognite AS
+
 import { BaseResourceAPI, CDFHttpClient, MetadataMap } from '@cognite/sdk-core';
 import { IdEither } from '@cognite/sdk';
 import {

--- a/packages/alpha/src/api/alerts/subscribersApi.ts
+++ b/packages/alpha/src/api/alerts/subscribersApi.ts
@@ -1,3 +1,5 @@
+// Copyright 2022 Cognite AS
+
 import { BaseResourceAPI, CDFHttpClient, MetadataMap } from '@cognite/sdk-core';
 import {
   Subscriber,

--- a/packages/alpha/src/api/alerts/subscriptionsApi.ts
+++ b/packages/alpha/src/api/alerts/subscriptionsApi.ts
@@ -1,3 +1,5 @@
+// Copyright 2022 Cognite AS
+
 import { BaseResourceAPI, CDFHttpClient, MetadataMap } from '@cognite/sdk-core';
 import {
   Subscription,

--- a/packages/alpha/src/api/monitoringTasks/monitoringTasksApi.ts
+++ b/packages/alpha/src/api/monitoringTasks/monitoringTasksApi.ts
@@ -1,0 +1,23 @@
+import { BaseResourceAPI, IdEither } from '@cognite/sdk-core';
+import {
+  MonitoringTask,
+  MonitoringTaskCreate,
+  MonitoringTaskFilterQuery,
+} from '../../types';
+
+export class MonitoringTasksAPI extends BaseResourceAPI<MonitoringTask> {
+  public create = async (items: MonitoringTaskCreate[]) => {
+    return this.createEndpoint(items);
+  };
+
+  public list = async (filter?: MonitoringTaskFilterQuery) => {
+    return this.listEndpoint<MonitoringTaskFilterQuery>(
+      this.callListEndpointWithPost,
+      filter
+    );
+  };
+
+  public delete = async (ids: IdEither[]) => {
+    return this.deleteEndpoint(ids);
+  };
+}

--- a/packages/alpha/src/api/monitoringTasks/monitoringTasksApi.ts
+++ b/packages/alpha/src/api/monitoringTasks/monitoringTasksApi.ts
@@ -1,3 +1,5 @@
+// Copyright 2022 Cognite AS
+
 import { BaseResourceAPI, IdEither } from '@cognite/sdk-core';
 import {
   MonitoringTask,

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -6,9 +6,11 @@ import {
 import { accessApi } from '@cognite/sdk-core';
 import { version } from '../package.json';
 import { AlertsAPI } from './api/alerts/alertsApi';
+import { MonitoringTasksAPI } from './api/monitoringTasks/monitoringTasksApi';
 
 export default class CogniteClientAlpha extends CogniteClientStable {
   private alertsApi?: AlertsAPI;
+  private monitoringTasksApi?: MonitoringTasksAPI;
 
   /**
    * Create a new SDK client (alpha)
@@ -22,12 +24,20 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     return accessApi(this.alertsApi);
   }
 
+  public get monitoringTasks() {
+    return accessApi(this.monitoringTasksApi);
+  }
+
   protected initAPIs() {
     super.initAPIs();
 
     this.httpClient.setDefaultHeader('cdf-version', 'alpha');
 
     this.alertsApi = this.apiFactory(AlertsAPI, 'alerts');
+    this.monitoringTasksApi = this.apiFactory(
+      MonitoringTasksAPI,
+      'monitoringtask'
+    );
   }
 
   protected get version() {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -17,6 +17,53 @@ import {
 
 export * from '@cognite/sdk';
 
+export interface MonitoringTaskParametersCreate {
+  timeseriesExternalId: CogniteExternalId;
+  granularity?: string;
+  threshold: number;
+}
+
+export interface MonitoringTaskParameters {
+  timeseriesExternalId: CogniteInternalId;
+  granularity?: string;
+  threshold: number;
+}
+
+export interface MonitoringTaskCreate {
+  externalId: CogniteExternalId;
+  modelExternalId: CogniteExternalId;
+  channelId: CogniteInternalId;
+  interval: number;
+  overlap: number;
+  parameters: MonitoringTaskParametersCreate;
+  nonce: string;
+}
+
+export interface MonitoringTask {
+  id: CogniteInternalId;
+  externalId?: CogniteExternalId;
+  modelExternalId: CogniteExternalId;
+  channelId: CogniteInternalId;
+  interval: number;
+  overlap: number;
+  parameters: MonitoringTaskParameters;
+}
+
+export interface MonitoringTaskParametersFilter {
+  timeseriesExternalId: CogniteInternalId;
+}
+
+export interface MonitoringTaskFilter {
+  externalIds?: CogniteExternalId[];
+  ids?: CogniteInternalId[];
+  channelIds?: CogniteInternalId[];
+  parameters?: MonitoringTaskParametersFilter;
+}
+
+export interface MonitoringTaskFilterQuery extends FilterQuery {
+  filter?: MonitoringTaskFilter;
+}
+
 export interface AlertFilter {
   channelIds?: CogniteInternalId[];
   channelExternalIds?: CogniteExternalId[];

--- a/packages/stable/src/__tests__/api/geospatial.int.spec.ts
+++ b/packages/stable/src/__tests__/api/geospatial.int.spec.ts
@@ -81,7 +81,8 @@ const DUMMY_TEST_FEATURE: GeospatialFeature[] = [
   },
 ];
 
-describe('Geospatial integration test', () => {
+// re-enable this when geospacial is back to life
+describe.skip('Geospatial integration test', () => {
   let client: CogniteClient;
   let featureType: FeatureType;
 


### PR DESCRIPTION
Adds monitoring task api to the alpha client

NOTE: Geospatial tests are failing these days, spoke to @saagar-cognite we agreed to disable them until the backend stabilizes. 