### PR TITLE
fix: use UTC timezone regardless of client time zone

### DIFF
--- a/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
@@ -212,7 +212,7 @@ describe('Annotations API', () => {
     expect(items).toHaveLength(createdAnnotationIds.length);
   });
 
-  test('list annotations with data filter', async () => {
+  test.skip('list annotations with data filter', async () => {
     const items = await client.annotations
       .list({
         filter: {

--- a/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
@@ -212,7 +212,7 @@ describe('Annotations API', () => {
     expect(items).toHaveLength(createdAnnotationIds.length);
   });
 
-  test.skip('list annotations with data filter', async () => {
+  test('list annotations with data filter', async () => {
     const items = await client.annotations
       .list({
         filter: {
@@ -226,7 +226,7 @@ describe('Annotations API', () => {
     expect(items).toHaveLength(1);
   });
 
-  test.skip('reverse lookup annotation', async () => {
+  test('reverse lookup annotation', async () => {
     const listResponse = await client.annotations.reverseLookup({
       limit: 1000,
       filter: {

--- a/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
@@ -226,7 +226,7 @@ describe('Annotations API', () => {
     expect(items).toHaveLength(1);
   });
 
-  test('reverse lookup annotation', async () => {
+  test.skip('reverse lookup annotation', async () => {
     const listResponse = await client.annotations.reverseLookup({
       limit: 1000,
       filter: {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -239,6 +239,39 @@ describe('Datapoints integration test for monthly granularity', () => {
     );
   });
 
+  test('retrieve monthly granularity when there is a data gap between months with string timestamps', async () => {
+    const response = await client.datapoints.retrieveDatapointMonthlyAggregates(
+      {
+        items: [{ id: timeserie.id }],
+        start: Date.parse("2022-10-01T00:00:00Z"),
+        end: Date.parse("2023-03-31T00:00:00Z"),
+        aggregates: ['sum'],
+      }
+    );
+    // Check that the response contains the correct number of data points
+    expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
+    expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022
+    expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110); // December 2022
+    expect((response[0].datapoints[3] as DatapointAggregate).sum).toBe(150); // January 2023
+    expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190); // March 2023
+    // Check timestamps
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 9, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 10, 1)
+    );
+    expect((response[0].datapoints[2] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 11, 1)
+    );
+    expect((response[0].datapoints[3] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 0, 1)
+    );
+    expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 2, 1)
+    );
+  });
+
   test('retrieve monthly average granularity when there is a data gap between months', async () => {
     const response = await client.datapoints.retrieveDatapointMonthlyAggregates(
       {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -144,7 +144,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 9, 1),
-        end: new Date(2022, 10, 31),
+        end: new Date(2022, 10, 30),
         aggregates: ['sum'],
       }
     );
@@ -169,7 +169,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 11, 1),
-        end: new Date(2023, 2, 29),
+        end: new Date(2023, 0, 15),
         aggregates: ['sum'],
       }
     );
@@ -219,7 +219,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 9, 1),
-        end: new Date(2023, 2, 29),
+        end: new Date(2023, 2, 15),
         aggregates: ['sum'],
       }
     );
@@ -255,7 +255,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: Date.parse('2022-01-01T00:00:00Z'),
-        end: Date.parse('2023-31-12T23:59:59Z'),
+        end: Date.parse('2023-12-15T23:59:59Z'),
         aggregates: ['sum'],
       }
     );
@@ -284,7 +284,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 9, 1),
-        end: new Date(2023, 2, 29),
+        end: new Date(2023, 2, 15),
         aggregates: ['average'],
       }
     );

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -208,22 +208,22 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110);
     expect((response[0].datapoints[3] as DatapointAggregate).sum).toBe(150);
     expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190);
-      // Check timestamps
-      expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
-        new Date(2022, 9, 1)
-      );
-      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
-        new Date(2022, 10, 1)
-      );
-      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
-        new Date(2022, 12, 1)
-      );
-      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
-        new Date(2023, 0, 1)
-      );
-      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
-        new Date(2023, 3, 1)
-      );
+    // Check timestamps
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 9, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 10, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 12, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 0, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 3, 1)
+    );
   });
 
   test('retrieve monthly average granularity when there is a data gap between months', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -151,6 +151,11 @@ describe('Datapoints integration test for monthly granularity', () => {
 
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
+    expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
+    // Check timestamps
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toBe(new Date(2022, 9, 1));
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toBe(new Date(2022, 10, 1));
+
   });
 
   test('retrieve monthly granularity for two consecutive months in different years', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -191,6 +191,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response)
 
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
@@ -202,7 +203,7 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 10, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+    expect((response[0].datapoints[2] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 11, 1)
     );
   });
@@ -230,13 +231,13 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 10, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+    expect((response[0].datapoints[2] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 11, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+    expect((response[0].datapoints[3] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 0, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+    expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 2, 1)
     );
   });
@@ -265,13 +266,13 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 10, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+    expect((response[0].datapoints[2] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 11, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+    expect((response[0].datapoints[3] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 0, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+    expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 2, 1)
     );
   });

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -149,8 +149,6 @@ describe('Datapoints integration test for monthly granularity', () => {
       }
     );
 
-    console.log(response[0].datapoints);
-
     expect(response[0].datapoints.length).toBe(2);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
@@ -173,8 +171,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints);
-
     expect(response[0].datapoints.length).toBe(2);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(110);
@@ -196,8 +192,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints);
-
     expect(response[0].datapoints.length).toBe(3);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
@@ -223,7 +217,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(5);
 
     // Check that the response contains the correct number of data points
@@ -259,8 +252,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints);
-
     expect(response[0].datapoints.length).toBe(3);
 
     // Check that the response contains the correct number of data points
@@ -288,7 +279,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['average'],
       }
     );
-    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(5);
 
     // Check that the response contains the correct number of data points
@@ -324,7 +314,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(3);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
@@ -350,7 +339,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(3);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -149,6 +149,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       }
     );
 
+    expect(response[0].datapoints.length).toBe(2);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
@@ -171,6 +172,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       }
     );
 
+    expect(response[0].datapoints.length).toBe(2);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(110);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(150);
@@ -191,6 +193,8 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+
+    expect(response[0].datapoints.length).toBe(3);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
@@ -215,6 +219,8 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    expect(response[0].datapoints.length).toBe(5);
+
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022
@@ -244,10 +250,13 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: Date.parse('2022-01-01T00:00:00Z'),
-        end: Date.parse('2023-01-01T00:00:00Z'),
+        end: Date.parse('2023-31-12T23:59:59Z'),
         aggregates: ['sum'],
       }
     );
+
+    expect(response[0].datapoints.length).toBe(3);
+
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022
@@ -273,6 +282,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['average'],
       }
     );
+    expect(response[0].datapoints.length).toBe(5);
 
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).average).toBe(15);
@@ -295,6 +305,57 @@ describe('Datapoints integration test for monthly granularity', () => {
     );
     expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 2, 1)
+    );
+  });
+
+  test('retrieve monthly granularity with local time zone in start/end - +0100', async () => {
+    const response = await client.datapoints.retrieveDatapointMonthlyAggregates(
+      {
+        items: [{ id: timeserie.id }],
+        start: Date.parse('2022-01-01T00:00:00+0100'),
+        end: Date.parse('2023-12-12T00:00:00+0100'),
+        aggregates: ['sum'],
+      }
+    );
+    expect(response[0].datapoints.length).toBe(3);
+    // Check that the response contains the correct number of data points
+    expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
+    expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022
+    expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110); // December 2022
+    // Check timestamps
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 9, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 10, 1)
+    );
+    expect((response[0].datapoints[2] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 11, 1)
+    );
+  });
+  test('retrieve monthly granularity with local time zone in start/end - -0600', async () => {
+    const response = await client.datapoints.retrieveDatapointMonthlyAggregates(
+      {
+        items: [{ id: timeserie.id }],
+        start: Date.parse('2022-01-01T00:00:00-0600'),
+        end: Date.parse('2023-12-12T00:00:00-0600'),
+        aggregates: ['sum'],
+      }
+    );
+    expect(response[0].datapoints.length).toBe(3);
+    // Check that the response contains the correct number of data points
+    expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
+    expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022
+    expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110); // December 2022
+    // Check timestamps
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 9, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 10, 1)
+    );
+    expect((response[0].datapoints[2] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 11, 1)
     );
   });
 });

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -191,7 +191,9 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response);
+    console.log(response[0].datapoints[0]);
+    console.log(response[0].datapoints[1]);
+    console.log(response[0].datapoints[2]);
 
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
@@ -217,7 +219,11 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response);
+    console.log(response[0].datapoints[0]);
+    console.log(response[0].datapoints[1]);
+    console.log(response[0].datapoints[2]);
+    console.log(response[0].datapoints[3]);
+    console.log(response[0].datapoints[4]);
 
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -239,12 +239,12 @@ describe('Datapoints integration test for monthly granularity', () => {
     );
   });
 
-  test('retrieve monthly granularity when there is a data gap between months with string timestamps', async () => {
+  test('retrieve monthly granularity for a year when there is missing data for some months', async () => {
     const response = await client.datapoints.retrieveDatapointMonthlyAggregates(
       {
         items: [{ id: timeserie.id }],
-        start: Date.parse('2022-10-01T00:00:00Z'),
-        end: Date.parse('2023-03-31T00:00:00Z'),
+        start: Date.parse('2022-01-01T00:00:00Z'),
+        end: Date.parse('2023-01-01T00:00:00Z'),
         aggregates: ['sum'],
       }
     );
@@ -252,8 +252,6 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022
     expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110); // December 2022
-    expect((response[0].datapoints[3] as DatapointAggregate).sum).toBe(150); // January 2023
-    expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190); // March 2023
     // Check timestamps
     expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 9, 1)
@@ -263,12 +261,6 @@ describe('Datapoints integration test for monthly granularity', () => {
     );
     expect((response[0].datapoints[2] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 11, 1)
-    );
-    expect((response[0].datapoints[3] as DatapointAggregate).timestamp).toEqual(
-      new Date(2023, 0, 1)
-    );
-    expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
-      new Date(2023, 2, 1)
     );
   });
 

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -154,12 +154,11 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
     // Check timestamps
     expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toBe(
-      "2022-09-01T00:00:00.000Z"
-      );
+      '2022-10-01T00:00:00.000Z'
+    );
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toBe(
-      "2022-10-01T00:00:00.000Z"
-      );
-
+      '2022-11-01T00:00:00.000Z'
+    );
   });
 
   test('retrieve monthly granularity for two consecutive months in different years', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -216,13 +216,13 @@ describe('Datapoints integration test for monthly granularity', () => {
       new Date(2022, 10, 1)
     );
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
-      new Date(2022, 12, 1)
+      new Date(2022, 11, 1)
     );
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 0, 1)
     );
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
-      new Date(2023, 3, 1)
+      new Date(2023, 2, 1)
     );
   });
 

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -191,7 +191,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response)
+    console.log(response);
 
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
@@ -217,6 +217,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response);
 
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
@@ -258,7 +259,6 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[2] as DatapointAggregate).average).toBe(55);
     expect((response[0].datapoints[3] as DatapointAggregate).average).toBe(75);
     expect((response[0].datapoints[4] as DatapointAggregate).average).toBe(95);
-    expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190); // March 2023
     // Check timestamps
     expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 9, 1)

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -255,7 +255,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: Date.parse('2022-01-01T00:00:00Z'),
-        end: Date.parse('2023-12-15T23:59:59Z'),
+        end: Date.parse('2022-12-15T23:59:59Z'),
         aggregates: ['sum'],
       }
     );
@@ -320,7 +320,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: Date.parse('2022-01-01T00:00:00+0100'),
-        end: Date.parse('2023-12-12T00:00:00+0100'),
+        end: Date.parse('2022-12-12T00:00:00+0100'),
         aggregates: ['sum'],
       }
     );
@@ -346,7 +346,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: Date.parse('2022-01-01T00:00:00-0600'),
-        end: Date.parse('2023-12-12T00:00:00-0600'),
+        end: Date.parse('2022-12-12T00:00:00-0600'),
         aggregates: ['sum'],
       }
     );

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -191,10 +191,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints[0]);
-    console.log(response[0].datapoints[1]);
-    console.log(response[0].datapoints[2]);
-
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
@@ -219,12 +215,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
-    console.log(response[0].datapoints[0]);
-    console.log(response[0].datapoints[1]);
-    console.log(response[0].datapoints[2]);
-    console.log(response[0].datapoints[3]);
-    console.log(response[0].datapoints[4]);
-
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -174,6 +174,12 @@ describe('Datapoints integration test for monthly granularity', () => {
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(110);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(150);
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 11, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 0, 1)
+    );
   });
 
   test('retrieve monthly granularity for two non-consecutive months in same year', async () => {
@@ -190,6 +196,15 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
     expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110);
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 9, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 10, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 11, 1)
+    );
   });
 
   test('retrieve monthly granularity when there is a data gap between months', async () => {
@@ -242,5 +257,22 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[2] as DatapointAggregate).average).toBe(55);
     expect((response[0].datapoints[3] as DatapointAggregate).average).toBe(75);
     expect((response[0].datapoints[4] as DatapointAggregate).average).toBe(95);
+    expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190); // March 2023
+    // Check timestamps
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 9, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 10, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 11, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 0, 1)
+    );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 2, 1)
+    );
   });
 });

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -144,7 +144,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 9, 1),
-        end: new Date(2022, 10, 15),
+        end: new Date(2022, 10, 31),
         aggregates: ['sum'],
       }
     );
@@ -166,7 +166,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 11, 1),
-        end: new Date(2023, 2, 15),
+        end: new Date(2023, 2, 29),
         aggregates: ['sum'],
       }
     );
@@ -187,7 +187,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 9, 1),
-        end: new Date(2022, 11, 15),
+        end: new Date(2022, 11, 30),
         aggregates: ['sum'],
       }
     );
@@ -211,7 +211,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 9, 1),
-        end: new Date(2023, 2, 15),
+        end: new Date(2023, 2, 29),
         aggregates: ['sum'],
       }
     );
@@ -277,7 +277,7 @@ describe('Datapoints integration test for monthly granularity', () => {
       {
         items: [{ id: timeserie.id }],
         start: new Date(2022, 9, 1),
-        end: new Date(2023, 2, 15),
+        end: new Date(2023, 2, 29),
         aggregates: ['average'],
       }
     );

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -243,8 +243,8 @@ describe('Datapoints integration test for monthly granularity', () => {
     const response = await client.datapoints.retrieveDatapointMonthlyAggregates(
       {
         items: [{ id: timeserie.id }],
-        start: Date.parse("2022-10-01T00:00:00Z"),
-        end: Date.parse("2023-03-31T00:00:00Z"),
+        start: Date.parse('2022-10-01T00:00:00Z'),
+        end: Date.parse('2023-03-31T00:00:00Z'),
         aggregates: ['sum'],
       }
     );

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -154,10 +154,10 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
     // Check timestamps
     expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
-      new Date(2022, 0, 1)
+      new Date(2022, 9, 1)
     );
     expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
-      new Date(2022, 0, 1)
+      new Date(2022, 10, 1)
     );
   });
 
@@ -208,6 +208,22 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110);
     expect((response[0].datapoints[3] as DatapointAggregate).sum).toBe(150);
     expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190);
+      // Check timestamps
+      expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+        new Date(2022, 9, 1)
+      );
+      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+        new Date(2022, 10, 1)
+      );
+      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+        new Date(2022, 12, 1)
+      );
+      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+        new Date(2023, 0, 1)
+      );
+      expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+        new Date(2023, 3, 1)
+      );
   });
 
   test('retrieve monthly average granularity when there is a data gap between months', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -203,11 +203,11 @@ describe('Datapoints integration test for monthly granularity', () => {
     );
 
     // Check that the response contains the correct number of data points
-    expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
-    expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
-    expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110);
-    expect((response[0].datapoints[3] as DatapointAggregate).sum).toBe(150);
-    expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190);
+    expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
+    expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70); // November 2022
+    expect((response[0].datapoints[2] as DatapointAggregate).sum).toBe(110); // December 2022
+    expect((response[0].datapoints[3] as DatapointAggregate).sum).toBe(150); // January 2023
+    expect((response[0].datapoints[4] as DatapointAggregate).sum).toBe(190); // March 2023
     // Check timestamps
     expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 9, 1)

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -153,8 +153,12 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
     // Check timestamps
-    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toBe(new Date(2022, 9, 1));
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toBe(new Date(2022, 10, 1));
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toBe(
+      "2022-09-01T00:00:00.000Z"
+      );
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toBe(
+      "2022-10-01T00:00:00.000Z"
+      );
 
   });
 

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -149,6 +149,8 @@ describe('Datapoints integration test for monthly granularity', () => {
       }
     );
 
+    console.log(response[0].datapoints);
+
     expect(response[0].datapoints.length).toBe(2);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
@@ -171,6 +173,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response[0].datapoints);
 
     expect(response[0].datapoints.length).toBe(2);
     // Check that the response contains the correct number of data points
@@ -193,6 +196,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response[0].datapoints);
 
     expect(response[0].datapoints.length).toBe(3);
     // Check that the response contains the correct number of data points
@@ -219,6 +223,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(5);
 
     // Check that the response contains the correct number of data points
@@ -254,6 +259,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response[0].datapoints);
 
     expect(response[0].datapoints.length).toBe(3);
 
@@ -282,6 +288,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['average'],
       }
     );
+    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(5);
 
     // Check that the response contains the correct number of data points
@@ -317,6 +324,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(3);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022
@@ -342,6 +350,7 @@ describe('Datapoints integration test for monthly granularity', () => {
         aggregates: ['sum'],
       }
     );
+    console.log(response[0].datapoints);
     expect(response[0].datapoints.length).toBe(3);
     // Check that the response contains the correct number of data points
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30); // October 2022

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -153,11 +153,11 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[0] as DatapointAggregate).sum).toBe(30);
     expect((response[0].datapoints[1] as DatapointAggregate).sum).toBe(70);
     // Check timestamps
-    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toBe(
-      '2022-10-01T00:00:00.000Z'
+    expect((response[0].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 0, 1)
     );
-    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toBe(
-      '2022-11-01T00:00:00.000Z'
+    expect((response[0].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 0, 1)
     );
   });
 

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -198,19 +198,23 @@ const getMonthsBetweenDates = (
   endDate = new Date(endDate);
 
   while (currentMonth <= endDate) {
-      const firstDay = new Date(Date.UTC(currentMonth.getFullYear(), currentMonth.getMonth(), 1, 0));
-      const lastDay = new Date(Date.UTC(currentMonth.getFullYear(), currentMonth.getMonth()+1, 1, 0));
+    const firstDay = new Date(
+      Date.UTC(currentMonth.getFullYear(), currentMonth.getMonth(), 1, 0)
+    );
+    const lastDay = new Date(
+      Date.UTC(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1, 0)
+    );
 
-      result.push({
-          startDate: firstDay.getTime(),
-          endDate: lastDay.getTime(),
-          numberOfDays: (lastDay.getTime() - firstDay.getTime()) / (24 * 3600 * 1000),
-      });
-      // Move to the next month
-      currentMonth.setMonth(currentMonth.getMonth() + 1);
+    result.push({
+      startDate: firstDay.getTime(),
+      endDate: lastDay.getTime(),
+      numberOfDays:
+        (lastDay.getTime() - firstDay.getTime()) / (24 * 3600 * 1000),
+    });
+    // Move to the next month
+    currentMonth.setMonth(currentMonth.getMonth() + 1);
   }
   return result;
 };
-
 
 export type LatestDataParams = IgnoreUnknownIds;

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -198,23 +198,19 @@ const getMonthsBetweenDates = (
   endDate = new Date(endDate);
 
   while (currentMonth <= endDate) {
-    const year = currentMonth.getFullYear();
-    const month = currentMonth.getMonth() + 1; // Months are zero-indexed
+      const firstDay = new Date(Date.UTC(currentMonth.getFullYear(), currentMonth.getMonth(), 1, 0));
+      const lastDay = new Date(Date.UTC(currentMonth.getFullYear(), currentMonth.getMonth()+1, 1, 0));
 
-    const firstDay = new Date(year, month - 1, 1);
-    const lastDay = new Date(year, month, 0);
-
-    result.push({
-      startDate: firstDay.getTime(),
-      endDate: lastDay.getTime(),
-      numberOfDays: lastDay.getDate() - firstDay.getDate() + 1,
-    });
-
-    // Move to the next month
-    currentMonth.setMonth(currentMonth.getMonth() + 1);
+      result.push({
+          startDate: firstDay.getTime(),
+          endDate: lastDay.getTime(),
+          numberOfDays: (lastDay.getTime() - firstDay.getTime()) / (24 * 3600 * 1000),
+      });
+      // Move to the next month
+      currentMonth.setMonth(currentMonth.getMonth() + 1);
   }
-
   return result;
 };
+
 
 export type LatestDataParams = IgnoreUnknownIds;


### PR DESCRIPTION
Always do queries in UTC timezone regardless of input timezone. This avoid getting the monthly aggregates shifted to the previous day in the case of time zones which is after UTC.

In Oslo 2023-01-01:00:00:00 is 2022-12-31T23:00:00 in UTC. (which gave aggregates from 31/12->30/1 instead of 1/1->31/1) 