### PR TITLE
fix: fixing failing subscriber tests

### DIFF
--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -101,10 +101,13 @@ describe('alerts api', () => {
   });
 
   test('create subscribers', async () => {
+
+    const subscriberUserProfile = await client.profiles.search({search: {name: 'Charts Smoke Test User'}})
+    const subscriberExternalId = subscriberUserProfile[0].userIdentifier
+    
     const response = await client.alerts.createSubscribers([
       {
-        email,
-        externalId: email,
+        externalId: subscriberExternalId,
       },
     ]);
     expect(response.length).toBe(1);
@@ -156,9 +159,11 @@ describe('alerts api', () => {
   });
 
   test('delete subscriber', async () => {
+    const subscriberUserProfile = await client.profiles.search({search: {name: 'Charts Smoke Test User'}})
+    const subscriberExternalId = subscriberUserProfile[0].userIdentifier
     const response = await client.alerts.deleteSubscribers([
       {
-        externalId: email,
+        externalId: subscriberExternalId,
       },
     ]);
     expect(response).toEqual({});

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -103,7 +103,7 @@ describe('alerts api', () => {
   test('create subscribers', async () => {
 
     const subscriberUserProfile = await client.profiles.search({search: {name: 'Charts Smoke Test User'}})
-    const subscriberExternalId = subscriberUserProfile[0].userIdentifier
+    const subscriberExternalId = subscriberUserProfile[0]?.userIdentifier
     
     const response = await client.alerts.createSubscribers([
       {
@@ -160,7 +160,7 @@ describe('alerts api', () => {
 
   test('delete subscriber', async () => {
     const subscriberUserProfile = await client.profiles.search({search: {name: 'Charts Smoke Test User'}})
-    const subscriberExternalId = subscriberUserProfile[0].userIdentifier
+    const subscriberExternalId = subscriberUserProfile[0]?.userIdentifier
     const response = await client.alerts.deleteSubscribers([
       {
         externalId: subscriberExternalId,

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -263,11 +263,6 @@ export interface ChannelChangeByExternalId extends ChannelPatch, ExternalId {}
 
 export type ChannelChange = ChannelChangeById | ChannelChangeByExternalId;
 
-export interface SubscriberCreate {
-  externalId?: CogniteExternalId;
-  metadata?: Metadata;
-  email: string;
-}
 
 export interface SubscriberFilter {
   externalIds?: CogniteExternalId[];
@@ -288,9 +283,9 @@ export interface Subscriber {
 }
 
 export interface SubscriberCreate {
-  externalId?: CogniteExternalId;
+  externalId: CogniteExternalId;
   metadata?: Metadata;
-  email: string;
+  email?: string;
 }
 
 export interface SubscriptionCreate {


### PR DESCRIPTION
Fixing failing tests after added validation for user profile
Making subscriberExternalId mandatory and e-mail optional
[AH-1090]

[AH-1090]: https://cognitedata.atlassian.net/browse/AH-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ