### PR TITLE
feat: add name to mt-class

### DIFF
--- a/packages/alpha/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -23,6 +23,7 @@ describe('monitoring tasks api', () => {
   const client: CogniteClientAlpha | null = setupLoggedInClient();
   const ts = Date.now();
   const monitoringTaskExternalId = `test_mt_${ts}`;
+  const monitoringTaskName = `test_mt_${ts}`;
   const channelExternalId = `test_channel_mt_${ts}`;
   const sessionsApi = `/api/v1/projects/${TEST_PROJECT}/sessions`;
   const testMtModel: MonitoringTaskThresholdModelCreate = {
@@ -65,6 +66,7 @@ describe('monitoring tasks api', () => {
     const response = await client!.monitoringTasks.create([
       {
         externalId: monitoringTaskExternalId,
+        name: monitoringTaskName,
         channelId: channel.id,
         interval: testMtInterval,
         nonce: sessionsRes?.data?.items[0]?.nonce,
@@ -89,6 +91,7 @@ describe('monitoring tasks api', () => {
     });
     expect(response.items.length).toBe(1);
     expect(response.items[0].externalId).toEqual(monitoringTaskExternalId);
+    expect(response.items[0].name).toEqual(monitoringTaskName);
     expect(response.items[0].model).toEqual(expectedResponseModel);
     expect(response.items[0].interval).toEqual(testMtInterval);
     expect(response.items[0].overlap).toEqual(testMtOverlap);

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -50,7 +50,7 @@ export interface MonitoringTaskCreate {
 export interface MonitoringTask {
   id: CogniteInternalId;
   externalId?: CogniteExternalId;
-  name: String;
+  name: string;
   channelId: CogniteInternalId;
   interval: number;
   overlap: number;
@@ -165,8 +165,8 @@ export interface ChannelPatch {
   };
 }
 
-export interface ChannelChangeById extends ChannelPatch, InternalId { }
-export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId { }
+export interface ChannelChangeById extends ChannelPatch, InternalId {}
+export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId {}
 export type ChannelChange = ChannelChangeById | ChannelChangeByExternalId;
 
 export interface SubscriberCreate {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -39,6 +39,7 @@ export interface MonitoringTaskThresholdModel {
 
 export interface MonitoringTaskCreate {
   externalId: CogniteExternalId;
+  name: string;
   channelId: CogniteInternalId;
   interval: number;
   overlap: number;
@@ -49,6 +50,7 @@ export interface MonitoringTaskCreate {
 export interface MonitoringTask {
   id: CogniteInternalId;
   externalId?: CogniteExternalId;
+  name: String;
   channelId: CogniteInternalId;
   interval: number;
   overlap: number;
@@ -163,8 +165,8 @@ export interface ChannelPatch {
   };
 }
 
-export interface ChannelChangeById extends ChannelPatch, InternalId {}
-export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId {}
+export interface ChannelChangeById extends ChannelPatch, InternalId { }
+export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId { }
 export type ChannelChange = ChannelChangeById | ChannelChangeByExternalId;
 
 export interface SubscriberCreate {


### PR DESCRIPTION
Reflect the `monitoring- task-api` changes in the js-sdk, in the monitoring task api we added a new field `name`.