### PR TITLE
fix: fix simulator cron type

### DIFF
--- a/packages/alpha/README.md
+++ b/packages/alpha/README.md
@@ -14,7 +14,7 @@ npm install @cognite/sdk-alpha --save
 
 This will download `@cognite/sdk-alpha`. Import the `CogniteClientAlpha`:
 ```js
-import CogniteClientAlpha from '@congite/sdk-alpha';
+import CogniteClientAlpha from '@cognite/sdk-alpha';
 ```
 
 The CogniteClientAlpha can be initialized/configured in the same manner as the other packages (eg. stable, beta, etc.).

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -434,7 +434,7 @@ export interface SimulatorRoutineConfigDisabled {
 
 export interface SimulatorRoutineSchedule {
   enabled: boolean;
-  cron_expression: string;
+  cronExpression: string;
 }
 
 export interface SimulatorRoutineSteadyStateDetection {


### PR DESCRIPTION
fixes a typo in the simulator types and will trigger a deploy to NPM for the alpha SDK which didn't have the correct PR title to get deployed in a previous PR: https://github.com/cognitedata/cognite-sdk-js/pull/1076