### PR TITLE
chore: enable the disabled vision test

### DIFF
--- a/packages/stable/src/__tests__/api/visionApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/visionApi.int.spec.ts
@@ -78,7 +78,7 @@ describe('Vision API', () => {
         `Timed out while waiting for vision job to complete.`
       );
     });
-    test.skip('waitForCompletion=true', async () => {
+    test('waitForCompletion=true', async () => {
       const result = await client.vision.getExtractJob(extractJob.jobId, true);
       expect(result.status).toEqual('Completed');
       expect(result.jobId).toEqual(extractJob.jobId);


### PR DESCRIPTION
I disabled this test earlier, because it was blocking an unrelated PR, but we need to figure out why it was failing and get it enabled again.