### PR TITLE
fix(docs): added missing baseUrl in auth code to comply with demo code

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -125,6 +125,7 @@ async function quickstart() {
   const client = new CogniteClient({
     appId: 'Cognite SDK samples',
     project,
+    baseUrl: "https://api.cognitedata.com",
     getToken: () =>
       pca
         .acquireTokenByClientCredential({


### PR DESCRIPTION
Client instantiation needs baseUrl set - its correctly set in the demo code, but missing in the example docs. Added.