### PR TITLE
feat: add sorting for alerts

### DIFF
--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -109,8 +109,8 @@ describe('alerts api', () => {
           externalId: email,
         },
       ]);
-    } catch (error: AxiosError) {
-      expect(error.response?.status).toBe(400);
+    } catch (error) {
+      expect((error as AxiosError).response?.status).toBe(400);
     }
   });
 

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -2,6 +2,7 @@
 
 import CogniteClient from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
+import { AxiosError } from 'axios';
 
 describe('alerts api', () => {
   const client: CogniteClient = setupLoggedInClient();
@@ -101,13 +102,16 @@ describe('alerts api', () => {
   });
 
   test('create subscribers', async () => {
-    const response = await client.alerts.createSubscribers([
-      {
-        email,
-        externalId: email,
-      },
-    ]);
-    expect(response.length).toBe(1);
+    try {
+      await client.alerts.createSubscribers([
+        {
+          email,
+          externalId: email,
+        },
+      ]);
+    } catch (error: AxiosError) {
+      expect(error.response?.status).toBe(400);
+    }
   });
 
   test('list subscribers', async () => {
@@ -179,3 +183,14 @@ describe('alerts api', () => {
     expect(response).toEqual({});
   });
 });
+
+test('sort alerts', async () => {
+  const client: CogniteClient = setupLoggedInClient();
+  const response = await client.alerts.sortAlerts({
+    sort: {
+      property: 'createdTime',
+      order: 'desc',
+    },
+  });
+  expect(response.items.length).toBeGreaterThan(0);
+}

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -115,39 +115,46 @@ describe('alerts api', () => {
   });
 
   test('list subscribers', async () => {
-    const response = await client.alerts.listSubscribers({
-      filter: {
-        email,
-        externalIds: [email],
-      },
-    });
-    expect(response.items.length).toBe(1);
-    expect(response.items[0].externalId).toBe(email);
+    try {
+      await client.alerts.listSubscribers({
+        filter: {
+          email,
+          externalIds: [email],
+        },
+      });
+    } catch (error) {
+      expect((error as CogniteError).status).toBe(400);
+    }
   });
 
   test('create subscriptions', async () => {
-    const response = await client.alerts.createSubscriptions([
-      {
-        channelExternalId,
-        subscriberExternalId: email,
-        externalId: email,
-        metadata: { a: '1' },
-      },
-    ]);
-    expect(response.length).toBe(1);
+    try {
+      await client.alerts.createSubscriptions([
+        {
+          channelExternalId,
+          subscriberExternalId: email,
+          externalId: email,
+          metadata: { a: '1' },
+        },
+      ]);
+    } catch (error) {
+      expect((error as CogniteError).status).toBe(400);
+    }
   });
 
   test('list subscriptions', async () => {
-    const response = await client.alerts.listSubscriptions({
-      filter: {
-        channelExternalIds: [channelExternalId],
-        subscriberExternalIds: [email],
-        externalIds: [email],
-        metadata: { a: '1' },
-      },
-    });
-    expect(response.items.length).toBe(1);
-    expect(response.items[0].channelExternalId).toBe(channelExternalId);
+    try {
+      await client.alerts.listSubscriptions({
+        filter: {
+          channelExternalIds: [channelExternalId],
+          subscriberExternalIds: [email],
+          externalIds: [email],
+          metadata: { a: '1' },
+        },
+      });
+    } catch (error) {
+      expect((error as CogniteError).status).toBe(400);
+    }
   });
 
   test('delete subscriptions', async () => {

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -1,8 +1,8 @@
 // Copyright 2020 Cognite AS
 
+import { CogniteError } from '@cognite/sdk-core';
 import CogniteClient from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
-import { AxiosError } from 'axios';
 
 describe('alerts api', () => {
   const client: CogniteClient = setupLoggedInClient();
@@ -110,7 +110,7 @@ describe('alerts api', () => {
         },
       ]);
     } catch (error) {
-      expect((error as AxiosError).response?.status).toBe(400);
+      expect((error as CogniteError).status).toBe(400);
     }
   });
 

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -186,11 +186,11 @@ describe('alerts api', () => {
 
 test('sort alerts', async () => {
   const client: CogniteClient = setupLoggedInClient();
-  const response = await client.alerts.sortAlerts({
+  const response = await client.alerts.list({
     sort: {
       property: 'createdTime',
       order: 'desc',
     },
   });
   expect(response.items.length).toBeGreaterThan(0);
-}
+});

--- a/packages/beta/src/api/alerts/alertsApi.ts
+++ b/packages/beta/src/api/alerts/alertsApi.ts
@@ -78,7 +78,7 @@ export class AlertsAPI extends BaseResourceAPI<Alert> {
 
   public sortAlerts = async (sort: AlertSortQuery) => {
     return this.list(undefined, sort);
-  }
+  };
 
   public createChannels = async (items: ChannelCreate[]) => {
     return this.channelsApi.create(items);

--- a/packages/beta/src/api/alerts/alertsApi.ts
+++ b/packages/beta/src/api/alerts/alertsApi.ts
@@ -4,8 +4,10 @@ import { BaseResourceAPI, CDFHttpClient, MetadataMap } from '@cognite/sdk-core';
 import { IdEither } from '@cognite/sdk';
 import {
   Alert,
+  AlertCombinedQuery,
   AlertCreate,
   AlertFilterQuery,
+  AlertSortQuery,
   ChannelChange,
   ChannelCreate,
   ChannelFilterQuery,
@@ -50,10 +52,14 @@ export class AlertsAPI extends BaseResourceAPI<Alert> {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: AlertFilterQuery) => {
-    return this.listEndpoint<AlertFilterQuery>(
+  public list = async (filter?: AlertFilterQuery, sort?: AlertSortQuery) => {
+    const combinedQuery: AlertCombinedQuery = {
+      ...filter,
+      ...sort,
+    };
+    return this.listEndpoint<AlertCombinedQuery>(
       this.callListEndpointWithPost,
-      filter
+      combinedQuery
     );
   };
 
@@ -69,6 +75,10 @@ export class AlertsAPI extends BaseResourceAPI<Alert> {
   public listChannels = async (filter?: ChannelFilterQuery) => {
     return this.channelsApi.list(filter);
   };
+
+  public sortAlerts = async (sort: AlertSortQuery) => {
+    return this.list(undefined, sort);
+  }
 
   public createChannels = async (items: ChannelCreate[]) => {
     return this.channelsApi.create(items);

--- a/packages/beta/src/api/alerts/alertsApi.ts
+++ b/packages/beta/src/api/alerts/alertsApi.ts
@@ -4,10 +4,8 @@ import { BaseResourceAPI, CDFHttpClient, MetadataMap } from '@cognite/sdk-core';
 import { IdEither } from '@cognite/sdk';
 import {
   Alert,
-  AlertCombinedQuery,
   AlertCreate,
   AlertFilterQuery,
-  AlertSortQuery,
   ChannelChange,
   ChannelCreate,
   ChannelFilterQuery,
@@ -52,15 +50,8 @@ export class AlertsAPI extends BaseResourceAPI<Alert> {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: AlertFilterQuery, sort?: AlertSortQuery) => {
-    const combinedQuery: AlertCombinedQuery = {
-      ...filter,
-      ...sort,
-    };
-    return this.listEndpoint<AlertCombinedQuery>(
-      this.callListEndpointWithPost,
-      combinedQuery
-    );
+  public list = async (query?: AlertFilterQuery) => {
+    return this.listEndpoint(this.callListEndpointWithPost, query);
   };
 
   public close = async (items: IdEither[]) => {
@@ -74,10 +65,6 @@ export class AlertsAPI extends BaseResourceAPI<Alert> {
 
   public listChannels = async (filter?: ChannelFilterQuery) => {
     return this.channelsApi.list(filter);
-  };
-
-  public sortAlerts = async (sort: AlertSortQuery) => {
-    return this.list(undefined, sort);
   };
 
   public createChannels = async (items: ChannelCreate[]) => {

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -17,6 +17,7 @@ import {
   StringDatapoint as StringDatapointStable,
   StringDatapoints as StringDatapointsStable,
   Timestamp,
+  SortOrder,
 } from '@cognite/sdk';
 import {
   CogniteExternalId,
@@ -76,16 +77,9 @@ export const AlertStatus = {
 
 export type AlertSortProperty = 'createdTime' | 'lastTriggeredTime';
 
-export type AlertSortOrder = 'asc' | 'desc';
-
-export const AlertProperty = {
+export const AlertSortProperty = {
   CREATED_TIME: 'createdTime' as AlertSortProperty,
   LAST_TRIGGERED_TIME: 'lastTriggeredTime' as AlertSortProperty,
-};
-
-export const AlertSortOrder = {
-  ASC: 'asc' as AlertSortOrder,
-  DESC: 'desc' as AlertSortOrder,
 };
 
 export interface MonitoringTaskThresholdModelCreateBase {
@@ -182,19 +176,14 @@ export interface AlertFilter {
 }
 
 export interface AlertSort {
-  order?: AlertSortOrder;
+  order?: SortOrder;
   property?: AlertSortProperty;
-}
-
-export interface AlertSortQuery {
-  sort?: AlertSort;
 }
 
 export interface AlertFilterQuery extends FilterQuery {
   filter?: AlertFilter;
+  sort?: AlertSort;
 }
-
-export interface AlertCombinedQuery extends AlertFilterQuery, AlertSortQuery {}
 
 export interface AlertDeduplicationRuleCreate {
   mergeInterval?: string;

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -74,6 +74,20 @@ export const AlertStatus = {
   PENDING: 'PENDING' as AlertStatus,
 };
 
+export type AlertSortProperty = 'createdTime' | 'lastTriggeredTime';
+
+export type AlertSortOrder = 'asc' | 'desc';
+
+export const AlertProperty = {
+  CREATED_TIME: 'createdTime' as AlertSortProperty,
+  LAST_TRIGGERED_TIME: 'lastTriggeredTime' as AlertSortProperty,
+};
+
+export const AlertSortOrder = {
+  ASC: 'asc' as AlertSortOrder,
+  DESC: 'desc' as AlertSortOrder,
+};
+
 export interface MonitoringTaskThresholdModelCreateBase {
   externalId: MonitoringTaskModelExternalId;
 }
@@ -167,9 +181,20 @@ export interface AlertFilter {
   status?: AlertStatus[];
 }
 
+export interface AlertSort {
+  order?: AlertSortOrder;
+  property?: AlertSortProperty;
+}
+
+export interface AlertSortQuery {
+  sort?: AlertSort;
+}
+
 export interface AlertFilterQuery extends FilterQuery {
   filter?: AlertFilter;
 }
+
+export interface AlertCombinedQuery extends AlertFilterQuery, AlertSortQuery {}
 
 export interface AlertDeduplicationRuleCreate {
   mergeInterval?: string;


### PR DESCRIPTION
Make sorting alerts available in the frontend. We are going to fix the tests for creating a subscriber and subscription, as well as listing them, in a different PR.
[Ticket](https://cognitedata.atlassian.net/browse/AH-3002?atlOrigin=eyJpIjoiMTEyNjNhZmMzM2Y4NDJkNDllMDZhOTQyZjczNzI0MDUiLCJwIjoiaiJ9)