### PR TITLE
fix: model revision create boundary condition type

### DIFF
--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -340,7 +340,7 @@ export interface SimulatorModelRevisionCreate {
   modelExternalId: CogniteExternalId;
   description?: string;
   fileId: CogniteInternalId;
-  boundaryConditions?: SimulatorModelBoundaryCondition[];
+  boundaryConditions?: Pick<SimulatorModelBoundaryCondition, 'key'>[];
   metadata?: Record<string, any>;
 }
 


### PR DESCRIPTION
When creating a model revision, the `boundaryConditions` property expects an array of objects with only one key called `key`.