### PR TITLE
feat: add simulation run data API

### DIFF
--- a/packages/alpha/src/__tests__/api/simulationRunDataApi.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunDataApi.spec.ts
@@ -1,0 +1,35 @@
+// Copyright 2023 Cognite AS
+import CogniteClientAlpha from '../../cogniteClient';
+import { setupLoggedInClient } from '../testUtils';
+
+const SHOULD_RUN_TESTS = process.env.RUN_SDK_SIMINT_TESTS == 'true';
+
+const describeIf = SHOULD_RUN_TESTS ? describe : describe.skip;
+
+describeIf('simulation run data api', () => {
+  const client: CogniteClientAlpha = setupLoggedInClient();
+
+  test('list simulation run data', async () => {
+    const runs = await client.simulators.listRuns({
+      filter: {
+        simulatorName: 'DWSIM',
+        status: 'success',
+      },
+    });
+
+    const runId = runs.items[0].id;
+
+    const runData = await client.simulators.listRunData([
+      {
+        runId,
+      },
+    ]);
+
+    expect(runData).toBeDefined();
+    expect(runData.length).toBeGreaterThan(0);
+
+    const item = runData[0];
+
+    expect(item.runId).toBe(runId);
+  });
+});

--- a/packages/alpha/src/api/simulators/simulationRunDataApi.ts
+++ b/packages/alpha/src/api/simulators/simulationRunDataApi.ts
@@ -1,0 +1,16 @@
+// Copyright 2023 Cognite AS
+
+import { BaseResourceAPI, CDFHttpClient, MetadataMap } from '@cognite/sdk-core';
+import { SimulationRunData, SimulationRunId } from '../../types';
+
+export class SimulationRunDataAPI extends BaseResourceAPI<SimulationRunData> {
+  constructor(...args: [string, CDFHttpClient, MetadataMap]) {
+    super(...args);
+  }
+
+  public retrieve = async (ids: SimulationRunId[]) => {
+    const path = this.url('simulators/runs/data/list');
+
+    return this.retrieveEndpoint(ids, {}, path);
+  };
+}

--- a/packages/alpha/src/api/simulators/simulatorsApi.ts
+++ b/packages/alpha/src/api/simulators/simulatorsApi.ts
@@ -24,9 +24,11 @@ import {
   SimulatorModelRevisionChange,
   SimulatorRoutineRevisionCreate,
   SimulatorRoutineRevisionslFilterQuery,
+  SimulationRunId,
 } from '../../types';
 import { IntegrationsAPI } from './integrationsApi';
 import { SimulationRunsAPI } from './simulationRunsApi';
+import { SimulationRunDataAPI } from './simulationRunDataApi';
 import { ModelsAPI } from './modelsApi';
 import { ModelRevisionsAPI } from './modelRevisionsApi';
 import { RoutinesAPI } from './routinesApi';
@@ -36,6 +38,7 @@ import { LogsAPI } from './logsApi';
 export class SimulatorsAPI extends BaseResourceAPI<Simulator> {
   private integrationsApi: IntegrationsAPI;
   private runsApi: SimulationRunsAPI;
+  private runDataApi: SimulationRunDataAPI;
   private modelsApi: ModelsAPI;
   private modelRevisionsApi: ModelRevisionsAPI;
   private routinesApi: RoutinesAPI;
@@ -62,6 +65,12 @@ export class SimulatorsAPI extends BaseResourceAPI<Simulator> {
 
     this.runsApi = new SimulationRunsAPI(
       `${resourcePath}/runs`,
+      client,
+      metadataMap
+    );
+
+    this.runDataApi = new SimulationRunDataAPI(
+      `${resourcePath}/runs/data`,
       client,
       metadataMap
     );
@@ -125,6 +134,10 @@ export class SimulatorsAPI extends BaseResourceAPI<Simulator> {
 
   public listRuns = async (filter?: SimulationRunFilterQuery) => {
     return this.runsApi.list(filter);
+  };
+
+  public listRunData = async (ids: SimulationRunId[]) => {
+    return this.runDataApi.retrieve(ids);
   };
 
   public runSimulation = async (items: SimulationRunCreate[]) => {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -247,12 +247,12 @@ export interface SimulationRunDataOutput {
   referenceId: CogniteInternalId;
   value: string | number | string[] | number[];
   valueType: SimulationRunDataValueType;
-  unit: {
+  unit?: {
     name: string;
     externalId?: CogniteExternalId;
   };
   simulatorObjectReference?: Record<string, string>;
-  timeseriesExternalId: CogniteExternalId;
+  timeseriesExternalId?: CogniteExternalId;
 }
 
 export interface SimulationRunDataInput extends SimulationRunDataOutput {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -230,6 +230,45 @@ export interface SimulationRun {
   lastUpdatedTime: Date;
 }
 
+export type SimulationRunDataValueType =
+  | 'STRING'
+  | 'DOUBLE'
+  | 'STRING_ARRAY'
+  | 'DOUBLE_ARRAY';
+
+export const SimulationRunDataValueType = {
+  STRING: 'STRING' as SimulationRunDataValueType,
+  DOUBLE: 'DOUBLE' as SimulationRunDataValueType,
+  STRING_ARRAY: 'STRING_ARRAY' as SimulationRunDataValueType,
+  DOUBLE_ARRAY: 'DOUBLE_ARRAY' as SimulationRunDataValueType,
+};
+
+export interface SimulationRunDataOutput {
+  referenceId: CogniteInternalId;
+  value: string | number | string[] | number[];
+  valueType: SimulationRunDataValueType;
+  unit: {
+    name: string;
+    externalId?: CogniteExternalId;
+  };
+  simulatorObjectReference?: Record<string, string>;
+  timeseriesExternalId: CogniteExternalId;
+}
+
+export interface SimulationRunDataInput extends SimulationRunDataOutput {
+  overridden?: boolean;
+}
+
+export interface SimulationRunId {
+  runId: CogniteInternalId;
+}
+
+export interface SimulationRunData {
+  runId: CogniteInternalId;
+  inputs: SimulationRunDataInput[];
+  outputs: SimulationRunDataOutput[];
+}
+
 export type SimulatorLogSeverityLevel =
   | 'Debug'
   | 'Information'


### PR DESCRIPTION
add methods for `Simulation Data By Run Id` endpoint.

`https://{cluster}.cognitedata.com/api/v1/projects/{project}/simulators/runs/data/list`