### PR TITLE
docs: typo in example

### DIFF
--- a/packages/stable/src/api/timeSeries/timeSeriesApi.ts
+++ b/packages/stable/src/api/timeSeries/timeSeriesApi.ts
@@ -45,7 +45,7 @@ export class TimeSeriesAPI extends BaseResourceAPI<Timeseries> {
    * ```js
    * const timeseries = [
    *   { name: 'Pressure sensor', assetId: 123 },
-   *   { name: 'Temprature sensor', description: 'Pump abc', unit: 'C' },
+   *   { name: 'Temperature sensor', description: 'Pump abc', unit: 'C' },
    * ];
    * const createdTimeseries = await client.timeseries.create(timeseries);
    * ```


### PR DESCRIPTION
Assume we don't need to bump the version? Since there is no change at all.
Curious that no one discovered this since 2019... 
https://cognitedata.slack.com/archives/CG10VQPFX/p1706099505720579