### PR TITLE
fix: simulation run data api path

### DIFF
--- a/packages/alpha/src/__tests__/api/simulationRunsApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunsApi.int.spec.ts
@@ -15,7 +15,7 @@ describeIf('simulator integrations api', () => {
   test('run a simulation', async () => {
     const res = await client.simulators.runSimulation([
       {
-        routineExternalId: 'ShowerMixerIntegrationTestConstInputs',
+        routineExternalId: 'ShowerMixerWithExtendedIO',
         runType: 'external',
         runTime: new Date(ts),
         queue: true,
@@ -30,8 +30,10 @@ describeIf('simulator integrations api', () => {
     const item = res[0];
 
     expect(item.simulatorName).toBe('DWSIM');
-    expect(item.modelName).toBe('ShowerMixerIntegrationTest');
-    expect(item.routineName).toBe('ShowerMixerIntegrationTest');
+    expect(item.modelName).toBe('Shower Mixer');
+    expect(item.routineName).toBe(
+      'Shower Mixer With Extended Inputs / Outputs'
+    );
     expect(item.status).toBe('ready');
     expect(item.runType).toBe('external');
     expect(item.runTime?.valueOf()).toBe(ts);

--- a/packages/alpha/src/__tests__/api/simulationRunsApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunsApi.int.spec.ts
@@ -17,7 +17,7 @@ describeIf('simulator integrations api', () => {
       {
         routineExternalId: 'ShowerMixerIntegrationTestConstInputs',
         runType: 'external',
-        validationEndTime: new Date(ts),
+        runTime: new Date(ts),
         queue: true,
       },
     ]);
@@ -34,7 +34,7 @@ describeIf('simulator integrations api', () => {
     expect(item.routineName).toBe('ShowerMixerIntegrationTest');
     expect(item.status).toBe('ready');
     expect(item.runType).toBe('external');
-    expect(item.validationEndTime?.valueOf()).toBe(ts);
+    expect(item.runTime?.valueOf()).toBe(ts);
     expect(item.createdTime.valueOf()).toBeGreaterThanOrEqual(ts);
     expect(item.lastUpdatedTime.valueOf()).toBeGreaterThanOrEqual(ts);
   });

--- a/packages/alpha/src/api/simulators/simulationRunDataApi.ts
+++ b/packages/alpha/src/api/simulators/simulationRunDataApi.ts
@@ -9,7 +9,7 @@ export class SimulationRunDataAPI extends BaseResourceAPI<SimulationRunData> {
   }
 
   public retrieve = async (ids: SimulationRunId[]) => {
-    const path = this.url('simulators/runs/data/list');
+    const path = this.url('list');
 
     return this.retrieveEndpoint(ids, {}, path);
   };

--- a/packages/alpha/src/api/simulators/simulationRunsApi.ts
+++ b/packages/alpha/src/api/simulators/simulationRunsApi.ts
@@ -19,7 +19,7 @@ export class SimulationRunsAPI extends BaseResourceAPI<SimulationRun> {
   protected getDateProps() {
     return this.pickDateProps(
       ['items'],
-      ['createdTime', 'lastUpdatedTime', 'validationEndTime', 'simulationTime']
+      ['createdTime', 'lastUpdatedTime', 'runTime', 'simulationTime']
     );
   }
 

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -193,7 +193,7 @@ export const SimulationRunType = {
 export interface SimulationRunCreate {
   routineExternalId: CogniteExternalId;
   runType?: SimulationRunType;
-  validationEndTime?: Date;
+  runTime?: Date;
   queue?: boolean;
 }
 
@@ -218,7 +218,7 @@ export interface SimulationRun {
   routineExternalId?: CogniteExternalId;
   routineRevisionExternalId?: CogniteExternalId;
   status: SimulationRunStatus;
-  validationEndTime?: Date;
+  runTime?: Date;
   simulationTime?: Date;
   statusMessage?: string;
   dataSetId?: CogniteInternalId;


### PR DESCRIPTION
Fixes the path for the simulation run data endpoint.

Renames `validationEndTime` to `runTime`.