### PR TITLE
feat: change default autopage limit to infinity

### DIFF
--- a/packages/core/src/autoPagination.ts
+++ b/packages/core/src/autoPagination.ts
@@ -81,7 +81,7 @@ function makeAutoPagingEach<T>(
 
 function makeAutoPagingToArray<T>(autoPagingEach: AutoPagingEach<T>) {
   return async function autoPagingToArray(options?: AutoPagingToArrayOptions) {
-    let limit = (options && options.limit) || 25;
+    let limit = (options && options.limit) || Infinity;
     if (limit === -1) {
       limit = Infinity;
     }


### PR DESCRIPTION
In my opinion this is a much more sensible limit, as the point of autopage is to easily retrieve all results from a query where the query max limit is exceeded. This would at least have saved me quite some time of debugging, and likely others as well.

BREAKING CHANGE: Changes default limit in `autoPageToArray`