### PR TITLE
feat: monitoring tasks upsert

### DIFF
--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -45,6 +45,23 @@ describe('alerts api', () => {
     });
   });
 
+  test('update channel name', async () => {
+      const updatedName = channelExternalId + '_updated';
+      const response = await client.alerts.updateChannels([
+        {
+          externalId: channelExternalId,
+          update: {
+            name: {
+              set: updatedName,
+            },
+          }
+        }]);
+
+      expect(response.length).toBe(1);
+      expect(response[0].name).toBe(updatedName);
+    }
+  )
+
   test('list channels', async () => {
     const response = await client.alerts.listChannels({
       filter: { externalIds: [channelExternalId] },

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -46,21 +46,21 @@ describe('alerts api', () => {
   });
 
   test('update channel name', async () => {
-      const updatedName = channelExternalId + '_updated';
-      const response = await client.alerts.updateChannels([
-        {
-          externalId: channelExternalId,
-          update: {
-            name: {
-              set: updatedName,
-            },
-          }
-        }]);
+    const updatedName = channelExternalId + '_updated';
+    const response = await client.alerts.updateChannels([
+      {
+        externalId: channelExternalId,
+        update: {
+          name: {
+            set: updatedName,
+          },
+        },
+      },
+    ]);
 
-      expect(response.length).toBe(1);
-      expect(response[0].name).toBe(updatedName);
-    }
-  )
+    expect(response.length).toBe(1);
+    expect(response[0].name).toBe(updatedName);
+  });
 
   test('list channels', async () => {
     const response = await client.alerts.listChannels({

--- a/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -16,7 +16,7 @@ describe('monitoring tasks api', () => {
   const client: CogniteClient = setupLoggedInClient();
   const ts = Date.now();
   const monitoringTaskExternalId = `test_mt_${ts}`;
-  const monitoringTaskName = `test_mt_${ts}`;
+  let monitoringTaskName = `test_mt_${ts}`;
   const channelExternalId = `test_channel_mt_${ts}`;
   const sessionsApi = `/api/v1/projects/${process.env.COGNITE_PROJECT}/sessions`;
   const testMtModel: MonitoringTaskDoubleThresholdModelCreate = {
@@ -92,6 +92,33 @@ describe('monitoring tasks api', () => {
     expect(response[0].externalId).toBe(monitoringTaskExternalId);
     done();
   }, 10000);
+
+  test('upsert monitoring task', async () => {
+    const sessionsRes = await client.post<SessionsResponse>(sessionsApi, {
+      data: {
+        items: [
+          {
+            clientId: process.env.COGNITE_CLIENT_ID,
+            clientSecret: process.env.COGNITE_CLIENT_SECRET,
+          },
+        ],
+      },
+    });
+
+    monitoringTaskName = monitoringTaskName + '_updated';
+    const response = await client.monitoringTasks.upsert([
+      {
+        externalId: monitoringTaskExternalId,
+        name: monitoringTaskName,
+        channelId: channel.id,
+        model: testMtModel,
+        nonce: sessionsRes?.data?.items[0]?.nonce,
+      }
+    ]);
+
+    expect(response.length).toBe(1);
+    expect(response[name]).toBe(monitoringTaskName);
+  });
 
   test('list all monitoring tasks', async () => {
     const response = await client.monitoringTasks.list({

--- a/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -111,13 +111,15 @@ describe('monitoring tasks api', () => {
         externalId: monitoringTaskExternalId,
         name: monitoringTaskNameUpdated,
         channelId: channel.id,
-        model: testMtModel,
+        interval: testMtInterval,
         nonce: sessionsRes?.data?.items[0]?.nonce,
+        overlap: testMtOverlap,
+        model: testMtModel,
       },
     ]);
 
     expect(response.length).toBe(1);
-    expect(response[name]).toBe(monitoringTaskNameUpdated);
+    expect(response[0].name).toBe(monitoringTaskNameUpdated);
   });
 
   test('list all monitoring tasks', async () => {
@@ -137,6 +139,7 @@ describe('monitoring tasks api', () => {
     expect(response.items[0].model).toEqual(
       expect.objectContaining(expectedResponseModel)
     );
+
     expect(response.items[0].interval).toEqual(testMtInterval);
     expect(response.items[0].overlap).toEqual(testMtOverlap);
   });

--- a/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -113,7 +113,7 @@ describe('monitoring tasks api', () => {
         channelId: channel.id,
         model: testMtModel,
         nonce: sessionsRes?.data?.items[0]?.nonce,
-      }
+      },
     ]);
 
     expect(response.length).toBe(1);

--- a/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -16,7 +16,8 @@ describe('monitoring tasks api', () => {
   const client: CogniteClient = setupLoggedInClient();
   const ts = Date.now();
   const monitoringTaskExternalId = `test_mt_${ts}`;
-  let monitoringTaskName = `test_mt_${ts}`;
+  const monitoringTaskName = `test_mt_${ts}`;
+  const monitoringTaskNameUpdated = monitoringTaskName + '_updated';
   const channelExternalId = `test_channel_mt_${ts}`;
   const sessionsApi = `/api/v1/projects/${process.env.COGNITE_PROJECT}/sessions`;
   const testMtModel: MonitoringTaskDoubleThresholdModelCreate = {
@@ -105,11 +106,10 @@ describe('monitoring tasks api', () => {
       },
     });
 
-    monitoringTaskName = monitoringTaskName + '_updated';
     const response = await client.monitoringTasks.upsert([
       {
         externalId: monitoringTaskExternalId,
-        name: monitoringTaskName,
+        name: monitoringTaskNameUpdated,
         channelId: channel.id,
         model: testMtModel,
         nonce: sessionsRes?.data?.items[0]?.nonce,
@@ -117,7 +117,7 @@ describe('monitoring tasks api', () => {
     ]);
 
     expect(response.length).toBe(1);
-    expect(response[name]).toBe(monitoringTaskName);
+    expect(response[name]).toBe(monitoringTaskNameUpdated);
   });
 
   test('list all monitoring tasks', async () => {
@@ -133,7 +133,7 @@ describe('monitoring tasks api', () => {
     });
     expect(response.items.length).toBe(1);
     expect(response.items[0].externalId).toEqual(monitoringTaskExternalId);
-    expect(response.items[0].name).toEqual(monitoringTaskName);
+    expect(response.items[0].name).toEqual(monitoringTaskNameUpdated);
     expect(response.items[0].model).toEqual(
       expect.objectContaining(expectedResponseModel)
     );

--- a/packages/beta/src/api/monitoringTasks/monitoringTasksApi.ts
+++ b/packages/beta/src/api/monitoringTasks/monitoringTasksApi.ts
@@ -34,5 +34,5 @@ export class MonitoringTasksAPI extends BaseResourceAPI<MonitoringTask> {
 
   public upsert = async (items: MonitoringTaskCreate[]) => {
     return this.upsertEndpoint(items);
-  }
+  };
 }

--- a/packages/beta/src/api/monitoringTasks/monitoringTasksApi.ts
+++ b/packages/beta/src/api/monitoringTasks/monitoringTasksApi.ts
@@ -31,4 +31,8 @@ export class MonitoringTasksAPI extends BaseResourceAPI<MonitoringTask> {
   public delete = async (ids: IdEither[]) => {
     return this.deleteEndpoint(ids);
   };
+
+  public upsert = async (items: MonitoringTaskCreate[]) => {
+    return this.upsertEndpoint(items);
+  }
 }

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -2,7 +2,7 @@
 
 import {
   Metadata,
-  MetadataPatch,
+  MetadataPatch, SinglePatchRequired,
   SinglePatchRequiredString,
   SinglePatchString,
   Timestamp,
@@ -59,6 +59,7 @@ export const MonitoringTaskModelExternalId = {
 export interface MonitoringTaskThresholdModelCreateBase {
   externalId: MonitoringTaskModelExternalId;
 }
+
 export interface MonitoringTaskThresholdModelCreate
   extends MonitoringTaskThresholdModelCreateBase {
   externalId: 'threshold';
@@ -98,8 +99,8 @@ export interface MonitoringTaskCreate {
   externalId: CogniteExternalId;
   name: string;
   channelId: CogniteInternalId;
-  interval: number;
-  overlap: number;
+  interval?: number;
+  overlap?: number;
   model:
     | MonitoringTaskThresholdModelCreate
     | MonitoringTaskDoubleThresholdModelCreate;
@@ -228,12 +229,17 @@ export interface ChannelPatch {
     externalId?: SinglePatchString;
     name?: SinglePatchRequiredString;
     description?: SinglePatchString;
+    parentId?: SinglePatchRequired<number>;
     metadata?: MetadataPatch;
   };
 }
 
-export interface ChannelChangeById extends ChannelPatch, InternalId {}
-export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId {}
+export interface ChannelChangeById extends ChannelPatch, InternalId {
+}
+
+export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId {
+}
+
 export type ChannelChange = ChannelChangeById | ChannelChangeByExternalId;
 
 export interface SubscriberCreate {

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -2,7 +2,8 @@
 
 import {
   Metadata,
-  MetadataPatch, SinglePatchRequired,
+  MetadataPatch,
+  SinglePatchRequired,
   SinglePatchRequiredString,
   SinglePatchString,
   Timestamp,
@@ -234,11 +235,9 @@ export interface ChannelPatch {
   };
 }
 
-export interface ChannelChangeById extends ChannelPatch, InternalId {
-}
+export interface ChannelChangeById extends ChannelPatch, InternalId {}
 
-export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId {
-}
+export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId {}
 
 export type ChannelChange = ChannelChangeById | ChannelChangeByExternalId;
 

--- a/packages/core/src/baseResourceApi.ts
+++ b/packages/core/src/baseResourceApi.ts
@@ -20,6 +20,7 @@ import {
 } from './types';
 import { applyIfApplicable, promiseAllWithData } from './utils';
 import DateParser from './dateParser';
+
 /** @hidden */
 export abstract class BaseResourceAPI<ResponseType> {
   protected get listGetUrl() {
@@ -147,13 +148,12 @@ export abstract class BaseResourceAPI<ResponseType> {
 
   protected async upsertEndpoint<RequestType>(
     items: RequestType[],
-    path: string = this.url(),
     preRequestModifier?: (items: RequestType[]) => RequestType[],
     postRequestModifier?: (items: ResponseType[]) => ResponseType[]
   ) {
     return this.callEndpointWithMergeAndTransform(
       items,
-      (data) => this.callUpsertEndpoint(data, path),
+      (data) => this.callUpsertEndpoint(data),
       preRequestModifier,
       postRequestModifier
     );

--- a/packages/core/src/baseResourceApi.ts
+++ b/packages/core/src/baseResourceApi.ts
@@ -46,6 +46,10 @@ export abstract class BaseResourceAPI<ResponseType> {
     return this.url('delete');
   }
 
+  protected get upsertUrl() {
+    return this.url('upsert');
+  }
+
   protected get aggregateUrl() {
     return this.url('aggregate');
   }
@@ -136,6 +140,20 @@ export abstract class BaseResourceAPI<ResponseType> {
     return this.callEndpointWithMergeAndTransform(
       items,
       (data) => this.callCreateEndpoint(data, path),
+      preRequestModifier,
+      postRequestModifier
+    );
+  }
+
+  protected async upsertEndpoint<RequestType>(
+    items: RequestType[],
+    path: string = this.url(),
+    preRequestModifier?: (items: RequestType[]) => RequestType[],
+    postRequestModifier?: (items: ResponseType[]) => ResponseType[]
+  ) {
+    return this.callEndpointWithMergeAndTransform(
+      items,
+      (data) => this.callUpsertEndpoint(data, path),
       preRequestModifier,
       postRequestModifier
     );
@@ -364,6 +382,16 @@ export abstract class BaseResourceAPI<ResponseType> {
   private async callCreateEndpoint<RequestType>(
     items: RequestType[],
     path: string
+  ) {
+    return this.postInSequenceWithAutomaticChunking<
+      RequestType,
+      ItemsWrapper<ResponseType>
+    >(path, items);
+  }
+
+  private async callUpsertEndpoint<RequestType>(
+    items: RequestType[],
+    path: string = this.upsertUrl
   ) {
     return this.postInSequenceWithAutomaticChunking<
       RequestType,

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -2380,6 +2380,7 @@ export type SingleCogniteCapability =
   | { templateInstancesAcl: AclTemplateInstances };
 
 export type SinglePatch<T> = { set: T } | { setNull: boolean };
+export type SinglePatchRequired<T> = { set: T };
 
 export type SinglePatchDate = { set: Timestamp } | { setNull: boolean };
 


### PR DESCRIPTION
- Adds monitoring tasks upsert - [docs](https://pr-60.tasks-api.preview.cogniteapp.com/#tag/Monitoring/operation/upsert_monitoring_tasks_api_v1_projects__project__monitoringtasks_upsert_post)
- Updates MonitoringTaskCreate interface, make `interval` and `overlap` optional to match api 

These changes are primarily in the beta package, but I have [added a new endpoint to core](https://github.com/cognitedata/cognite-sdk-js/pull/1042/files#diff-393f42bfefc6d77b843d57c6cec2e9b4f2315f679029b72b71c2bb9c5fb026f7) and a [new type to stable](https://github.com/cognitedata/cognite-sdk-js/pull/1042/files#diff-a1cb34e0ba200ad9a54dfae19192d251fe8573729eea371b18dacdbf2850ab44R2383)

