### PR TITLE
chore: remove dead links

### DIFF
--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -1,25 +1,25 @@
-Cognite Javascript SDK playground
-===========================
-The package `@cognite/sdk-playground` provides a subset of api bindings to the Cognite [playground](https://docs.cognite.com/api/playground/). Note that the playground is
+# Cognite Javascript SDK playground
+
+The package `@cognite/sdk-playground` provides a subset of api bindings to the Cognite playground. Note that the playground is
 considered unstable and may periodically be out of date for certain resources. The playground sdk is not recommended for production and should only be used if you know what you are doing.
 When a resource is removed from the playground it _may_ be found in the beta or stable packages, unless it was discontinued.
 
 install instructions:
+
 ```
 yarn add @cognite/sdk@npm:@cognite/sdk-playground
 ```
+
 or with npm
+
 ```
 npm install @cognite/sdk@npm:@cognite/sdk-playground --save
 ```
 
 This will download `@cognite/sdk-playground`. Import the `CogniteClientPlayground`:
+
 ```js
 import { CogniteClientPlayground } from '@cognite/sdk-playground';
 ```
 
 The CogniteClientPlayground can be initialized/configured in the same manner as the other packages (eg. stable, beta, etc.).
-
-## Documentation
-
- - [playground resources](https://docs.cognite.com/api/playground/).

--- a/packages/stable/README.md
+++ b/packages/stable/README.md
@@ -8,13 +8,6 @@ See [Authentication Guide](https://github.com/cognitedata/cognite-sdk-js/blob/v1
 
 ## Installation
 
-<p align="right">
-  <a href="https://youtu.be/29Cuv6OhBmA">
-    Video quickstart<br />
-    <img src="https://img.youtube.com/vi/29Cuv6OhBmA/3.jpg" alt="Cognite JS SDK video guide" title="Watch our video guide" align="right" />
-  </a>
-</p>
-
 Install the package with yarn:
 
 ```


### PR DESCRIPTION
Playground API documentation has been removed in an effort to deprecate it. 
YouTube thumbnail link is broken and I believe the video itself is private.