### PR TITLE
fix: return all time series when asking for multiple time series of monthly aggregates

### DIFF
--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -171,8 +171,6 @@ describe('Datapoints integration test for monthly granularity', () => {
     },
   ];
 
-
-
   beforeAll(async () => {
     client = setupLoggedInClient();
     [timeserie] = await client.timeseries.create([{ name: 'tmp' }]);
@@ -281,7 +279,7 @@ describe('Datapoints integration test for monthly granularity', () => {
   test('retrieve monthly granularity when there is a data gap between months', async () => {
     const response = await client.datapoints.retrieveDatapointMonthlyAggregates(
       {
-        items: [{ id: timeserie.id }],
+        items: [{ id: timeserie.id }, { id: timeserie2.id }],
         start: new Date(2022, 9, 1),
         end: new Date(2023, 2, 15),
         aggregates: ['sum'],
@@ -336,7 +334,6 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 2, 1)
     );
-
   });
 
   test('retrieve monthly granularity for a year when there is missing data for some months', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -143,7 +143,6 @@ describe('Datapoints integration test for monthly granularity', () => {
         datapoints,
       },
     ]);
-
   });
   afterAll(async () => {
     await client.timeseries.delete([{ id: timeserie.id }]);
@@ -184,8 +183,6 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[1].datapoints[1] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 10, 1)
     );
-
-
   });
 
   test('retrieve monthly granularity for two consecutive months in different years', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -77,7 +77,6 @@ describe('Datapoints integration test for monthly granularity', () => {
   let client: CogniteClient;
   let timeserie: Timeseries;
   let timeserie2: Timeseries;
-
   const datapoints = [
     // Create two data points in October 2022
     {
@@ -125,6 +124,54 @@ describe('Datapoints integration test for monthly granularity', () => {
       value: 100,
     },
   ];
+  const datapoints2 = [
+    // Create two data points in October 2022
+    {
+      timestamp: new Date(2022, 9, 1),
+      value: 0,
+    },
+    {
+      timestamp: new Date(2022, 9, 2),
+      value: 10,
+    },
+    // Create two data points in November 2022
+    {
+      timestamp: new Date(2022, 10, 1),
+      value: 20,
+    },
+    {
+      timestamp: new Date(2022, 10, 2),
+      value: 30,
+    },
+    // Create two data points in December 2022
+    {
+      timestamp: new Date(2022, 11, 1),
+      value: 40,
+    },
+    {
+      timestamp: new Date(2022, 11, 2),
+      value: 50,
+    },
+    // Create a missing month in between, populated with data points in Feb 2023
+    {
+      timestamp: new Date(2023, 1, 1),
+      value: 60,
+    },
+    {
+      timestamp: new Date(2023, 1, 2),
+      value: 70,
+    },
+    {
+      timestamp: new Date(2023, 2, 1),
+      value: 80,
+    },
+    {
+      timestamp: new Date(2023, 2, 2),
+      value: 90,
+    },
+  ];
+
+
 
   beforeAll(async () => {
     client = setupLoggedInClient();
@@ -132,7 +179,7 @@ describe('Datapoints integration test for monthly granularity', () => {
     await client.datapoints.insert([
       {
         id: timeserie.id,
-        datapoints,
+        datapoints: datapoints,
       },
     ]);
 
@@ -140,7 +187,7 @@ describe('Datapoints integration test for monthly granularity', () => {
     await client.datapoints.insert([
       {
         id: timeserie2.id,
-        datapoints,
+        datapoints: datapoints2,
       },
     ]);
   });
@@ -174,8 +221,8 @@ describe('Datapoints integration test for monthly granularity', () => {
     // check that there is two timeseries in the response
     expect(response[1].datapoints.length).toBe(2);
     // Check that the response contains the correct number of data points
-    expect((response[1].datapoints[0] as DatapointAggregate).sum).toBe(30);
-    expect((response[1].datapoints[1] as DatapointAggregate).sum).toBe(70);
+    expect((response[1].datapoints[0] as DatapointAggregate).sum).toBe(10);
+    expect((response[1].datapoints[1] as DatapointAggregate).sum).toBe(50);
     // Check timestamps
     expect((response[1].datapoints[0] as DatapointAggregate).timestamp).toEqual(
       new Date(2022, 9, 1)
@@ -264,6 +311,32 @@ describe('Datapoints integration test for monthly granularity', () => {
     expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
       new Date(2023, 2, 1)
     );
+
+    expect(response[1].datapoints.length).toBe(5);
+
+    // Check that the response contains the correct number of data points
+    expect((response[1].datapoints[0] as DatapointAggregate).sum).toBe(10); // October 2022
+    expect((response[1].datapoints[1] as DatapointAggregate).sum).toBe(50); // November 2022
+    expect((response[1].datapoints[2] as DatapointAggregate).sum).toBe(90); // December 2022
+    expect((response[1].datapoints[3] as DatapointAggregate).sum).toBe(130); // February 2023
+    expect((response[1].datapoints[4] as DatapointAggregate).sum).toBe(170); // March 2023
+    // Check timestamps
+    expect((response[1].datapoints[0] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 9, 1)
+    );
+    expect((response[1].datapoints[1] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 10, 1)
+    );
+    expect((response[1].datapoints[2] as DatapointAggregate).timestamp).toEqual(
+      new Date(2022, 11, 1)
+    );
+    expect((response[1].datapoints[3] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 1, 1)
+    );
+    expect((response[0].datapoints[4] as DatapointAggregate).timestamp).toEqual(
+      new Date(2023, 2, 1)
+    );
+
   });
 
   test('retrieve monthly granularity for a year when there is missing data for some months', async () => {

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -15,7 +15,7 @@ import {
   Timestamp,
   DatapointsMonthlyGranularityMultiQuery,
   DoubleDatapoint,
-  StringDatapoint
+  StringDatapoint,
 } from '../../types';
 
 export class DataPointsAPI extends BaseResourceAPI<
@@ -90,13 +90,20 @@ export class DataPointsAPI extends BaseResourceAPI<
       const results = await Promise.all(promises);
 
       // Merge the datapoints into a single item per time series
-      const mergedDatapoints: { [id: number]: DatapointAggregate[] | DoubleDatapoint[] | StringDatapoint[]; } = {};
-      const mergedTimeseries: { [id: number]: Datapoints | DatapointAggregates; } = {};
+      const mergedDatapoints: {
+        [id: number]:
+          | DatapointAggregate[]
+          | DoubleDatapoint[]
+          | StringDatapoint[];
+      } = {};
+      const mergedTimeseries: {
+        [id: number]: Datapoints | DatapointAggregates;
+      } = {};
 
       for (const result of results) {
         // There can be multiple time series in a response, so we need to loop through each item
         for (const item of result) {
-          if(!mergedTimeseries[item.id]) {
+          if (!mergedTimeseries[item.id]) {
             mergedTimeseries[item.id] = item;
           }
           if (item?.datapoints?.length) {
@@ -107,11 +114,10 @@ export class DataPointsAPI extends BaseResourceAPI<
             }
           }
         }
-
       }
-      const resultSet: DatapointAggregates[] = []
+      const resultSet: DatapointAggregates[] = [];
 
-      for(const key in mergedTimeseries) {
+      for (const key in mergedTimeseries) {
         const item = mergedTimeseries[key];
         item.datapoints = mergedDatapoints[key];
         resultSet.push(item as DatapointAggregates);

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -14,8 +14,6 @@ import {
   DatapointInfo,
   Timestamp,
   DatapointsMonthlyGranularityMultiQuery,
-  DoubleDatapoint,
-  StringDatapoint,
 } from '../../types';
 
 export class DataPointsAPI extends BaseResourceAPI<
@@ -91,26 +89,25 @@ export class DataPointsAPI extends BaseResourceAPI<
 
       // Merge the datapoints into a single item per time series
       const mergedDatapoints: {
-        [id: number]:
-          | DatapointAggregate[]
-          | DoubleDatapoint[]
-          | StringDatapoint[];
+        [id: number]: DatapointAggregate[];
       } = {};
       const mergedTimeseries: {
-        [id: number]: Datapoints | DatapointAggregates;
+        [id: number]: DatapointAggregates;
       } = {};
 
       for (const result of results) {
         // There can be multiple time series in a response, so we need to loop through each item
         for (const item of result) {
           if (!mergedTimeseries[item.id]) {
-            mergedTimeseries[item.id] = item;
+            mergedTimeseries[item.id] = item as DatapointAggregates;
           }
           if (item?.datapoints?.length) {
             if (!mergedDatapoints[item.id]) {
               mergedDatapoints[item.id] = item.datapoints;
             } else {
-              mergedDatapoints[item.id].concat(item.datapoints);
+              mergedDatapoints[item.id] = mergedDatapoints[item.id].concat(
+                item.datapoints
+              );
             }
           }
         }

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -105,9 +105,7 @@ export class DataPointsAPI extends BaseResourceAPI<
             if (!mergedDatapoints[item.id]) {
               mergedDatapoints[item.id] = item.datapoints;
             } else {
-              mergedDatapoints[item.id] = mergedDatapoints[item.id].concat(
-                item.datapoints
-              );
+              mergedDatapoints[item.id].push(...item.datapoints);
             }
           }
         }

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -169,7 +169,7 @@ export class DataPointsAPI extends BaseResourceAPI<
   private async retrieveDatapointsEndpoint<
     T extends DatapointAggregates[] | Datapoints[] =
       | DatapointAggregates[]
-      | Datapoints[]
+      | Datapoints[],
   >(query: DatapointsMultiQuery) {
     const path = this.listPostUrl;
     const response = await this.post<ItemsWrapper<T>>(path, {

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -169,7 +169,7 @@ export class DataPointsAPI extends BaseResourceAPI<
   private async retrieveDatapointsEndpoint<
     T extends DatapointAggregates[] | Datapoints[] =
       | DatapointAggregates[]
-      | Datapoints[],
+      | Datapoints[]
   >(query: DatapointsMultiQuery) {
     const path = this.listPostUrl;
     const response = await this.post<ItemsWrapper<T>>(path, {


### PR DESCRIPTION
The monthly aggregates would only return one time series (the first in the result set) regardless of the number of time series asked for in the query.

It appeared that the queries were correct, but the result parsing only used the first time series in the result.