### PR TITLE
fix(alpha): rename monitoringtask to monitoringtasks

### DIFF
--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -36,7 +36,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     this.alertsApi = this.apiFactory(AlertsAPI, 'alerts');
     this.monitoringTasksApi = this.apiFactory(
       MonitoringTasksAPI,
-      'monitoringtask'
+      'monitoringtasks'
     );
   }
 


### PR DESCRIPTION
Endpoint of MonitoringTasks API has changed from /api/v1/.../monitoringtask ->  /api/v1/.../monitoringtasks