### PR TITLE
fix: add baseUrl to oidc nodejs samples

### DIFF
--- a/samples/nodejs/oidc-typescript/README.md
+++ b/samples/nodejs/oidc-typescript/README.md
@@ -69,6 +69,7 @@ async function quickstart() {
     const client = new CogniteClient({
       appId: 'Cognite SDK samples',
       project,
+      baseUrl: 'https://api.cognitedata.com',
       getToken: () =>
         pca
           .acquireTokenByClientCredential({

--- a/samples/nodejs/oidc-typescript/quickstart.ts
+++ b/samples/nodejs/oidc-typescript/quickstart.ts
@@ -25,6 +25,7 @@ async function quickstart() {
   const client = new CogniteClient({
     appId: 'Cognite SDK samples',
     project,
+    baseUrl: 'https://api.cognitedata.com',
     getToken: () =>
       pca
         .acquireTokenByClientCredential({

--- a/samples/nodejs/public-client-device-grant-flow/README.md
+++ b/samples/nodejs/public-client-device-grant-flow/README.md
@@ -71,6 +71,7 @@ async function deviceCodeGrantExample() {
   const client = new CogniteClient({
     appId: 'Cognite SDK samples',
     project,
+    baseUrl: 'https://api.cognitedata.com',
     getToken: () =>
       pca
         .acquireTokenByDeviceCode({

--- a/samples/nodejs/public-client-device-grant-flow/device_grant.ts
+++ b/samples/nodejs/public-client-device-grant-flow/device_grant.ts
@@ -24,6 +24,7 @@ async function deviceCodeGrantExample() {
   const client = new CogniteClient({
     appId: 'Cognite SDK samples',
     project,
+    baseUrl: 'https://api.cognitedata.com',    
     getToken: () =>
       pca
         .acquireTokenByDeviceCode({


### PR DESCRIPTION
Missing baseUrl is causing issues when customer are trying this out