### PR TITLE
fix(stable/models): pass 'inlineViews' as params instead of request body for data models retrieve

### DIFF
--- a/packages/stable/src/__tests__/api/datamodels.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datamodels.int.spec.ts
@@ -123,6 +123,23 @@ describe('Data models integration test', () => {
     expect(datamodel.items[0].name).toEqual(datamodelCreationDefinition.name);
   });
 
+  it('should include views when retrieving datamodels', async () => {
+    const datamodel = await client.dataModels.retrieve(
+      [
+        {
+          space: TEST_SPACE_NAME,
+          externalId: datamodelCreationDefinition.externalId,
+        },
+      ],
+      {
+        inlineViews: true,
+      }
+    );
+    console.log('data model', datamodel);
+    expect(datamodel.items[0].views).toHaveLength(1);
+    // expect(datamodel.items[0].views[0].externalId).toEqual(TEST_VIEW_NAME);
+  });
+
   it('should successfully delete datamodels', async () => {
     const response = await client.dataModels.delete([
       {

--- a/packages/stable/src/__tests__/api/datamodels.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datamodels.int.spec.ts
@@ -135,7 +135,8 @@ describe('Data models integration test', () => {
         inlineViews: true,
       }
     );
-    console.log('data model', datamodel);
+    console.log('data model', datamodel, datamodel.items[0].views);
+    expect(datamodel.items[0].views).toBeDefined();
     expect(datamodel.items[0].views).toHaveLength(1);
     // expect(datamodel.items[0].views[0].externalId).toEqual(TEST_VIEW_NAME);
   });

--- a/packages/stable/src/__tests__/api/datamodels.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datamodels.int.spec.ts
@@ -1,6 +1,10 @@
 // Copyright 2024 Cognite AS
 
-import { DataModelCreate, ViewCreateDefinition } from 'stable/src/types';
+import {
+  DataModelCreate,
+  ViewCreateDefinition,
+  ViewDefinition,
+} from 'stable/src/types';
 import CogniteClient from '../../cogniteClient';
 import { deleteOldSpaces, randomInt, setupLoggedInClient } from '../testUtils';
 
@@ -121,6 +125,7 @@ describe('Data models integration test', () => {
     ]);
     expect(datamodel.items.length).toBe(1);
     expect(datamodel.items[0].name).toEqual(datamodelCreationDefinition.name);
+    expect(datamodel.items[0].views).toBeDefined();
   });
 
   it('should include views when retrieving datamodels', async () => {
@@ -135,10 +140,16 @@ describe('Data models integration test', () => {
         inlineViews: true,
       }
     );
-    console.log('data model', datamodel, datamodel.items?.[0]?.views);
+
+    expect(datamodel.items.length).toBe(1);
     expect(datamodel.items[0].views).toBeDefined();
     expect(datamodel.items[0].views).toHaveLength(1);
-    // expect(datamodel.items[0].views[0].externalId).toEqual(TEST_VIEW_NAME);
+
+    const view = datamodel.items?.[0]?.views?.[0] as ViewDefinition;
+
+    expect(view?.externalId).toEqual(TEST_VIEW_NAME);
+    expect(view?.space).toEqual(TEST_SPACE_NAME);
+    expect(view?.properties).toBeDefined();
   });
 
   it('should successfully delete datamodels', async () => {

--- a/packages/stable/src/__tests__/api/datamodels.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datamodels.int.spec.ts
@@ -126,6 +126,12 @@ describe('Data models integration test', () => {
     expect(datamodel.items.length).toBe(1);
     expect(datamodel.items[0].name).toEqual(datamodelCreationDefinition.name);
     expect(datamodel.items[0].views).toBeDefined();
+
+    // Incorrect type cast to check for negative case (ensuring no 'properties' field)
+    const view = datamodel.items?.[0]?.views?.[0] as ViewDefinition;
+    expect(view?.externalId).toEqual(TEST_VIEW_NAME);
+    expect(view?.space).toEqual(TEST_SPACE_NAME);
+    expect(view?.properties).not.toBeDefined();
   });
 
   it('should include views when retrieving datamodels', async () => {

--- a/packages/stable/src/__tests__/api/datamodels.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datamodels.int.spec.ts
@@ -135,7 +135,7 @@ describe('Data models integration test', () => {
         inlineViews: true,
       }
     );
-    console.log('data model', datamodel, datamodel.items[0].views);
+    console.log('data model', datamodel, datamodel.items?.[0]?.views);
     expect(datamodel.items[0].views).toBeDefined();
     expect(datamodel.items[0].views).toHaveLength(1);
     // expect(datamodel.items[0].views[0].externalId).toEqual(TEST_VIEW_NAME);

--- a/packages/stable/src/api/models/datamodelsApi.ts
+++ b/packages/stable/src/api/models/datamodelsApi.ts
@@ -99,7 +99,8 @@ export class DataModelsAPI extends BaseResourceAPI<DataModel> {
     const response = await this.post<DataModelCollectionResponse>(
       this.byIdsUrl,
       {
-        data: { items: params, ...options },
+        data: { items: params },
+        params: { ...options },
       }
     );
     return response.data;


### PR DESCRIPTION
According to the documentation, the 'inlineViews' has to be passed as a query param: https://api-docs.cognite.com/20230101/tag/Data-models/operation/byExternalIdsDataModels