### PR TITLE
chore: fix test env

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
 
       - name: Cache node_modules
         id: cache-modules
@@ -43,6 +48,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
 
       - name: Cache node_modules
         id: cache-modules

--- a/.github/workflows/test-permissions.yaml
+++ b/.github/workflows/test-permissions.yaml
@@ -14,6 +14,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
 
       - name: Cache node_modules
         id: cache-modules


### PR DESCRIPTION
Seems stuff is breaking since the default node version is 18.x.