### PR TITLE
feat: update monitoringTaskCreate type

### DIFF
--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -110,7 +110,8 @@ export interface MonitoringTaskCreate {
   sourceId?: string;
   alertContext?: {
     unsubscribeUrl: string;
-    investigateUrl: string;
+    investigateUrl?: string;
+    editUrl?: string;
   };
 }
 


### PR DESCRIPTION
Updates monitoringTaskCreate type to match tasks api 
https://pr-60.tasks-api.preview.cogniteapp.com/#tag/Monitoring/operation/create_monitoring_tasks_api_v1_projects__project__monitoringtasks_post

- Adds editUrl
- investigateUrl is now optional