### PR TITLE
chore: revert breaking change created by isoplan annotations

### DIFF
--- a/packages/stable/src/.cognite-openapi-snapshot.json
+++ b/packages/stable/src/.cognite-openapi-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.0",
+  "openapi": "3.0.2",
   "info": {
     "title": "Cognite API",
     "description": "# Introduction\nThis is the reference documentation for the Cognite API with\nan overview of all the available methods.\n\n# Postman\nSelect the **Download** button to download our OpenAPI specification to get started.\n\nTo import your data into Postman, select **Import**, and the Import modal opens.\nYou can import items by dragging or dropping files or folders. You can choose how to import your API and manage the import settings in **View Import Settings**.\n\nIn the Import Settings, set the **Folder organization** to **Tags**, select\n**Enable optional parameters** to turn off the settings, and select **Always inherit authentication** to turn on the settings. Select **Import**.\n\nSet the Authorization to **Oauth2.0**. By default, the settings are for Open Industrial Data. Navigate to [Cognite Hub](https://hub.cognite.com/open-industrial-data-211) to understand how to get the credentials for use in Postman.\n\nFor more information, see [Getting Started with Postman](https://developer.cognite.com/dev/guides/postman/).\n\n# Pagination\nMost resource types can be paginated, indicated by the field `nextCursor` in the response.\nBy passing the value of `nextCursor` as the cursor you will get the next page of `limit` results.\nNote that all parameters except `cursor` has to stay the same.\n\n# Parallel retrieval\nAs general guidance, Parallel Retrieval is a technique that should be used when due to query complexity, retrieval of data in a single request is significantly slower than it would otherwise be for a simple request.  Parallel retrieval does not act as a speed multiplier on optimally running queries.  By parallelizing such requests, data retrieval performance can be tuned to meet the client application needs. \n\nCDF supports parallel retrieval through the `partition` parameter, which has the format `m/n` where `n` is the amount of partitions you would like to split the entire data set into.\nIf you want to download the entire data set by splitting it into 10 partitions, do the following in parallel with `m` running from 1 to 10:\n  - Make a request to `/events` with `partition=m/10`.\n  - Paginate through the response by following the cursor as explained above. Note that the `partition` parameter needs to be passed to all subqueries.\n\nProcessing of parallel retrieval requests is subject to concurrency quota availability. The request returns the `429` response upon exceeding concurrency limits. See the Request throttling chapter below.\n\nTo prevent unexpected problems and to maximize read throughput, you should at most use 10 partitions. \nSome CDF resources will automatically enforce a maximum of 10 partitions.\nFor more specific and detailed information, please read the ```partition``` attribute documentation for the CDF resource you're using.  \n\n# Requests throttling\nCognite Data Fusion (CDF) returns the HTTP `429` (too many requests) response status code when project capacity exceeds the limit.\n\nThe throttling can happen:\n  - If a user or a project sends too many (more than allocated) concurrent requests.\n  - If a user or a project sends a too high (more than allocated) rate of requests in a given amount of time.\n\nCognite recommends using a retry strategy based on truncated exponential backoff to handle sessions with HTTP response codes 429.\n\nCognite recommends using a reasonable number (up to 10) of  `Parallel retrieval` partitions.\n\nFollowing these strategies lets you slow down the request frequency to maximize productivity without having to re-submit/retry failing requests.\n\nSee more [here](https://developer.cognite.com/dev/concepts/request_throttling/).\n\n# API versions\n## Version headers\nThis API uses calendar versioning, and version names follow the `YYYYMMDD` format.\nYou can find the versions currently available by using the version selector at the top of this page.\n\nTo use a specific API version, you can pass the `cdf-version: $version` header along with your requests to the API.\n\n## Beta versions\nThe beta versions provide a preview of what the stable version will look like in the future.\nBeta versions contain functionality that is reasonably mature, and highly likely to become a part of the stable API.\n\nBeta versions are indicated by a `-beta` suffix after the version name. For example, the beta version header for the\n2023-01-01 version is then `cdf-version: 20230101-beta`.\n\n## Alpha versions\nAlpha versions contain functionality that is new and experimental, and not guaranteed to ever become a part of the stable API.\nThis functionality presents no guarantee of service, so its use is subject to caution.\n\nAlpha versions are indicated by an `-alpha` suffix after the version name. For example, the alpha version header for\nthe 2023-01-01 version is then `cdf-version: 20230101-alpha`.",
@@ -13,9 +13,9 @@
   "servers": [
     {
       "url": "https://{cluster}.cognitedata.com/api/v1/projects/{project}",
-      "description": "The URL for the CDF cluster to connect to",
       "variables": {
         "cluster": {
+          "description": "The CDF cluster to connect to",
           "enum": [
             "api",
             "az-tyo-gp-001",
@@ -28,6 +28,7 @@
           "default": "api"
         },
         "project": {
+          "description": "The CDF project name.",
           "default": "publicdata"
         }
       }
@@ -39,9 +40,9 @@
         "servers": [
           {
             "url": "https://{cluster}.cognitedata.com/api/v1",
-            "description": "The URL for the CDF cluster to connect to",
             "variables": {
               "cluster": {
+                "description": "The CDF cluster to connect to",
                 "default": "api",
                 "enum": [
                   "api",
@@ -7656,9 +7657,9 @@
         "servers": [
           {
             "url": "https://{cluster}.cognitedata.com/api/v1",
-            "description": "The URL for the CDF cluster to connect to",
             "variables": {
               "cluster": {
+                "description": "The CDF cluster to connect to",
                 "default": "api",
                 "enum": [
                   "api",
@@ -7724,9 +7725,9 @@
         "servers": [
           {
             "url": "https://{cluster}.cognitedata.com/api/v1",
-            "description": "The URL for the CDF cluster to connect to",
             "variables": {
               "cluster": {
+                "description": "The CDF cluster to connect to",
                 "default": "api",
                 "enum": [
                   "api",
@@ -7765,6 +7766,11 @@
       }
     },
     "/update": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/project"
+        }
+      ],
       "post": {
         "tags": [
           "Projects"
@@ -9280,7 +9286,7 @@
           "Engineering diagrams"
         ],
         "summary": "Detect annotations in engineering diagrams",
-        "description": "Detect annotations in engineering diagrams. Note: All users in a CDF project with assets read-all and files read access to the requested files can access data sent to this endpoint.\nSupported input file mime_types are application/pdf, image/jpeg, image/png, image/tiff. Also note that the header of a successful response contains an `X-Job-Token` which allows to fetch the result of the\njob at `/context/diagram/detect/{jobId}` without requiring 'assetsAcl:READ'.",
+        "description": "Detect annotations in engineering diagrams. Note: All users in a CDF project with assets read-all and files read access to the requested files can access data sent to this endpoint.\nSupported input file mime_types are application/pdf, image/jpeg, image/png, image/tiff. Also note that the header of a successful response contains an `X-Job-Token` which allows to fetch the result of the \njob at `/context/diagram/detect/{jobId}` without requiring 'assetsAcl:READ'.",
         "operationId": "diagramDetect",
         "requestBody": {
           "content": {
@@ -9371,7 +9377,7 @@
           "Engineering diagrams"
         ],
         "summary": "Retrieve engineering diagram detect results",
-        "description": "Get the results from an engineering diagram detect job. Providing the `X-Job-Token` header returned by the\n`/context/diagram/detect` endpoint is required unless the caller has read access to all assets.",
+        "description": "Get the results from an engineering diagram detect job. Providing the `X-Job-Token` header returned by the \n`/context/diagram/detect` endpoint is required unless the caller has read access to all assets.",
         "operationId": "diagramDetectResults",
         "parameters": [
           {
@@ -10030,7 +10036,7 @@
           "Entity matching"
         ],
         "summary": "Predict matches",
-        "description": "Predicts entity matches using a trained model. Note: 'assetsAcl:READ' capability is required unless both `sources` and `targets` are specified in the request. Also note that the header of a successful response contains a `X-Job-Token` which allows to fetch the result of the job at `/context/entitymatching/jobs/{jobId}` without requiring 'assetsAcl:READ'.",
+        "description": "Predicts entity matches using a trained model. Note: 'assetsAcl:READ' capability is required unless both `sources` and `targets` are specified in the request.  Also note that the header of a successful response contains a `X-Job-Token` which allows to fetch the result of the  job at `/context/entitymatching/jobs/{jobId}` without requiring 'assetsAcl:READ'.",
         "operationId": "entityMatchingPredict",
         "requestBody": {
           "content": {
@@ -10106,7 +10112,7 @@
           "Entity matching"
         ],
         "summary": "Retrieve entity matcher predict results",
-        "description": "Get the results from a predict job. Note: 'assetsAcl:READ' capability is required, unless you specify a valid `X-Job-Token` in the request header. The `X-Job-Token` is provided in the response header of the initial call to `/context/entitymatching/predict`",
+        "description": "Get the results from a predict job.  Note: 'assetsAcl:READ' capability is required, unless you specify a valid `X-Job-Token` in the request header.  The `X-Job-Token` is provided in the response header of the initial call to `/context/entitymatching/predict`",
         "operationId": "entityMatchingPredictResults",
         "parameters": [
           {
@@ -10370,6 +10376,18 @@
         "summary": "Search for documents",
         "description": "This endpoint lets you search for documents by using advanced filters and free text queries.\nFree text queries are matched against the documents' filenames and contents.\n\n### Free text search\n\n#### Boolean operators\n\nThe `+` symbol represents an AND operation, and the `|` symbol represents an OR.\nSearching for `lorem + ipsum` will match documents containing both \"lorem\" AND \"ipsum\" in the filename or content.\nSimilarly, searching for `lorem | ipsum` will match documents containing either \"lorem\" OR \"ipsum\" in the filename or\ncontent.\n\nThe default operator between the search keywords is AND.\nThat means that searching for two terms without any operator, for example, `lorem ipsum`, will\nmatch documents containing both the words \"lorem\" and \"ipsum\" in the filename or content.\n\nYou can use the operator `-` to exclude documents containing a specific word.\nFor instance, the search `lorem -ipsum` will match documents that contain the word \"lorem\", but does NOT contain the\nword \"ipsum\".\n\n#### Phrases\n\nEnclose multiple words inside double quotes `\"` to group these words together.\nNormally, the search query `lorem ipsum` will match not only \"lorem ipsum\" but also \"lorem cognite ipsum\",\nand in general, there can be any number of words between the two words in the query.\nThe search query `\"lorem ipsum\"`, however, will match only exactly \"lorem ipsum\" and not \"lorem cognite ipsum\".\n\n#### Escape\n\nTo search for the special characters (`+`, `|`, `-`, `\"`. `\\`), escape with a preceding backslash `\\`.\n\n#### Ordering\n\nWhen you search for a term, the endpoint tries to return the most relevant documents first, with less relevant documents further down\nthe list.\nThere are a few factors that determine the relevance of a document:\n\n- If the search terms are found multiple times within a document, the relevance of that document is higher.\n- For searches with multiple terms, documents containing all the terms are considered more relevant than documents\n  containing only some.\n- Matches of the terms in the filename field of the document are more relevant than matches in the document's content.\n\n#### Examples\n\nThe following request will return documents matching the specified search query.\n\n```json\n{\n  \"search\": {\n    \"query\": \"cognite \\\"lorem ipsum\\\"\"\n   }\n}\n ```\n\nThe following example combines a query with a filter.\nThe search request will return documents matching the search query, where `externalId` starts with \"1\".\nThe results will be ordered by how well they match the query string.\n\n```json\n{\n    \"search\":{\n        \"query\":\"cognite \\\"lorem ipsum\\\"\"\n    },\n    \"filter\":{\n        \"prefix\":{\n            \"property\":[\n                \"externalId\"\n            ],\n            \"value\":\"1\"\n        }\n    }\n}\n```\n\n### Highlights\n\nWhen you enable highlights for your search query, the response contains an additional highlight field for each\nsearch hit, including the highlighted fragments for your query matches. However, the result limit is 20 documents due to the operation costs.\n\n### Filtering\n\nFiltering uses a special JSON filtering language.\nIt's quite flexible and consists of a number of different \"leaf\" filters, which can be combined arbitrarily using the boolean clauses `and`, `or`, and `not`.\n\n#### Supported leaf filters\n\n<table>\n<tr>\n<th> <div style=\"width:150px\"> Leaf filter </div> </th> \n<th> <div style=\"width:200px\"> Supported fields </div> </th> \n<th> Description  </th>\n</tr>\n\n<tr>\n<td> <code>equals</code> </td> <td> Non-array type fields </td> <td> Only includes results that are equal to the specified value. \n\n```json\n{\n    \"equals\":{\n        \"property\":[\n            \"property\"\n        ],\n        \"value\":\"example\"\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>in</code> </td> <td> Non-array type fields </td> <td> Only includes results that are equal to one of the specified values.  \n\n```json\n{\n    \"in\":{\n        \"property\":[\n            \"property\"\n        ],\n        \"values\":[\n            1,\n            2,\n            3\n        ]\n    }\n}\n```\n</td>\n</tr>\n\n<td> <code>containsAll</code> </td> <td> Array type fields </td> <td> Only includes results which contain all of the specified values.  \n\n```json\n{\n    \"containsAll\":{\n        \"property\":[\n            \"property\"\n        ],\n        \"values\":[\n            1,\n            2,\n            3\n        ]\n    }\n}\n```\n</td>\n<tr>\n\n<td> <code>containsAny</code> </td> <td> Array type fields </td> <td> Only includes results which contain all of the specified values.  \n\n```json\n{\n    \"containsAny\":{\n        \"property\":[\n            \"property\"\n        ],\n        \"values\":[\n            1,\n            2,\n            3\n        ]\n    }\n}\n```\n</td>\n\n<tr>\n<td> <code>exists</code> </td> <td> All fields </td> <td> Only includes results where the specified property exists (has value).  \n\n```json\n{\n    \"exists\":{\n        \"property\":[\n            \"property\"\n        ]\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>prefix</code> </td> <td> String type fields </td> <td> Only includes results which start with the specified value. \n\n```json\n{\n    \"prefix\":{\n        \"property\":[\n            \"property\"\n        ],\n        \"value\":\"example\"\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>range</code> </td> <td> Non-array type fields </td> <td> Only includes results that fall within the specified range. \n\nSupported operators: <code>gt</code>, <code>lt</code>, <code>gte</code>, <code>lte</code>\n\n```json\n{\n    \"range\":{\n        \"property\":[\n            \"property\"\n        ],\n        \"gt\":1,\n        \"lte\":5\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>geojsonIntersects</code> </td> <td> <code>geoLocation</code> </td> <td> Only includes results where the geoshape intersects with the specified geometry.\n\n```json\n{\n    \"geojsonIntersects\":{\n        \"property\":[\n            \"sourceFile\",\n            \"geoLocation\"\n        ],\n        \"geometry\":{\n            \"type\":\"Polygon\",\n            \"coordinates\": [[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]],\n        }\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>geojsonDisjoint</code> </td> <td> <code>geoLocation</code> </td> <td> Only includes results where the geoshape has nothing in common with the specified geometry.\n\n```json\n{\n    \"geojsonDisjoint\":{\n        \"property\":[\n            \"sourceFile\",\n            \"geoLocation\"\n        ],\n        \"geometry\":{\n            \"type\":\"Polygon\",\n            \"coordinates\": [[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]],\n        }\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>geojsonWithin</code> </td> <td> <code>geoLocation</code> </td> <td> Only includes results where the geoshape falls within the specified geometry.\n\n```json\n{\n    \"geojsonWithin\":{\n        \"property\":[\n            \"sourceFile\",\n            \"geoLocation\"\n        ],\n        \"geometry\":{\n            \"type\":\"Polygon\",\n            \"coordinates\": [[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]],\n        }\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>inAssetSubtree</code> </td> <td> <code>assetIds</code>, <code>assetExternalIds</code> </td> <td> Only includes results with a related asset in a subtree rooted at any specified IDs.\n\n```json\n{\n    \"filter\":{\n        \"inAssetSubtree\":{\n            \"property\":[\n                \"sourceFile\",\n                \"assetIds\"\n            ],\n            \"values\":[\n                1,\n                2,\n                3\n            ]\n        }\n    }\n}\n```\n</td>\n</tr>\n\n<tr>\n<td> <code>search</code> </td> <td> <code>name</code>, <code>content</code> </td> <td>\n\n```json\n{\n    \"search\":{\n        \"property\":[\n            \"property\"\n        ],\n        \"value\":\"example\"\n    }\n}\n```\n</td>\n</tr>\n\n</table>\n\n#### Properties\n\nThe following overview shows the properties you can filter and which filter applies to which property.\n\n| Property                                 | Type                | Applicable filters                                                                                                                                                             |\n|------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| `[\"id\"]`                                 | integer             | equals, in, range, exists                                                                                                                                                      |\n| `[\"externalId\"]`                         | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"title\"]`                              | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"author\"]`                             | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"createdTime\"]`                        | integer             | equals, in, range, exists                                                                                                                                                      |\n| `[\"modifiedTime\"]`                       | integer             | equals, in, range, exists                                                                                                                                                      |\n| `[\"lastIndexedTime\"]`                    | integer             | equals, in, range, exists                                                                                                                                                      |\n| `[\"mimeType\"]`                           | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"extension\"]`                          | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"pageCount\"]`                          | integer             | equals, in, range, exists                                                                                                                                                      |\n| `[\"type\"]`                               | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"geoLocation\"]`                        | geometry object     | geojsonIntersects, geojsonDisjoint, geojsonWithin, exists                                                                                                                      |\n| `[\"language\"]`                           | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"assetIds\"]`                           | array of integers   | containsAny, containsAll, exists, inAssetSubtree                                                                                                                               |\n| `[\"assetExternalIds\"]`                   | array of strings    | containsAny, containsAll, exists, inAssetSubtree                                                                                                                               |\n| `[\"labels\"]`                             | array of Labels     | containsAny, containsAll, exists                                                                                                                                               |\n| `[\"content\"]`                            | string              | search                                                                                                                                                                         |\n| `[\"sourceFile\", \"name\"]`                 | string              | equals, in, prefix, exists, search                                                                                                                                             |\n| `[\"sourceFile\", \"mimeType\"]`             | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"sourceFile\", \"size\"]`                 | integer             | equals, in, range, exists                                                                                                                                                      |\n| `[\"sourceFile\", \"source\"]`               | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"sourceFile\", \"directory\"]`            | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"sourceFile\", \"assetIds\"]`             | array of integers   | containsAny, containsAll, exists, inAssetSubtree                                                                                                                               |\n| `[\"sourceFile\", \"assetExternalIds\"]`     | array of strings    | containsAny, containsAll, exists, inAssetSubtree                                                                                                                               |\n| `[\"sourceFile\", \"datasetId\"]`            | integer             | equals, in, range, exists                                                                                                                                                      |\n| `[\"sourceFile\", \"securityCategories\"]`   | array of integers   | containsAny, containsAll, exists                                                                                                                                               |\n| `[\"sourceFile\", \"geoLocation\"]`          | geometry object     | geojsonIntersects, geojsonDisjoint, geojsonWithin, exists                                                                                                                      |\n| `[\"sourceFile\", \"labels\"]`               | array of Labels     | containsAny, containsAll, exists                                                                                                                                               |\n| `[\"sourceFile\", \"metadata\", <key>]`      | string              | equals, in, prefix, exists                                                                                                                                                     |\n| `[\"sourceFile\", \"metadata\"]`             | string              | equals, in, prefix, exists<br><br>This is a special filter field that targets all metadata values. <br>An alternative to creating a filter for each key in the metadata field. |\n\n#### Full example\n\n```json\n{\n   \"filter\": {\n      \"and\": [\n         {\n            \"or\": [\n               {\n                  \"equals\": {\n                     \"property\": [\n                        \"type\"\n                     ],\n                     \"value\": \"PDF\"\n                  }\n               },\n               {\n                  \"prefix\": {\n                     \"property\": [\n                        \"externalId\"\n                     ],\n                     \"value\": \"hello\"\n                  }\n               }\n            ]\n         },\n         {\n            \"range\": {\n               \"property\": [\n                  \"createdTime\"\n               ],\n               \"lte\": 1519862400000\n            }\n         },\n         {\n            \"not\": {\n               \"in\": {\n                  \"property\": [\n                     \"sourceFile\",\n                     \"name\"\n                  ],\n                  \"values\": [\n                     \"My Document.doc\",\n                     \"My Other Document.docx\"\n                  ]\n               }\n            }\n         }\n      ]\n   }\n}\n ```\n\n### Sorting\n\nBy default, search results are ordered by relevance, meaning how well they match the given query string.\nHowever, it's possible to specify a different property to sort by.\nSorting can be ascending or descending. The sort order is ascending if none is specified.\n\n#### Properties\n\nThe following overview shows all properties that can be sorted on.\n\n| Property                        |\n|---------------------------------|\n| `[\"id\"]`                        |\n| `[\"externalId\"]`                |\n| `[\"mimeType\"]`                  |\n| `[\"extension\"]`                 |\n| `[\"pageCount\"]`                 |\n| `[\"author\"]`                    |\n| `[\"title\"]`                     |\n| `[\"language\"]`                  |\n| `[\"type\"]`                      |\n| `[\"createdTime\"]`               |\n| `[\"modifiedTime\"]`              |\n| `[\"lastIndexedTime\"]`           |\n| `[\"sourceFile\", \"name\"]`        |\n| `[\"sourceFile\", \"mimeType\"]`    |\n| `[\"sourceFile\", \"size\"]`        |\n| `[\"sourceFile\", \"source\"]`      |\n| `[\"sourceFile\", \"datasetId\"]`   |\n| `[\"sourceFile\", \"metadata\", *]` |\n\n#### Example\n\n```json\n{\n    \"sort\":[\n        {\n            \"property\":[\n                \"createdTime\"\n            ],\n            \"order\":\"asc\",\n            \n        }\n    ]\n}\n ```\n",
         "operationId": "documentsSearch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project",
+            "required": true,
+            "description": "The project name.",
+            "schema": {
+              "type": "string",
+              "example": "publicdata"
+            }
+          }
+        ],
         "requestBody": {
           "description": "Fields to be set for the search request.",
           "content": {
@@ -12638,6 +12656,15 @@
         "operationId": "getTransformations",
         "parameters": [
           {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "Limits the number of results to be returned. The maximum is 1000, default limit is 100.",
@@ -12818,6 +12845,17 @@
         "summary": "Create transformations",
         "description": "Create a maximum of 1000 transformations per request.",
         "operationId": "createTransformations",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13043,6 +13081,17 @@
         "summary": "Retrieve transformations",
         "description": "Retrieve a maximum of 1000 transformations by ids and externalIds per request.",
         "operationId": "getTransformationsByIds",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13268,6 +13317,17 @@
         "summary": "Filter transformations",
         "description": "Filter transformations. Use nextCursor to paginate through the results.",
         "operationId": "filterTransformations",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13433,6 +13493,17 @@
         "summary": "Delete transformations",
         "description": "Delete a maximum of 1000 transformations by ids and externalIds per request.",
         "operationId": "deleteTransformations",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13658,6 +13729,17 @@
         "summary": "Update transformations",
         "description": "Update the attributes of transformations, maximum 1000 per request.",
         "operationId": "updateTransformations",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13882,6 +13964,17 @@
         ],
         "summary": "Run a transformation",
         "operationId": "runTransformation",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14054,6 +14147,15 @@
         "summary": "List jobs",
         "operationId": "getTransformationJobs",
         "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "transformationId",
             "in": "query",
@@ -14250,6 +14352,17 @@
         "summary": "Retrieve jobs by ids",
         "description": "Retrieve a maximum of 1000 jobs by ids per request.",
         "operationId": "getTransformationJobsByIds",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14476,6 +14589,15 @@
         "operationId": "getTransformationJobsMetrics",
         "parameters": [
           {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "id",
             "in": "path",
             "description": "The job id.",
@@ -14640,6 +14762,17 @@
         ],
         "summary": "Cancel a transformation",
         "operationId": "postApiV1ProjectsProjectTransformationsCancel",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14813,6 +14946,15 @@
         "description": "List all transformation schedules. Use nextCursor to paginate through the results.",
         "operationId": "getTransformationSchedules",
         "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "limit",
             "in": "query",
@@ -15057,6 +15199,17 @@
         "summary": "Schedule transformations",
         "description": "Schedule transformations with the specified configurations.",
         "operationId": "createTransformationSchedules",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "List of the schedules to create. Must be up to a maximum of 1000 items.",
           "content": {
@@ -15283,6 +15436,17 @@
         "summary": "Retrieve schedules",
         "description": "Retrieve transformation schedules by transformation IDs or external IDs.",
         "operationId": "getTransformationSchedulesByIds",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "List of transformation IDs of schedules to retrieve. Must be up to a maximum of 1000 items and all of them must be unique.",
           "content": {
@@ -15509,6 +15673,17 @@
         "summary": "Unschedule transformations",
         "description": "Unschedule transformations by IDs or externalIds.",
         "operationId": "deleteTransformationSchedules",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "List of transformation IDs of schedules to delete. Must be up to a maximum of 1000 items and all of them must be unique.",
           "content": {
@@ -15734,6 +15909,17 @@
         ],
         "summary": "Update schedules",
         "operationId": "updateTransformationSchedules",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "List of schedule updates. Must be up to a maximum of 1000 items.",
           "content": {
@@ -15961,6 +16147,15 @@
         "operationId": "getTransformationNotifications",
         "parameters": [
           {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "transformationId",
             "in": "query",
             "description": "List only notifications for the specified transformation. The transformation is identified by ID.",
@@ -16163,6 +16358,17 @@
         "summary": "Subscribe for notifications",
         "description": "Subscribe for notifications on the transformation errors.",
         "operationId": "createTransformationNotifications",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "List of the notifications for new subscriptions. Must be up to a maximum of 1000 items.",
           "content": {
@@ -16389,6 +16595,17 @@
         "summary": "Delete notification subscriptions by notification ID",
         "description": "Deletes the specified notification subscriptions on the transformation. Requests to delete non-existing subscriptions do nothing, but do not throw an error.",
         "operationId": "deleteTransformationNotifications",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "List of IDs to be deleted.",
           "content": {
@@ -16616,6 +16833,15 @@
         "operationId": "getTransformationSequenceRowSchema",
         "parameters": [
           {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "externalId",
             "in": "query",
             "description": "External ID of the Sequence",
@@ -16770,6 +16996,15 @@
         "description": "For View centric schema, `viewSpace`, `viewExternalId`, `viewVersion` need to be specified while `withInstanceSpace`, `isConnectionDefinition`, `instanceType` are optional . For Data Model centric schema, `dataModelSpace`, `dataModelExternalId`, `dataModelVersion`, `type` need to be specified and `relationshipFromType` is optional. For Both scenarios `conflictMode` is required.",
         "operationId": "getFlexibleDataModelInstanceSchema",
         "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "conflictMode",
             "in": "query",
@@ -17041,6 +17276,15 @@
         "operationId": "getTransformationSchema",
         "parameters": [
           {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "schemaType",
             "in": "path",
             "description": "Name of the target schema type, please provide one of the following:\n `assets`, `timeseries`, `asset_hierarchy`, `events`, `datapoints`\n `string_datapoints`, `sequences`, `files`, `labels`,\n `relationships`, `raw`, `data_sets`",
@@ -17209,6 +17453,17 @@
         "summary": "Run query",
         "description": "Preview a SQL query.",
         "operationId": "runPreview",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "description": "The project name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -18017,7 +18272,7 @@
             "description": "If `true`, ignore unknown workflow ids. If `false`, a `404 Not Found` error is returned and none of the workflows are deleted if any of the workflow ids are unknown.",
             "schema": {
               "type": "boolean",
-              "default": true
+              "default": false
             }
           }
         ],
@@ -18306,7 +18561,7 @@
             "description": "If `true`, ignore unknown version ids. If `false`, a `404 Not Found` error is returned and none of the versions are deleted if any of the version ids are unknown.",
             "schema": {
               "type": "boolean",
-              "default": true
+              "default": false
             }
           }
         ],
@@ -18396,7 +18651,16 @@
                 "type": "object",
                 "properties": {
                   "authentication": {
-                    "$ref": "#/components/schemas/Authentication"
+                    "type": "object",
+                    "properties": {
+                      "nonce": {
+                        "type": "string",
+                        "description": "The nonce of a sessions token, which can be obtained using client credentials authentication flow. The nonce's session must be a root session, i.e. it must not be a child of another session.  See [Sessions API](https://api-docs.cognite.com/20230101/tag/Sessions) documentation for more information."
+                      }
+                    },
+                    "required": [
+                      "nonce"
+                    ]
                   },
                   "input": {
                     "$ref": "#/components/schemas/ExecutionInput"
@@ -18531,100 +18795,70 @@
         ]
       }
     },
-    "/workflows/executions/{executionId}/cancel": {
+    "/workflows/executions/cancel": {
       "post": {
-        "operationId": "WorkflowExecutionCancellation",
-        "summary": "Cancel a workflow execution",
-        "description": "Stops the specified execution from starting new workflow tasks and sets the workflow execution status to `TERMINATED`. Already running tasks will be marked as CANCELED.  Note that the actions taken by the canceled tasks won't be stopped, and these need to be canceled separately if desired. For example, to cancel a running transformation, use the [/transformations/cancel](#/Transformations/postApiV1ProjectsProjectTransformationsCancel) endpoint.",
+        "operationId": "CancelationOfSpecificRunsOfWorkflow",
+        "summary": "Cancel workflow executions",
+        "description": "Stops the specified executions from starting new workflow tasks and sets the workflow execution status to `TERMINATED`. Already running tasks won't be stopped and need to be canceled manually. For example, to cancel a running transformation, use the [/transformations/cancel](#/Transformations/postApiV1ProjectsProjectTransformationsCancel) endpoint .",
         "tags": [
           "Workflow executions"
         ],
         "x-capability": [
           "workflowOrchestrationACL:WRITE"
-        ],
-        "parameters": [
-          {
-            "name": "executionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/WorkflowExecutionId"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CancelExecution"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated workflow execution",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowExecutionResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/ErrorResponse"
-          }
-        }
-      }
-    },
-    "/workflows/executions/{executionId}/retry": {
-      "post": {
-        "operationId": "WorkflowExecutionRetry",
-        "summary": "Retry workflow execution",
-        "description": "This endpoint restarts a previously failed, timed out, or terminated workflow execution by retrying tasks that did not complete successfully. It aims to resume execution activity from the point(s) of failure.\n\nBehavior of the retry operation:\n- Targeted Task Retry: Only retries tasks that have stopped in a terminal state such as `CANCELED`, `FAILED`, `FAILED_WITH_TERMINAL_ERROR`, and `TIMED_OUT`. Optional tasks are not retried.\n- Subworkflows and Dynamic Tasks: When a failure occurs within a subworkflow or as part of a dynamic task, only the individual nested tasks that failed are retried. The subworkflow or dynamic task container itself is not retried.\n- Retry Limits: Tasks that have reached or exceeded their designated retry limits will not have their retry counts reset to zero. Instead, each retry request permits these tasks a single additional retry.\n",
-        "tags": [
-          "Workflow executions"
-        ],
-        "x-capability": [
-          "workflowOrchestrationACL:WRITE"
-        ],
-        "parameters": [
-          {
-            "name": "executionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/WorkflowExecutionId"
-            }
-          }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RetryExecution"
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                      "$ref": "#/components/schemas/CancelExecution"
+                    },
+                    "required": [
+                      "items"
+                    ]
+                  }
+                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Updated workflow execution",
+            "description": "List of canceled workflow executions",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowExecutionResponse"
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "maxItems": 100,
+                      "items": {
+                        "$ref": "#/components/schemas/WorkflowExecutionResponse"
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
                 }
               }
             }
-          },
-          "404": {
-            "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "x-code-samples": [
+          {
+            "lang": "Python",
+            "label": "Python SDK",
+            "source": "from cognite.client.data_classes import CancelExecution\nres = client.workflows.executions.trigger(\"foo\", \"1\")\nclient.workflows.executions.cancel([CancelExecution(res.id, \"test cancelation\")])\n"
+          }
+        ]
       }
     },
     "/workflows/tasks/{taskId}/update": {
@@ -25106,7 +25340,7 @@
             ],
             "properties": {
               "type": {
-                "description": "The data-type to use when storing the property. Supported storage types are;\n\n\n* single value,\n * lists of text (allows user control of collation),\n * boolean,\n * 32-bit, and 64-bit floats,\n * 32-bit, and 64-bit integers,\n * timestamps,\n * dates,\n * JSON fragments,\n * time series external-id reference,\n * file external-id reference,\n * sequence external-id reference\n * direct relation to an existing node.\n\n\nThe JSON fragments have to be valid JSON objects. If JSON arrays are to be stored, these must be wrapped in a JSON object. JSON values (such as string, number, boolean) should use their respective primitive form instead. The maximum allowed size for a JSON object is 40960 bytes. For lists of json values, the size of the entire list must be within this limit. The maximum allowed length of a key is 128, while the maximum allowed size of a value is 10240 bytes and you can have up to 256 key-value pairs. The  byte sizes are computed by representing the data as a UTF-8 encoded JSON string.\nDirect relations use a space external-id, the external-id for an existing node, and the external-id for the data container. E.g. ```s-spaceExternalId.uniqueNodeExternalId.containerExternalId```. The ```view``` property on direct relation can optionally be set, and if it is set then this is a hint to the client on what kind of data is expected to exist.\nTimestamps must be a string in the format 'YYYY-MM-DDTHH:MM:SS[.millis][Z|time zone]' with optional milliseconds having precision of 1-3 decimal digits and optional timezone with format ±HH:MM, ±HHMM, ±HH or Z, where Z represents UTC, Year must be between 0001 and 9999.\nDates must be a date string in the format 'YYYY-MM-DD'. Year must be between 1 and 9999. ",
+                "description": "The data-type to use when storing the property. Supported storage types are;\n\n\n* single value,\n * lists of text (allows user control of collation),\n * boolean,\n * 32-bit, and 64-bit floats,\n * 32-bit, and 64-bit integers,\n * timestamps,\n * dates,\n * JSON fragments,\n * time series external-id reference,\n * file external-id reference,\n * sequence external-id reference\n * direct relation to an existing node.\n\n\nThe JSON fragments have to be valid JSON objects. If JSON arrays are to be stored, these must be wrapped in a JSON object. JSON values (such as string, number, boolean) should use their respective primitive form instead. The maximum allowed size for a JSON object is 40960 bytes. The maximum allowed length of a key is 128, while the maximum allowed size of a value is 10240 bytes and you can have up to 256 key-value pairs.\nDirect relations use a space external-id, the external-id for an existing node, and the external-id for the data container. E.g. ```s-spaceExternalId.uniqueNodeExternalId.containerExternalId```. The ```view``` property on direct relation can optionally be set, and if it is set then this is a hint to the client on what kind of data is expected to exist.\nTimestamps must be a string in the format 'YYYY-MM-DDTHH:MM:SS[.millis][Z|time zone]' with optional milliseconds having precision of 1-3 decimal digits and optional timezone with format ±HH:MM, ±HHMM, ±HH or Z, where Z represents UTC, Year must be between 0001 and 9999.\nDates must be a date string in the format 'YYYY-MM-DD'. Year must be between 1 and 9999. ",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/TextProperty"
@@ -25138,7 +25372,7 @@
             ],
             "properties": {
               "type": {
-                "description": "The data-type to use when storing the property. Supported storage types are;\n\n\n* single value,\n * lists of text (allows user control of collation),\n * boolean,\n * 32-bit, and 64-bit floats,\n * 32-bit, and 64-bit integers,\n * timestamps,\n * dates,\n * JSON fragments,\n * time series external-id reference,\n * file external-id reference,\n * sequence external-id reference\n * direct relation to an existing node.\n\n\nThe JSON fragments have to be valid JSON objects. If JSON arrays are to be stored, these must be wrapped in a JSON object. JSON values (such as string, number, boolean) should use their respective primitive form instead. The maximum allowed size for a JSON object is 40960 bytes. For lists of json values, the size of the entire list must be within this limit. The maximum allowed length of a key is 128, while the maximum allowed size of a value is 10240 bytes and you can have up to 256 key-value pairs. The  byte sizes are computed by representing the data as a UTF-8 encoded JSON string.\nDirect relations use a space external-id, the external-id for an existing node, and the external-id for the data container. E.g. ```s-spaceExternalId.uniqueNodeExternalId.containerExternalId```\nTimestamps must be a string in the format 'YYYY-MM-DDTHH:MM:SS[.millis][Z|time zone]' with optional milliseconds having precision of 1-3 decimal digits and optional timezone with format ±HH:MM, ±HHMM, ±HH or Z, where Z represents UTC, Year must be between 0001 and 9999.\nDates must be a date string in the format 'YYYY-MM-DD'. Year must be between 1 and 9999. ",
+                "description": "The data-type to use when storing the property. Supported storage types are;\n\n\n* single value,\n * lists of text (allows user control of collation),\n * boolean,\n * 32-bit, and 64-bit floats,\n * 32-bit, and 64-bit integers,\n * timestamps,\n * dates,\n * JSON fragments,\n * time series external-id reference,\n * file external-id reference,\n * sequence external-id reference\n * direct relation to an existing node.\n\n\nThe JSON fragments have to be valid JSON objects. If JSON arrays are to be stored, these must be wrapped in a JSON object. JSON values (such as string, number, boolean) should use their respective primitive form instead. The maximum allowed size for a JSON object is 40960 bytes. The maximum allowed length of a key is 128, while the maximum allowed size of a value is 10240 bytes and you can have up to 256 key-value pairs.\nDirect relations use a space external-id, the external-id for an existing node, and the external-id for the data container. E.g. ```s-spaceExternalId.uniqueNodeExternalId.containerExternalId```\nTimestamps must be a string in the format 'YYYY-MM-DDTHH:MM:SS[.millis][Z|time zone]' with optional milliseconds having precision of 1-3 decimal digits and optional timezone with format ±HH:MM, ±HHMM, ±HH or Z, where Z represents UTC, Year must be between 0001 and 9999.\nDates must be a date string in the format 'YYYY-MM-DD'. Year must be between 1 and 9999. ",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/TextProperty"
@@ -28336,7 +28570,7 @@
           },
           "list": {
             "type": "boolean",
-            "description": "Specifies that the data type is a list of values. The ordering of values is preserved.\n",
+            "description": "Specifies that the data type is a list of values.\n",
             "default": false
           },
           "collation": {
@@ -29134,7 +29368,7 @@
       },
       "PrimitiveProperty": {
         "type": "object",
-        "description": "Primitive types for the property.\n\nWe expect dates to be in the ISO-8601 format, while timestamps are expected to be an epoch value with \nmillisecond precision. JSON values have to be valid JSON fragments. The maximum allowed size for a JSON\nobject is 40960 bytes. For list of json values, the size of the entire list must be within this limit. \nThe maximum allowed length of a key is 128, while the maximum allowed size of a value is 10240 bytes \nand you can have up to 256 key-value pairs.\n",
+        "description": "Primitive types for the property.\n\nWe expect dates to be in the ISO-8601 format, while timestamps are expected to be an epoch value with \nmillisecond precision. JSON values have to be valid JSON fragments. The maximum allowed size for a JSON\nobject is 40960 bytes. The maximum allowed length of a key is 128, while the maximum allowed size of a value\nis 10240 bytes and you can have up to 256 key-value pairs.\n",
         "required": [
           "type"
         ],
@@ -29169,7 +29403,7 @@
             }
           },
           "list": {
-            "description": "Specifies that the data type is a list of values. The ordering of values is preserved.\n",
+            "description": "Specifies that the data type is a list of values.\n",
             "type": "boolean",
             "default": false
           }
@@ -29191,7 +29425,7 @@
             ]
           },
           "list": {
-            "description": "Specifies that the data type is a list of values. The ordering of values is preserved.\n",
+            "description": "Specifies that the data type is a list of values.\n",
             "type": "boolean",
             "default": false
           }
@@ -31371,17 +31605,17 @@
         "properties": {
           "min": {
             "type": "number",
-            "example": 1,
+            "example": 0.1,
             "description": "The minimum value you can request when creating a function."
           },
           "max": {
             "type": "number",
-            "example": 1,
+            "example": 0.6,
             "description": "The maximum value you can request when creating a function."
           },
           "default": {
             "type": "number",
-            "example": 1,
+            "example": 0.25,
             "description": "The default value when creating a function."
           }
         }
@@ -31397,17 +31631,17 @@
         "properties": {
           "min": {
             "type": "number",
-            "example": 1.5,
+            "example": 0.1,
             "description": "The minimum value you can request when creating a function."
           },
           "max": {
             "type": "number",
-            "example": 1.5,
+            "example": 2.5,
             "description": "The maximum value you can request when creating a function."
           },
           "default": {
             "type": "number",
-            "example": 1.5,
+            "example": 1,
             "description": "The default value when creating a function."
           }
         }
@@ -31890,8 +32124,7 @@
           "createdTime",
           "cronExpression",
           "when",
-          "sessionId",
-          "nonce"
+          "sessionId"
         ]
       },
       "FunctionCallLogEntry": {
@@ -32009,10 +32242,7 @@
           "nonce": {
             "$ref": "#/components/schemas/nonce"
           }
-        },
-        "required": [
-          "nonce"
-        ]
+        }
       },
       "FunctionFileId": {
         "description": "The file ID to a file uploaded to Cognite's Files API. This file must be a zip file and contain a file called `handler.py` in the root folder (unless otherwise specified in the `functionPath` argument). This file must contain a function named `handle` with any of the following arguments: `data`, `client`, `secrets` and `function_call_info`, which are passed into the function. The zip file can contain other files as well (model binary data, libraries etc).\n\nCustom packages can be pip installed by providing a requirements.txt file in the root of the zip file. The latest version of the Cognite Python SDK is automatically installed. If a specific version is needed, please specify this in the requirements.txt file.",
@@ -32116,14 +32346,14 @@
           "cpu": {
             "type": "number",
             "format": "float",
-            "example": 1,
-            "description": "Number of CPU cores per function. Allowed range and default value are given by the [limits endpoint](https://developer.cognite.com/api#tag/Functions/operation/functionsLimits). On Azure, only the default value is used."
+            "example": 0.25,
+            "description": "Number of CPU cores per function (not available in Azure). Defaults to 0.25. Allowed values are in the range [0.1, 0.6]."
           },
           "memory": {
             "type": "number",
             "format": "float",
-            "example": 1.5,
-            "description": "Memory per function measured in GB. Allowed range and default value are given by the [limits endpoint](https://developer.cognite.com/api#tag/Functions/operation/functionsLimits). On Azure, only the default value is used."
+            "example": 1,
+            "description": "Memory per function measured in GB (not available in Azure). Defaults to 1. Allowed values are in the range [0.1, 2.5]."
           },
           "runtime": {
             "type": "string",
@@ -33387,6 +33617,7 @@
                 "type": "array",
                 "description": "Specify the aggregates to return. Omit to return data points without aggregation.",
                 "minItems": 1,
+                "maxItems": 10,
                 "uniqueItems": true,
                 "items": {
                   "$ref": "#/components/schemas/Aggregate"
@@ -33494,21 +33725,6 @@
             "description": "Defines whether to include the last data point before the requested time period and the first one after. This option can be useful for interpolating data. It's not available for aggregates or cursors.\nNote: If there are more than `limit` data points in the time period, we will omit the excess data points and then append the first data point after the time period, thus causing a gap with omitted data points. When this is the case, we return up to `limit+2` data points.\nWhen doing manual paging (sequentially requesting smaller intervals instead of requesting a larger interval and using cursors to get all the data points) with this field set to true, the `start` of the each subsequent request should be one millisecond more than the `timestamp` of the _second-to-last_ data point from the previous response. This is because the last data point in most cases will be the extra point from outside the interval.\n",
             "default": false
           },
-          "includeStatus": {
-            "type": "boolean",
-            "description": "Show the [status code](<https://developer.cognite.com/dev/concepts/reference/status_codes>) for each data point in the response.\n_Good_ (code = 0) status codes are always omitted.\nOnly relevant for raw data points queries, not aggregates.",
-            "default": false
-          },
-          "ignoreBadDataPoints": {
-            "type": "boolean",
-            "description": "Treat data points with a _Bad_ status code as if they do not exist.\n\nIf set to false, raw queries will include bad data points in the response, and\naggregates will in general omit the time period between a bad data point and the next good data point.\nAlso, the period between a bad data point and the previous good data point will be considered constant.",
-            "default": true
-          },
-          "treatUncertainAsBad": {
-            "type": "boolean",
-            "description": "Treat data points with _Uncertain_ status codes as _Bad_. If false, treat data points with _Uncertain_ status codes as _Good_.\nUsed for both raw queries and aggregates.",
-            "default": true
-          },
           "cursor": {
             "type": "string",
             "description": "To retrieve next page, insert the `nextCursor` from a previous response. Be sure to match with the corresponding time series. Not compatible with `includeOutsidePoints`.\n"
@@ -33598,21 +33814,6 @@
             "type": "string",
             "description": "The [unit system](<https://developer.cognite.com/dev/concepts/resource_types/units/>) of the data points returned. Cannot be used with targetUnit.",
             "example": "imperial"
-          },
-          "includeStatus": {
-            "type": "boolean",
-            "description": "Show the [status code](<https://developer.cognite.com/dev/concepts/reference/status_codes>) for each data point in the response.\n_Good_ (code = 0) status codes are always omitted.",
-            "default": false
-          },
-          "ignoreBadDataPoints": {
-            "type": "boolean",
-            "description": "Treat data points with a _Bad_ status code as if they do not exist.\nSet to false to include all data points.",
-            "default": true
-          },
-          "treatUncertainAsBad": {
-            "type": "boolean",
-            "description": "Treat data points with _Uncertain_ status codes as _Bad_.\nSet to false to to include uncertain data points.",
-            "default": true
           }
         }
       },
@@ -33883,13 +34084,7 @@
           "stepInterpolation",
           "totalVariation",
           "continuousVariance",
-          "discreteVariance",
-          "countGood",
-          "countUncertain",
-          "countBad",
-          "durationGood",
-          "durationUncertain",
-          "durationBad"
+          "discreteVariance"
         ]
       },
       "TimeSeriesCursorResponse": {
@@ -33930,7 +34125,8 @@
         "oneOf": [
           {
             "required": [
-              "timestamp"
+              "timestamp",
+              "value"
             ],
             "title": "NumericalDatapoint",
             "type": "object",
@@ -33942,16 +34138,14 @@
               },
               "value": {
                 "type": "number",
-                "description": "The numerical data value of a numerical metric. Numerical data values can be in the range (-1e100, 1e100) The value is required unless the status is bad.\n"
-              },
-              "status": {
-                "$ref": "#/components/schemas/DatapointStatus"
+                "description": "The numerical data value of a numerical metric. Numerical data values can be in the range (-1e100, 1e100)"
               }
             }
           },
           {
             "required": [
-              "timestamp"
+              "timestamp",
+              "value"
             ],
             "type": "object",
             "title": "StringDatapoint",
@@ -33964,29 +34158,11 @@
               "value": {
                 "maxLength": 255,
                 "type": "string",
-                "description": "The string data value of a string metric. The value is required unless the status is bad.\n"
-              },
-              "status": {
-                "$ref": "#/components/schemas/DatapointStatus"
+                "description": "The string data value of a string metric."
               }
             }
           }
         ]
-      },
-      "DatapointStatus": {
-        "type": "object",
-        "description": "The [status code](<https://developer.cognite.com/dev/concepts/reference/status_codes>) of the datapoint.\n\nThe most common status codes are:\\\n_Good_ (0) (Default)\\\n_Uncertain_ (1073741824)\\\n_Bad_ (2147483648)\n\nOnly one of code and symbol is required. If both are defined, they must match.",
-        "properties": {
-          "code": {
-            "type": "integer",
-            "format": "int64",
-            "description": "The numeric status code of the data point."
-          },
-          "symbol": {
-            "type": "string",
-            "description": "The status name of the data point."
-          }
-        }
       },
       "DataWithCursorGetTimeSeriesMetadataDTO": {
         "type": "object",
@@ -34258,13 +34434,13 @@
           },
           {
             "type": "object",
+            "required": [
+              "value"
+            ],
             "properties": {
               "value": {
                 "type": "string",
-                "description": "The data value. The value is required unless the status is bad.\n"
-              },
-              "status": {
-                "$ref": "#/components/schemas/DatapointStatus"
+                "description": "The data value."
               }
             }
           }
@@ -34277,14 +34453,14 @@
           },
           {
             "type": "object",
+            "required": [
+              "value"
+            ],
             "properties": {
               "value": {
                 "type": "number",
-                "description": "The data value. The value is required unless the status is bad.\n",
+                "description": "The data value.",
                 "format": "double"
-              },
-              "status": {
-                "$ref": "#/components/schemas/DatapointStatus"
               }
             }
           }
@@ -34347,36 +34523,6 @@
                 "type": "number",
                 "description": "The total variation of the interpolated underlying function.",
                 "format": "double"
-              },
-              "countGood": {
-                "type": "integer",
-                "description": "The number of data points in the aggregate period that have a _Good_ [status code](<https://developer.cognite.com/dev/concepts/reference/status_codes>). _Uncertain_ does not count, irrespective of `treatUncertainAsBad` parameter.",
-                "format": "int64"
-              },
-              "countUncertain": {
-                "type": "integer",
-                "description": "The number of data points in the aggregate period that have an _Uncertain_ [status code](<https://developer.cognite.com/dev/concepts/reference/status_codes>).",
-                "format": "int64"
-              },
-              "countBad": {
-                "type": "integer",
-                "description": "The number of data points in the aggregate period that have a _Bad_ [status code](<https://developer.cognite.com/dev/concepts/reference/status_codes>). _Uncertain_ does not count, irrespective of `treatUncertainAsBad` parameter.",
-                "format": "int64"
-              },
-              "durationGood": {
-                "type": "integer",
-                "description": "The duration the aggregate is defined and marked as good (regardless of `ignoreBadDataPoints` parameter). Measured in milliseconds. Equivalent to duration that the previous data point is _good_ and in range.",
-                "format": "int64"
-              },
-              "durationUncertain": {
-                "type": "integer",
-                "description": "The duration the aggregate is defined and marked as uncertain (regardless of `ignoreBadDataPoints` parameter). Measured in milliseconds. Equivalent to duration that the previous data point is _uncertain_ and in range.",
-                "format": "int64"
-              },
-              "durationBad": {
-                "type": "integer",
-                "description": "The duration the aggregate is defined but marked as bad (regardless of `ignoreBadDataPoints` parameter). Measured in milliseconds. Equivalent to duration that the previous data point is _bad_ and in range.",
-                "format": "int64"
               }
             }
           }
@@ -35427,17 +35573,17 @@
           },
           "includeStatus": {
             "type": "boolean",
-            "description": "Show the [status code](<https://developer.cognite.com/dev/concepts/reference/status_codes>) for each data point in the response.\n_Good_ (code = 0) status codes are always omitted.",
+            "description": "Show the [status code](<https://developer.cognite.com/dev/concepts/reference/quality_codes>) for each data point in the response.\n_Good_ (0x00) status codes are always omitted.",
             "default": false
           },
           "ignoreBadDataPoints": {
             "type": "boolean",
-            "description": "Treat data points with a _Bad_ status code as if they do not exist.\nSet to false to include all data points.",
+            "description": "Treat data points with a _Bad_ status code as if they do not exist.",
             "default": true
           },
           "treatUncertainAsBad": {
             "type": "boolean",
-            "description": "Treat data points with _Uncertain_ status codes as _Bad_.\nSet to false to include uncertain data points.",
+            "description": "Treat data points with _Uncertain_ status codes as _Bad_. If false, treat data points with _Uncertain_ status codes as _Good_.",
             "default": true
           }
         }
@@ -35549,8 +35695,7 @@
       "GetTimeSeriesForSubscription": {
         "type": "object",
         "required": [
-          "id",
-          "isString"
+          "id"
         ],
         "properties": {
           "id": {
@@ -35558,10 +35703,6 @@
           },
           "externalId": {
             "$ref": "#/components/schemas/CogniteExternalId"
-          },
-          "isString": {
-            "type": "boolean",
-            "description": "True if the time series contains string values; false if it contains numeric values.\n"
           }
         }
       },
@@ -39157,7 +39298,7 @@
         "properties": {
           "set": {
             "type": "string",
-            "description": "Reserves a prefix that can only be used by projects that are children of the project hierachy starting at\nthis project (reserved prefixes *MUST* only be specified for non-leaf projects).\n\nProjects outside this project hierachy will be rejected to create projects with url names starting with\nthis reserved prefix.\n\nOnly allowed for non-leaf projects. Currently only permitted to be updated by cluster administrators.\n",
+            "description": "Reserves a prefix that can only be used by projects that are children of the project hierachy starting at\nthis project (reserved prefixes *MUST* only be specified for non-leaf projects). \n\nProjects outside this project hierachy will be rejected to create projects with url names starting with\nthis reserved prefix. \n\nOnly allowed for non-leaf projects. Currently only permitted to be updated by cluster administrators.\n",
             "example": "test"
           }
         }
@@ -43202,122 +43343,23 @@
         "type": "object",
         "description": "Configuration for diagram detect that is only available in beta.",
         "properties": {
-          "annotationExtract": {
-            "type": "boolean",
-            "description": "Read SHX text embedded in the diagram file. If present, this text will override overlapping OCR text. Cannot be used at the same time as read_embedded_text."
-          },
-          "caseSensitive": {
-            "type": "boolean",
-            "description": "Case sensitive text matching.",
-            "default": true
-          },
-          "connectionFlags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Connection flags for token graph. Two flags are supported thus far: `no_text_inbetween` and `natural_reading_order`."
-          },
-          "customizeFuzziness": {
-            "$ref": "#/components/schemas/CustomizeFuzziness"
-          },
-          "directionDelta": {
-            "type": "number",
-            "format": "float",
-            "minimum": 0,
-            "maximum": 180,
-            "description": "Maximum angle between the direction of two text boxes for them to be connected. Directions are currently multiples of 90 degrees."
-          },
-          "directionWeights": {
-            "$ref": "#/components/schemas/DirectionWeights"
-          },
-          "minFuzzyScore": {
-            "type": "number",
-            "description": "For each detection, this controls to which degree characters can be replaced from the OCR text with similar characters, e.g. I and 1. A value of 1 will disable character replacements entirely. See also 'substitutions' for the characters that may be replaced.",
-            "default": 0.85,
-            "minimum": 0.7,
-            "maximum": 1
-          },
           "readEmbeddedText": {
             "type": "boolean",
             "description": "Read text embedded in the PDF file. If present, this text will override overlapping OCR text.",
             "default": true
           },
-          "removeLeadingZeros": {
-            "type": "boolean",
-            "description": "Disregard leading zeroes when matching tags (e.g. \"A0001\" will match \"A1\")."
-          },
-          "substitutions": {
-            "type": "object",
-            "description": "Override the default mapping of characters to an array of allowed substitute characters. The default mapping contains characters commonly confused by OCR. Provide your custom mapping in the format like so: `{\"0\": [\"O\", \"Q\"], \"1\": [\"l\", \"I\"]}`. This means: `0` (zero) is allowed to be replaced by uppercase letter `O` or `Q`, and `1` (one) is allowed to be replaced by lowercase letter `l` or uppercase letter `I`. No other replacements are allowed.\n\nThe substitutions are performed on the raw OCR text. For example, if we want to match a tag \"T10\" and OCR recognized the text as \"TI0\", mapping `{\"I\": [\"1\"]}` would allow the match. This substitution would happen given the default mapping. On the contrary, if the OCR accuracy is high, you may want to disable such substitutions to reduce false positive matches by overriding the mapping with `{\"I\": [\"I\"]}`.\n\nCurrently the default substitution mapping is as follows (it may be updated without notice):\n```\n{\n    \"0\": [\"C\", \"D\", \"O\"],\n    \"1\": [\"T\", \"I\"],\n    \"3\": [\"B\"],\n    \"6\": [\"G\"],\n    \"8\": [\"B\"],\n    \"Ä\": [\"A\"],\n    \"Ã\": [\"A\"],\n    \"Å\": [\"A\"],\n    \"B\": [\"8\", \"3\"],\n    \"C\": [\"0\"],\n    \"D\": [\"1)\", \"O\", \"0\"],\n    \"G\": [\"6\"],\n    \"I\": [\"T\", \"1\", \"l\"],\n    \"Í\": [\"I\", \"T\", \"l\", \"1\"],\n    \"K\": [\"|X\"],\n    \"O\": [\"C\", \"D\", \"0\"],\n    \"Q\": [\"0\", \"O\"],\n    \"T\": [\"1\", \"I\"],\n    \"Ø\": [\"0\"],\n    \"l\": [\"I\"],\n    \"p\": [\"P\", \"0\"],\n    \"v\": [\"V\"],\n    \"ø\": [\"0\", \"Ø\"],\n    \"?\": [\"2\"],\n    \"×\": [\"x\", \"X\"]\n}\n```",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "DirectionWeights": {
-        "type": "object",
-        "description": "Direction weights that control how far subsequent ocr text boxes can be from another in a particular direction and still be combined into the same detection. Lower value means larger distance is allowed. The direction is relative to the text orientation.",
-        "properties": {
-          "left": {
+          "minFuzzyScore": {
             "type": "number",
-            "format": "float",
-            "minimum": 0.5,
-            "maximum": 3,
-            "default": 1
-          },
-          "right": {
-            "type": "number",
-            "format": "float",
-            "minimum": 0.1,
-            "maximum": 3,
-            "default": 1
-          },
-          "up": {
-            "type": "number",
-            "format": "float",
-            "minimum": 0.5,
-            "maximum": 3,
-            "default": 1
-          },
-          "down": {
-            "type": "number",
-            "format": "float",
-            "minimum": 0.5,
-            "maximum": 3,
-            "default": 1
-          }
-        }
-      },
-      "CustomizeFuzziness": {
-        "type": "object",
-        "description": "Additional requirements for the fuzzy matching algorithm. The fuzzy match is allowed if any of these are true for each match candidate. The overall minFuzzyScore still applies, but a stricter fuzzyScore can be set here, which would not be enforced if either the minChars or maxBoxes conditions are met, making it possible to exclude detections using replacements if they are either short, or combined from many boxes.",
-        "properties": {
-          "minChars": {
-            "type": "integer",
-            "description": "The minimum number of characters that must be present in the candidate match string."
-          },
-          "maxBoxes": {
-            "type": "integer",
-            "description": "Maximum number of text boxes the potential match is composed of."
-          },
-          "fuzzyScore": {
-            "type": "number",
-            "format": "float",
-            "description": "The minimum fuzzy score of the candidate match.",
+            "description": "For each detection, this controls to which degree characters can be replaced from the OCR text with similar characters, e.g. I and 1. A value of 1 will disable character replacements entirely.",
+            "default": 0.85,
             "minimum": 0.7,
-            "maximum": 1,
-            "default": 1
+            "maximum": 1
           }
         }
       },
       "PatternMode": {
         "type": "boolean",
-        "description": "Only available in beta. If true, entities are not required to contain the search field. Instead they require a field called 'sample'. The sample field can be string, or list of alternative strings. Each string defines a pattern. E.g. 21-PT-1019 enables detecting tags consisting of 2 digits, 2 letters and 4 digits. Special characters are not necessary for detecting, but will be included in the detected string. It is possible to mark parts of the sample as constant strings by enclosing them in square brackets. Within square brackets, a | character can be used to separate alternative constants. Alternative constants must be either all digits or all letters. If false, regular diagram detect is performed, searching for occurrences of the search strings of the entities."
+        "description": "Only available in beta. If true, entities are not required to contain the search field. Instead they require a field called 'sample'. The sample field can be string, or list of alternative strings. Each string defines a pattern. E.g. 21-PT-1019 enables detecting tags consisting of 2 digits, 2 letters and 4 digits. Special characters are  not necessary for detecting, but will be included in the detected string. It is possible to mark parts of the sample as constant strings by enclosing them in square brackets. Within square brackets, a | character can be used to separate alternative constants. Alternative constants  must be either all digits or all letters. If false, regular diagram detect is performed, searching for occurrences of the search strings of the entities."
       },
       "DiagramConvertConfig": {
         "type": "object",
@@ -43662,7 +43704,7 @@
             "minimum": 1
           },
           "limit": {
-            "description": "The maximum number of pages to get results for. With a limit of 10 and start page of 1, results for pages 1-10 are returned if they are available.",
+            "description": "The maximum number of pages to get results for. With a limit of 10 and start page of 1,  results for pages 1-10 are returned if they are available.",
             "type": "integer",
             "example": 10,
             "default": 100,
@@ -53714,79 +53756,79 @@
         "type": "string",
         "description": "The type of the annotation. This uniquely decides what the structure of the `data` block will be.",
         "enum": [
-          "pointcloud.BoundingVolume",
-          "images.Classification",
-          "forms.Detection",
-          "documents.ExtractedText",
-          "diagrams.FileLink",
-          "isoplan.IsoPlanAnnotation",
-          "diagrams.Junction",
-          "images.KeypointCollection",
-          "diagrams.Line",
           "images.ObjectDetection",
-          "images.TextRegion",
-          "diagrams.UnhandledSymbolObject",
-          "diagrams.UnhandledTextObject",
-          "diagrams.AssetLink",
-          "diagrams.InstanceLink",
+          "images.Classification",
+          "images.KeypointCollection",
           "images.AssetLink",
-          "images.InstanceLink"
+          "images.TextRegion",
+          "images.InstanceLink",
+          "isoplan.IsoPlanAnnotation",
+          "diagrams.AssetLink",
+          "diagrams.FileLink",
+          "diagrams.InstanceLink",
+          "diagrams.UnhandledTextObject",
+          "diagrams.UnhandledSymbolObject",
+          "documents.ExtractedText",
+          "diagrams.Line",
+          "diagrams.Junction",
+          "pointcloud.BoundingVolume",
+          "forms.Detection"
         ],
-        "example": "pointcloud.BoundingVolume"
+        "example": "images.ObjectDetection"
       },
       "AnnotationData": {
         "description": "The annotation information. The format of this object is decided by and validated against the `annotationType`\nattribute.",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/Annotations.BoundingVolume"
+            "$ref": "#/components/schemas/Annotations.ObjectDetection"
           },
           {
             "$ref": "#/components/schemas/Annotations.Classification"
           },
           {
-            "$ref": "#/components/schemas/Annotations.Detection"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.ExtractedText"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.FileLink"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.IsoPlanAnnotation"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.Junction"
-          },
-          {
             "$ref": "#/components/schemas/Annotations.KeypointCollection"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.Line"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.ObjectDetection"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.TextRegion"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.UnhandledSymbolObject"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.UnhandledTextObject"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__diagrams__AssetLink"
-          },
-          {
-            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__diagrams__InstanceLink"
           },
           {
             "$ref": "#/components/schemas/Annotations.cognite__annotation_types__images__AssetLink"
           },
           {
+            "$ref": "#/components/schemas/Annotations.TextRegion"
+          },
+          {
             "$ref": "#/components/schemas/Annotations.cognite__annotation_types__images__InstanceLink"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.IsoPlanAnnotation"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__diagrams__AssetLink"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.FileLink"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__diagrams__InstanceLink"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.UnhandledTextObject"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.UnhandledSymbolObject"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.ExtractedText"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.Line"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.Junction"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.BoundingVolume"
+          },
+          {
+            "$ref": "#/components/schemas/Annotations.Detection"
           }
         ],
         "example": {
@@ -53869,79 +53911,47 @@
         "maxLength": 255,
         "example": "MzE1NjAwMDcxNzQ0ODI5"
       },
-      "Annotations.AssetRef": {
-        "additionalProperties": false,
-        "description": "A reference to an asset. Either the internal ID or the external ID must be provided (exactly one).",
-        "oneOf": [
-          {
-            "required": [
-              "id"
-            ]
+      "Annotations.Point": {
+        "title": "primitives.geometry2d.Point",
+        "description": "Point in a 2D-Cartesian coordinate system with origin at the top-left corner of the page",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
           },
-          {
-            "required": [
-              "externalId"
-            ]
+          "x": {
+            "description": "The abscissa of the point in a coordinate system with origin at the top-left corner of the page. Normalized in (0,1).",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "y": {
+            "description": "The ordinate of the point in a coordinate system with origin at the top-left corner of the page. Normalized in (0,1).",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
           }
+        },
+        "required": [
+          "x",
+          "y"
         ],
-        "properties": {
-          "id": {
-            "default": null,
-            "description": "The internal ID of the referenced resource",
-            "type": "integer"
-          },
-          "externalId": {
-            "default": null,
-            "description": "The external ID of the referenced resource",
-            "maxLength": 256,
-            "type": "string"
-          }
-        },
-        "title": "primitives.references.AssetRef",
-        "type": "object"
-      },
-      "Annotations.AttributesMixin": {
-        "additionalProperties": false,
-        "description": "Mixin that can be used to add attributes to a thing",
-        "properties": {
-          "attributes": {
-            "additionalProperties": {
-              "discriminator": {
-                "mapping": {
-                  "boolean": "#/components/schemas/Annotations.Boolean",
-                  "numerical": "#/components/schemas/Annotations.Numerical"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Annotations.Boolean"
-                },
-                {
-                  "$ref": "#/components/schemas/Annotations.Numerical"
-                }
-              ]
-            },
-            "default": null,
-            "description": "Additional attributes data for a compound.",
-            "type": "object"
-          }
-        },
-        "title": "primitives.attributes.AttributesMixin",
-        "type": "object"
+        "additionalProperties": false
       },
       "Annotations.Boolean": {
-        "additionalProperties": false,
+        "title": "primitives.attributes.Boolean",
         "description": "The boolean value of something",
+        "type": "object",
         "properties": {
           "description": {
-            "default": null,
             "description": "The description of a primitive",
             "maxLength": 500,
             "type": "string"
           },
           "type": {
-            "const": "boolean",
             "enum": [
               "boolean"
             ],
@@ -53956,42 +53966,121 @@
           "type",
           "value"
         ],
-        "title": "primitives.attributes.Boolean",
-        "type": "object"
+        "additionalProperties": false
+      },
+      "Annotations.Numerical": {
+        "title": "primitives.attributes.Numerical",
+        "description": "The numerical value of something",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of a primitive",
+            "maxLength": 500,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "numerical"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "description": "The numerical value",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.Keypoint": {
+        "title": "primitives.geometry2d.Keypoint",
+        "description": "A point attached with additional information such as a confidence value and\nvarious attribute(s).",
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "description": "Additional attributes data for a compound.",
+            "type": "object",
+            "additionalProperties": {
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "boolean": "#/components/schemas/Annotations.Boolean",
+                  "numerical": "#/components/schemas/Annotations.Numerical"
+                }
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Annotations.Boolean"
+                },
+                {
+                  "$ref": "#/components/schemas/Annotations.Numerical"
+                }
+              ]
+            }
+          },
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "point": {
+            "description": "The position of the keypoint",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.Point"
+              }
+            ]
+          }
+        },
+        "required": [
+          "point"
+        ],
+        "additionalProperties": false
       },
       "Annotations.BoundingBox": {
-        "additionalProperties": false,
+        "title": "primitives.geometry2d.BoundingBox",
         "description": "A plain rectangle",
+        "type": "object",
         "properties": {
           "confidence": {
-            "default": null,
             "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           },
           "xMin": {
             "description": "Minimum abscissa of the bounding box (left edge). Must be strictly less than x_max.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           },
           "xMax": {
             "description": "Maximum abscissa of the bounding box (right edge). Must be strictly more than x_min.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           },
           "yMin": {
             "description": "Minimum ordinate of the bounding box (bottom edge). Must be strictly less than y_max.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           },
           "yMax": {
             "description": "Maximum ordinate of the bounding box (top edge). Must be strictly more than y_min.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           }
         },
@@ -54001,93 +54090,158 @@
           "yMin",
           "yMax"
         ],
-        "title": "primitives.geometry2d.BoundingBox",
-        "type": "object"
+        "additionalProperties": false
+      },
+      "Annotations.Polygon": {
+        "title": "primitives.geometry2d.Polygon",
+        "description": "A _closed_ polygon represented by _n_ vertices. In other words, we assume\nthat the first and last vertex are connected.",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "vertices": {
+            "minItems": 3,
+            "maxItems": 1000,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotations.Point"
+            }
+          }
+        },
+        "required": [
+          "vertices"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.PolyLine": {
+        "title": "primitives.geometry2d.PolyLine",
+        "description": "A polygonal chain consisting of _n_ vertices",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "vertices": {
+            "minItems": 2,
+            "maxItems": 1000,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotations.Point"
+            }
+          }
+        },
+        "required": [
+          "vertices"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.cognite__annotation_types__primitives__geometry2d__Geometry": {
+        "title": "primitives.geometry2d.Geometry",
+        "description": "A geometry represented by exactly *one of* ` bounding_box`, `polygon` and\n`polyline` which, respectively, represents a BoundingBox, Polygon and\nPolyLine.",
+        "type": "object",
+        "properties": {
+          "boundingBox": {
+            "$ref": "#/components/schemas/Annotations.BoundingBox"
+          },
+          "polygon": {
+            "$ref": "#/components/schemas/Annotations.Polygon"
+          },
+          "polyline": {
+            "$ref": "#/components/schemas/Annotations.PolyLine"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.GeometryMixin": {
+        "title": "primitives.geometry2d.GeometryMixin",
+        "description": "A mixin that can be used to add a geometry to a thing.\nA is geometry represented by exactly *one of* ` bounding_box`, `polygon` and\n`polyline` which, respectively, represents a BoundingBox, Polygon and\nPolyLine.",
+        "type": "object",
+        "properties": {
+          "boundingBox": {
+            "$ref": "#/components/schemas/Annotations.BoundingBox"
+          },
+          "polygon": {
+            "$ref": "#/components/schemas/Annotations.Polygon"
+          },
+          "polyline": {
+            "$ref": "#/components/schemas/Annotations.PolyLine"
+          }
+        },
+        "additionalProperties": false
       },
       "Annotations.Box": {
-        "additionalProperties": false,
+        "title": "primitives.geometry3d.Box",
         "description": "A box in 3D space, defined by a 4x4 row-major homogeneous transformation matrix that rotates,\ntranslates and scales a box centered at the origin to its location and orientation in 3D space.\nThe box that is transformed is the axis-aligned cube spanning the volume between\nthe points (-1, -1, -1) and (1, 1, 1).",
+        "type": "object",
         "properties": {
           "label": {
-            "default": null,
             "description": "The label describing what type of object it is",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
           },
           "confidence": {
-            "default": null,
             "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           },
           "matrix": {
             "description": "The homogeneous transformation matrix",
+            "minItems": 16,
+            "maxItems": 16,
+            "type": "array",
             "items": {
               "type": "number"
-            },
-            "maxItems": 16,
-            "minItems": 16,
-            "type": "array"
+            }
           }
         },
         "required": [
           "matrix"
         ],
-        "title": "primitives.geometry3d.Box",
-        "type": "object"
-      },
-      "Annotations.ConfidenceMixin": {
-        "additionalProperties": false,
-        "description": "Mixin that can be used to add confidence score to a thing",
-        "properties": {
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          }
-        },
-        "title": "primitives.confidence.ConfidenceMixin",
-        "type": "object"
+        "additionalProperties": false
       },
       "Annotations.Cylinder": {
-        "additionalProperties": false,
+        "title": "primitives.geometry3d.Cylinder",
         "description": "A cylinder in 3D space, defined by the centers of the two end surfaces and the radius.",
+        "type": "object",
         "properties": {
           "label": {
-            "default": null,
             "description": "The label describing what type of object it is",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
           },
           "confidence": {
-            "default": null,
             "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           },
           "centerA": {
             "description": "The center of the first cap.",
+            "minItems": 3,
+            "maxItems": 3,
+            "type": "array",
             "items": {
               "type": "number"
-            },
-            "maxItems": 3,
-            "minItems": 3,
-            "type": "array"
+            }
           },
           "centerB": {
             "description": "The center of the second cap.",
+            "minItems": 3,
+            "maxItems": 3,
+            "type": "array",
             "items": {
               "type": "number"
-            },
-            "maxItems": 3,
-            "minItems": 3,
-            "type": "array"
+            }
           },
           "radius": {
             "description": "The radius of the cylinder.",
@@ -54100,26 +54254,38 @@
           "centerB",
           "radius"
         ],
-        "title": "primitives.geometry3d.Cylinder",
-        "type": "object"
+        "additionalProperties": false
       },
-      "Annotations.DescriptionMixin": {
-        "additionalProperties": false,
-        "description": "Mixin that can be used to add a description to a thing",
+      "Annotations.cognite__annotation_types__primitives__geometry3d__Geometry": {
+        "title": "primitives.geometry3d.Geometry",
+        "description": "A 3D geometry model represented by exactly *one of* `cylinder` and `box`.",
+        "type": "object",
         "properties": {
-          "description": {
-            "default": null,
-            "description": "The description of a primitive",
-            "maxLength": 500,
+          "cylinder": {
+            "$ref": "#/components/schemas/Annotations.Cylinder"
+          },
+          "box": {
+            "$ref": "#/components/schemas/Annotations.Box"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.AssetRef": {
+        "title": "primitives.references.AssetRef",
+        "description": "A reference to an asset. Either the internal ID or the external ID must be provided (exactly one).",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The internal ID of the referenced resource",
+            "type": "integer"
+          },
+          "externalId": {
+            "description": "The external ID of the referenced resource",
+            "maxLength": 256,
             "type": "string"
           }
         },
-        "title": "primitives.description.DescriptionMixin",
-        "type": "object"
-      },
-      "Annotations.FileRef": {
         "additionalProperties": false,
-        "description": "A reference to a file. Either the internal ID or the external ID must be provided (exactly one).",
         "oneOf": [
           {
             "required": [
@@ -54131,356 +54297,43 @@
               "externalId"
             ]
           }
-        ],
+        ]
+      },
+      "Annotations.FileRef": {
+        "title": "primitives.references.FileRef",
+        "description": "A reference to a file. Either the internal ID or the external ID must be provided (exactly one).",
+        "type": "object",
         "properties": {
           "id": {
-            "default": null,
             "description": "The internal ID of the referenced resource",
             "type": "integer"
           },
           "externalId": {
-            "default": null,
             "description": "The external ID of the referenced resource",
             "maxLength": 256,
             "type": "string"
           }
         },
-        "title": "primitives.references.FileRef",
-        "type": "object"
-      },
-      "Annotations.GeometryMixin": {
         "additionalProperties": false,
-        "description": "A mixin that can be used to add a geometry to a thing.\nA is geometry represented by exactly *one of* ` bounding_box`, `polygon` and\n`polyline` which, respectively, represents a BoundingBox, Polygon and\nPolyLine.",
-        "properties": {
-          "boundingBox": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "default": null
+        "oneOf": [
+          {
+            "required": [
+              "id"
+            ]
           },
-          "polygon": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.Polygon"
-              }
-            ],
-            "default": null
-          },
-          "polyline": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.PolyLine"
-              }
-            ],
-            "default": null
+          {
+            "required": [
+              "externalId"
+            ]
           }
-        },
-        "title": "primitives.geometry2d.GeometryMixin",
-        "type": "object"
-      },
-      "Annotations.InstanceRef": {
-        "additionalProperties": false,
-        "description": "A reference to an DMS instance,\ndefined by the instance itself and the sources (views)\nthat define how the data should be interpreted",
-        "properties": {
-          "sources": {
-            "description": "References to views",
-            "items": {
-              "discriminator": {
-                "mapping": {
-                  "view": "#/components/schemas/Annotations.View"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Annotations.View"
-                }
-              ]
-            },
-            "maxItems": 10,
-            "type": "array"
-          },
-          "instanceType": {
-            "description": "The type of instance, an edge or a node.",
-            "enum": [
-              "node",
-              "edge"
-            ],
-            "type": "string"
-          },
-          "externalId": {
-            "description": "External id of the instance",
-            "maxLength": 255,
-            "minLength": 1,
-            "pattern": "^[^\\x00]{1,255}$",
-            "type": "string"
-          },
-          "space": {
-            "description": "Id of the space that the instance belongs to",
-            "maxLength": 43,
-            "minLength": 1,
-            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]{0,41}[a-zA-Z0-9]?$",
-            "type": "string"
-          }
-        },
-        "required": [
-          "sources",
-          "instanceType",
-          "externalId",
-          "space"
-        ],
-        "title": "primitives.references.InstanceRef",
-        "type": "object"
-      },
-      "Annotations.Keypoint": {
-        "additionalProperties": false,
-        "description": "A point attached with additional information such as a confidence value and\nvarious attribute(s).",
-        "properties": {
-          "attributes": {
-            "additionalProperties": {
-              "discriminator": {
-                "mapping": {
-                  "boolean": "#/components/schemas/Annotations.Boolean",
-                  "numerical": "#/components/schemas/Annotations.Numerical"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Annotations.Boolean"
-                },
-                {
-                  "$ref": "#/components/schemas/Annotations.Numerical"
-                }
-              ]
-            },
-            "default": null,
-            "description": "Additional attributes data for a compound.",
-            "type": "object"
-          },
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "point": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.Point"
-              }
-            ],
-            "description": "The position of the keypoint"
-          }
-        },
-        "required": [
-          "point"
-        ],
-        "title": "primitives.geometry2d.Keypoint",
-        "type": "object"
-      },
-      "Annotations.Numerical": {
-        "additionalProperties": false,
-        "description": "The numerical value of something",
-        "properties": {
-          "description": {
-            "default": null,
-            "description": "The description of a primitive",
-            "maxLength": 500,
-            "type": "string"
-          },
-          "type": {
-            "const": "numerical",
-            "enum": [
-              "numerical"
-            ],
-            "type": "string"
-          },
-          "value": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              }
-            ],
-            "description": "The numerical value"
-          }
-        },
-        "required": [
-          "type",
-          "value"
-        ],
-        "title": "primitives.attributes.Numerical",
-        "type": "object"
-      },
-      "Annotations.OptionalLabelMixin": {
-        "additionalProperties": false,
-        "description": "Mixin that can be used to add an *optional* label string to a thing",
-        "properties": {
-          "label": {
-            "default": null,
-            "description": "The label describing what type of object it is",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "title": "primitives.label.OptionalLabelMixin",
-        "type": "object"
-      },
-      "Annotations.PageInformationMixin": {
-        "additionalProperties": false,
-        "description": "Mixin that can be used to add page number information",
-        "properties": {
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          }
-        },
-        "title": "primitives.page.PageInformationMixin",
-        "type": "object"
-      },
-      "Annotations.Point": {
-        "additionalProperties": false,
-        "description": "Point in a 2D-Cartesian coordinate system with origin at the top-left corner of the page",
-        "properties": {
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "x": {
-            "description": "The abscissa of the point in a coordinate system with origin at the top-left corner of the page. Normalized in (0,1).",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "y": {
-            "description": "The ordinate of the point in a coordinate system with origin at the top-left corner of the page. Normalized in (0,1).",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          }
-        },
-        "required": [
-          "x",
-          "y"
-        ],
-        "title": "primitives.geometry2d.Point",
-        "type": "object"
-      },
-      "Annotations.PolyLine": {
-        "additionalProperties": false,
-        "description": "A polygonal chain consisting of _n_ vertices",
-        "properties": {
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "vertices": {
-            "items": {
-              "$ref": "#/components/schemas/Annotations.Point"
-            },
-            "maxItems": 1000,
-            "minItems": 2,
-            "type": "array"
-          }
-        },
-        "required": [
-          "vertices"
-        ],
-        "title": "primitives.geometry2d.PolyLine",
-        "type": "object"
-      },
-      "Annotations.Polygon": {
-        "additionalProperties": false,
-        "description": "A _closed_ polygon represented by _n_ vertices. In other words, we assume\nthat the first and last vertex are connected.",
-        "properties": {
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "vertices": {
-            "items": {
-              "$ref": "#/components/schemas/Annotations.Point"
-            },
-            "maxItems": 1000,
-            "minItems": 3,
-            "type": "array"
-          }
-        },
-        "required": [
-          "vertices"
-        ],
-        "title": "primitives.geometry2d.Polygon",
-        "type": "object"
-      },
-      "Annotations.RequiredLabelMixin": {
-        "additionalProperties": false,
-        "description": "Mixin that can be used to add a *required* label string to a thing",
-        "properties": {
-          "label": {
-            "description": "The label describing what type of object it is",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "title": "primitives.label.RequiredLabelMixin",
-        "type": "object"
-      },
-      "Annotations.SizeAndClassType": {
-        "additionalProperties": false,
-        "description": "Store the dimension, units and class of a given annotation",
-        "properties": {
-          "size": {
-            "default": null,
-            "description": "The size of the valve or spade",
-            "type": "number"
-          },
-          "unit": {
-            "default": null,
-            "description": "The units of the size (mm/inches)",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "classType": {
-            "default": null,
-            "description": "The class type of the valve or spade",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "title": "primitives.dimensions.SizeAndClassType",
-        "type": "object"
+        ]
       },
       "Annotations.View": {
-        "additionalProperties": false,
+        "title": "primitives.references.View",
         "description": "Defines a DMS source (e.g. view)",
+        "type": "object",
         "properties": {
           "type": {
-            "const": "view",
             "enum": [
               "view"
             ],
@@ -54514,112 +54367,213 @@
           "externalId",
           "version"
         ],
-        "title": "primitives.references.View",
-        "type": "object"
+        "additionalProperties": false
       },
-      "Annotations.cognite__annotation_types__primitives__geometry2d__Geometry": {
-        "additionalProperties": false,
-        "description": "A geometry represented by exactly *one of* ` bounding_box`, `polygon` and\n`polyline` which, respectively, represents a BoundingBox, Polygon and\nPolyLine.",
+      "Annotations.InstanceRef": {
+        "title": "primitives.references.InstanceRef",
+        "description": "A reference to an DMS instance,\ndefined by the instance itself and the sources (views)\nthat define how the data should be interpreted",
+        "type": "object",
         "properties": {
-          "boundingBox": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "default": null
+          "sources": {
+            "description": "References to views",
+            "maxItems": 10,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotations.View"
+            }
           },
-          "polygon": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.Polygon"
-              }
+          "instanceType": {
+            "description": "The type of instance, an edge or a node.",
+            "enum": [
+              "node",
+              "edge"
             ],
-            "default": null
-          },
-          "polyline": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.PolyLine"
-              }
-            ],
-            "default": null
-          }
-        },
-        "title": "primitives.geometry2d.Geometry",
-        "type": "object"
-      },
-      "Annotations.cognite__annotation_types__primitives__geometry3d__Geometry": {
-        "additionalProperties": false,
-        "description": "A 3D geometry model represented by exactly *one of* `cylinder` and `box`.",
-        "properties": {
-          "cylinder": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.Cylinder"
-              }
-            ],
-            "default": null
-          },
-          "box": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.Box"
-              }
-            ],
-            "default": null
-          }
-        },
-        "title": "primitives.geometry3d.Geometry",
-        "type": "object"
-      },
-      "Annotations.BoundingVolume": {
-        "additionalProperties": false,
-        "description": "A bounding volume represents a region in a point cloud",
-        "properties": {
-          "label": {
-            "default": null,
-            "description": "The label describing what type of object it is",
-            "maxLength": 128,
-            "minLength": 1,
             "type": "string"
           },
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
+          "externalId": {
+            "description": "External id of the instance",
+            "maxLength": 255,
+            "minLength": 1,
+            "pattern": "^[^\\x00]{1,255}$",
+            "type": "string"
           },
-          "assetRef": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.AssetRef"
-              }
-            ],
-            "default": null,
-            "description": "The asset this annotation is pointing to"
-          },
-          "region": {
-            "description": "The region of the annotation defined by a list of geometry primitives (cylinder and box).",
-            "items": {
-              "$ref": "#/components/schemas/Annotations.cognite__annotation_types__primitives__geometry3d__Geometry"
-            },
-            "maxItems": 1000,
-            "minItems": 1,
-            "type": "array"
+          "space": {
+            "description": "Id of the space that the instance belongs to",
+            "maxLength": 43,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]{0,41}[a-zA-Z0-9]?$",
+            "type": "string"
           }
         },
         "required": [
-          "region"
+          "sources",
+          "instanceType",
+          "externalId",
+          "space"
         ],
-        "title": "pointcloud.BoundingVolume",
-        "type": "object"
+        "additionalProperties": false
       },
-      "Annotations.Classification": {
-        "additionalProperties": false,
-        "description": "Models an image classification represented by a label, and optionally a\nconfidence value.",
+      "Annotations.AttributesMixin": {
+        "title": "primitives.attributes.AttributesMixin",
+        "description": "Mixin that can be used to add attributes to a thing",
+        "type": "object",
         "properties": {
+          "attributes": {
+            "description": "Additional attributes data for a compound.",
+            "type": "object",
+            "additionalProperties": {
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "boolean": "#/components/schemas/Annotations.Boolean",
+                  "numerical": "#/components/schemas/Annotations.Numerical"
+                }
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Annotations.Boolean"
+                },
+                {
+                  "$ref": "#/components/schemas/Annotations.Numerical"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.ConfidenceMixin": {
+        "title": "primitives.confidence.ConfidenceMixin",
+        "description": "Mixin that can be used to add confidence score to a thing",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.OptionalLabelMixin": {
+        "title": "primitives.label.OptionalLabelMixin",
+        "description": "Mixin that can be used to add an *optional* label string to a thing",
+        "type": "object",
+        "properties": {
+          "label": {
+            "description": "The label describing what type of object it is",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.RequiredLabelMixin": {
+        "title": "primitives.label.RequiredLabelMixin",
+        "description": "Mixin that can be used to add a *required* label string to a thing",
+        "type": "object",
+        "properties": {
+          "label": {
+            "description": "The label describing what type of object it is",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.DescriptionMixin": {
+        "title": "primitives.description.DescriptionMixin",
+        "description": "Mixin that can be used to add a description to a thing",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of a primitive",
+            "maxLength": 500,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.PageInformationMixin": {
+        "title": "primitives.page.PageInformationMixin",
+        "description": "Mixin that can be used to add page number information",
+        "type": "object",
+        "properties": {
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.SizeAndClassType": {
+        "title": "primitives.dimensions.SizeAndClassType",
+        "description": "Store the dimension, units and class of a given annotation",
+        "type": "object",
+        "properties": {
+          "size": {
+            "description": "The size of the valve or spade",
+            "type": "number"
+          },
+          "unit": {
+            "description": "The units of the size (mm/inches)",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "classType": {
+            "description": "The class type of the valve or spade",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.ObjectDetection": {
+        "title": "images.ObjectDetection",
+        "description": "Models an image object detection represented by a label, a geometry, and\noptionally a confidence value.",
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "description": "Additional attributes data for a compound.",
+            "type": "object",
+            "additionalProperties": {
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "boolean": "#/components/schemas/Annotations.Boolean",
+                  "numerical": "#/components/schemas/Annotations.Numerical"
+                }
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Annotations.Boolean"
+                },
+                {
+                  "$ref": "#/components/schemas/Annotations.Numerical"
+                }
+              ]
+            }
+          },
+          "boundingBox": {
+            "$ref": "#/components/schemas/Annotations.BoundingBox"
+          },
+          "polygon": {
+            "$ref": "#/components/schemas/Annotations.Polygon"
+          },
+          "polyline": {
+            "$ref": "#/components/schemas/Annotations.PolyLine"
+          },
           "label": {
             "description": "The label describing what type of object it is",
             "maxLength": 128,
@@ -54627,54 +54581,721 @@
             "type": "string"
           },
           "confidence": {
-            "default": null,
             "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
             "type": "number"
           }
         },
         "required": [
           "label"
         ],
-        "title": "images.Classification",
-        "type": "object"
+        "additionalProperties": false
       },
-      "Annotations.Detection": {
-        "additionalProperties": false,
-        "description": "Represents a detection of a field value in a form.\nA field is identified by a field_name, optionally component_name and component_type if the field belongs to a subcomponent.\nThe bounding_box indicates the position of the detection. The content of the field is given by the value, and optionally\nan unnormalized_value and the unit.",
+      "Annotations.Classification": {
+        "title": "images.Classification",
+        "description": "Models an image classification represented by a label, and optionally a\nconfidence value.",
+        "type": "object",
         "properties": {
+          "label": {
+            "description": "The label describing what type of object it is",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
           "confidence": {
-            "default": null,
             "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
             "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.KeypointCollection": {
+        "title": "images.KeypointCollection",
+        "description": "Models a collection of keypoints represented by a label, a dictionary of\nkeypoints (mapping from a (unique) label name to a keypoint), and\noptionally a confidence value and an attributes dictionary.",
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "description": "Additional attributes data for a compound.",
+            "type": "object",
+            "additionalProperties": {
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "boolean": "#/components/schemas/Annotations.Boolean",
+                  "numerical": "#/components/schemas/Annotations.Numerical"
+                }
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Annotations.Boolean"
+                },
+                {
+                  "$ref": "#/components/schemas/Annotations.Numerical"
+                }
+              ]
+            }
+          },
+          "label": {
+            "description": "The label describing what type of object it is",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
             "type": "number"
           },
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
+          "keypoints": {
+            "description": "The detected keypoints",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Annotations.Keypoint"
+            }
+          }
+        },
+        "required": [
+          "label",
+          "keypoints"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.cognite__annotation_types__images__AssetLink": {
+        "title": "images.AssetLink",
+        "description": "Models a link to a CDF Asset referenced in an image",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
           },
-          "boundingBox": {
+          "assetRef": {
+            "description": "The asset this annotation is pointing to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.AssetRef"
+              }
+            ]
+          },
+          "text": {
+            "description": "The extracted text",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "textRegion": {
+            "description": "The location of the text mentioning the asset",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Annotations.BoundingBox"
               }
-            ],
-            "description": "Bounding box of the detection area"
+            ]
+          },
+          "objectRegion": {
+            "description": "The region of the object representing the asset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.cognite__annotation_types__primitives__geometry2d__Geometry"
+              }
+            ]
+          }
+        },
+        "required": [
+          "assetRef",
+          "text",
+          "textRegion"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.TextRegion": {
+        "title": "images.TextRegion",
+        "description": "Models an extracted text region in an image",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "text": {
+            "description": "The extracted text",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "textRegion": {
+            "description": "The location of the extracted text",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          }
+        },
+        "required": [
+          "text",
+          "textRegion"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.cognite__annotation_types__images__InstanceLink": {
+        "title": "images.InstanceLink",
+        "description": "Models a link to an FDM instance referenced in an image",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "instanceRef": {
+            "description": "The FDM instance this annotation is pointing to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.InstanceRef"
+              }
+            ]
+          },
+          "text": {
+            "description": "The extracted text",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "textRegion": {
+            "description": "The location of the text mentioning the FDM instance",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          }
+        },
+        "required": [
+          "instanceRef",
+          "text",
+          "textRegion"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.IsoPlanAnnotation": {
+        "title": "isoplan.IsoPlanAnnotation",
+        "description": "Model a custom link in a engineering diagram where it capture details from the texts and linked to assets when necessary",
+        "type": "object",
+        "properties": {
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "text": {
+            "description": "The text input",
+            "type": "string"
+          },
+          "assetRef": {
+            "description": "The asset this annotation is pointing to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.AssetRef"
+              }
+            ]
+          },
+          "textRegion": {
+            "description": "The location of the hotspot represented with a bounding box",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "indirectRelation": {
+            "description": "Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'second valve upstreams of'. This references the 'indirectExternalId'",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "indirectExternalId": {
+            "description": "indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. E.g. this is the <indirectRelation> of <indirectExternalId>",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.AssetRef"
+              }
+            ]
+          },
+          "lineExternalId": {
+            "description": "The id of the Pipe that the hotspot belongs to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.AssetRef"
+              }
+            ]
+          },
+          "detail": {
+            "description": "Detail describing the equipment, not identifying it. E..g 12V12 for a valve.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type of equipment, valve, pump etc.",
+            "type": "string"
+          },
+          "relativePosition": {
+            "description": "Indicate the relative position of an annotation",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "revision": {
+            "description": "Keeps track of the modification to an annotation",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "sizeAndClass": {
+            "description": "Store the dimensions of a valve or spade",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.SizeAndClassType"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Annotations.cognite__annotation_types__diagrams__AssetLink": {
+        "title": "diagrams.AssetLink",
+        "description": "Models a link to a CDF Asset referenced in an engineering diagram",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of a primitive",
+            "maxLength": 500,
+            "type": "string"
+          },
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "assetRef": {
+            "description": "The asset this annotation is pointing to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.AssetRef"
+              }
+            ]
+          },
+          "symbolRegion": {
+            "description": "The location of the symbol representing the asset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "textRegion": {
+            "description": "The location of the text mentioning the asset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "text": {
+            "description": "The extracted text",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "symbol": {
+            "description": "The symbol representing the asset",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "assetRef",
+          "textRegion"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.FileLink": {
+        "title": "diagrams.FileLink",
+        "description": "Models a link to a CDF File referenced in an engineering diagram",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of a primitive",
+            "maxLength": 500,
+            "type": "string"
+          },
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "fileRef": {
+            "description": "The file this annotation is pointing to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.FileRef"
+              }
+            ]
+          },
+          "symbolRegion": {
+            "description": "The location of the symbol representing the file",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "textRegion": {
+            "description": "The location of the text mentioning the file",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "text": {
+            "description": "The extracted text",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "symbol": {
+            "description": "The symbol found in the file",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "fileRef",
+          "textRegion"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.cognite__annotation_types__diagrams__InstanceLink": {
+        "title": "diagrams.InstanceLink",
+        "description": "Models a link to an FDM instance referenced in an engineering diagram",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of a primitive",
+            "maxLength": 500,
+            "type": "string"
+          },
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "instanceRef": {
+            "description": "The FDM instance this annotation is pointing to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.InstanceRef"
+              }
+            ]
+          },
+          "symbolRegion": {
+            "description": "Optional location of a symbol",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "symbol": {
+            "description": "The symbol found in the file",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "text": {
+            "description": "The extracted text",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "textRegion": {
+            "description": "The location of the text mentioning the file",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          }
+        },
+        "required": [
+          "instanceRef",
+          "text",
+          "textRegion"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.UnhandledTextObject": {
+        "title": "diagrams.UnhandledTextObject",
+        "description": "Models an extracted text region in an engineering diagram",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of a primitive",
+            "maxLength": 500,
+            "type": "string"
+          },
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "textRegion": {
+            "description": "The location of the text",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "text": {
+            "description": "The extracted text",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "textRegion",
+          "text"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.UnhandledSymbolObject": {
+        "title": "diagrams.UnhandledSymbolObject",
+        "description": "Models an extracted symbol region in an engineering diagram",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of a primitive",
+            "maxLength": 500,
+            "type": "string"
+          },
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "symbolRegion": {
+            "description": "The location of the symbol",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "symbol": {
+            "description": "The symbol found in the file",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbolRegion",
+          "symbol"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.ExtractedText": {
+        "title": "documents.ExtractedText",
+        "description": "Represents text extracted from a document. Annotations of this type are low-level and not specific to any domain.",
+        "type": "object",
+        "properties": {
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "textRegion": {
+            "description": "The location of the extracted text",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
+          },
+          "extractedText": {
+            "description": "The extracted text",
+            "maxLength": 1024,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "textRegion",
+          "extractedText"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.Line": {
+        "title": "diagrams.Line",
+        "description": "Models a line in an engineering diagram",
+        "type": "object",
+        "properties": {
+          "label": {
+            "description": "The label describing what type of object it is",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "polyline": {
+            "description": "The polyline representing the line",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.PolyLine"
+              }
+            ]
+          }
+        },
+        "required": [
+          "label",
+          "polyline"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.Junction": {
+        "title": "diagrams.Junction",
+        "description": "Models a junction between lines in an engineering diagram",
+        "type": "object",
+        "properties": {
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "position": {
+            "description": "The point representing the junction",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.Point"
+              }
+            ]
+          }
+        },
+        "required": [
+          "position"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.BoundingVolume": {
+        "title": "pointcloud.BoundingVolume",
+        "description": "A bounding volume represents a region in a point cloud",
+        "type": "object",
+        "properties": {
+          "label": {
+            "description": "The label describing what type of object it is",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "assetRef": {
+            "description": "The asset this annotation is pointing to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.AssetRef"
+              }
+            ]
+          },
+          "region": {
+            "description": "The region of the annotation defined by a list of geometry primitives (cylinder and box).",
+            "minItems": 1,
+            "maxItems": 1000,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotations.cognite__annotation_types__primitives__geometry3d__Geometry"
+            }
+          }
+        },
+        "required": [
+          "region"
+        ],
+        "additionalProperties": false
+      },
+      "Annotations.Detection": {
+        "title": "forms.Detection",
+        "description": "Represents a detection of a field value in a form.\nA field is identified by a field_name, optionally component_name and component_type if the field belongs to a subcomponent.\nThe bounding_box indicates the position of the detection. The content of the field is given by the value, and optionally\nan unnormalized_value and the unit.",
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "description": "The confidence score for the primitive. It should be between 0 and 1.",
+            "minimum": 0,
+            "maximum": 1,
+            "type": "number"
+          },
+          "pageNumber": {
+            "description": "The number of the page on which this annotation is located. The first page has number 1.",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 100000,
+            "type": "integer"
+          },
+          "boundingBox": {
+            "description": "Bounding box of the detection area",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Annotations.BoundingBox"
+              }
+            ]
           },
           "componentType": {
-            "default": null,
             "description": "Type of subcomponent that the detection belongs to",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
           },
           "componentName": {
-            "default": null,
             "description": "Name of subcomponent that the detection belongs to",
             "maxLength": 128,
             "minLength": 1,
@@ -54692,13 +55313,11 @@
             "type": "string"
           },
           "valueUnnormalized": {
-            "default": null,
             "description": "The value that has been detected, before normalization. Optional.",
             "maxLength": 128,
             "type": "string"
           },
           "unit": {
-            "default": null,
             "description": "The unit of the value field. Optional.",
             "maxLength": 128,
             "minLength": 1,
@@ -54710,775 +55329,7 @@
           "fieldName",
           "value"
         ],
-        "title": "forms.Detection",
-        "type": "object"
-      },
-      "Annotations.ExtractedText": {
-        "additionalProperties": false,
-        "description": "Represents text extracted from a document. Annotations of this type are low-level and not specific to any domain.",
-        "properties": {
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the extracted text"
-          },
-          "extractedText": {
-            "description": "The extracted text",
-            "maxLength": 1024,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "textRegion",
-          "extractedText"
-        ],
-        "title": "documents.ExtractedText",
-        "type": "object"
-      },
-      "Annotations.FileLink": {
-        "additionalProperties": false,
-        "description": "Models a link to a CDF File referenced in an engineering diagram",
-        "properties": {
-          "description": {
-            "default": null,
-            "description": "The description of a primitive",
-            "maxLength": 500,
-            "type": "string"
-          },
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "fileRef": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.FileRef"
-              }
-            ],
-            "description": "The file this annotation is pointing to"
-          },
-          "symbolRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "default": null,
-            "description": "The location of the symbol representing the file"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the text mentioning the file"
-          },
-          "text": {
-            "default": null,
-            "description": "The extracted text",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "symbol": {
-            "default": null,
-            "description": "The symbol found in the file",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "fileRef",
-          "textRegion"
-        ],
-        "title": "diagrams.FileLink",
-        "type": "object"
-      },
-      "Annotations.IsoPlanAnnotation": {
-        "additionalProperties": false,
-        "description": "Model a custom link in a engineering diagram where it capture details from the texts and linked to assets when necessary",
-        "properties": {
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "fileRef": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.FileRef"
-              }
-            ],
-            "default": null,
-            "description": "Contains a link to a file in CDF. This is used to navigate between files."
-          },
-          "text": {
-            "default": null,
-            "description": "Text found in the area, might be a FLOC, valve detail, pipe or diagram name.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "default": null,
-            "description": "The location of the hotspot represented with a bounding box."
-          },
-          "indirectRelation": {
-            "default": null,
-            "description": "Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'upstreams of'. This references the 'indirectExternalId'.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "indirectExternalId": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.AssetRef"
-              }
-            ],
-            "default": null,
-            "description": "The indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. E.g. first valve upstreams of <indirectExternalId>."
-          },
-          "lineExternalId": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.AssetRef"
-              }
-            ],
-            "default": null,
-            "description": "The id of the Pipe that the hotspot belongs to."
-          },
-          "detail": {
-            "default": null,
-            "description": "Detail describing the equipment.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "subDetail": {
-            "default": null,
-            "description": "Additional details, the fluid code for pipes e.g. LO for Lube oil etc.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "sourceType": {
-            "default": null,
-            "description": "Marks the hotspot as user created or detected via pipeline.",
-            "enum": [
-              "pipeline",
-              "user"
-            ],
-            "type": "string"
-          },
-          "linkedResourceInternalId": {
-            "default": null,
-            "description": "Stores the Functional Location (FLOC) ID represented by the hotspot.",
-            "type": "integer"
-          },
-          "linkedResourceExternalId": {
-            "default": null,
-            "description": "Stores Functional Location (FLOC) external ID represented by the hotspot.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "linkedResourceType": {
-            "default": null,
-            "description": "Whether the hotspot represents an asset (FLOC) or file.",
-            "enum": [
-              "asset",
-              "file"
-            ],
-            "type": "string"
-          },
-          "type": {
-            "default": null,
-            "description": "Type of equipment, valve, pump etc.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "relativePosition": {
-            "default": null,
-            "description": "Relative position of the relation connecting the hotspot to a tag. E.g. '2nd'. This references the 'indirectExternalId'.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "revision": {
-            "default": null,
-            "description": "Revision number of the P&ID file that the hotspot is valid for.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "sizeAndClass": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.SizeAndClassType"
-              }
-            ],
-            "default": null,
-            "description": "Stores the dimensions of a valve or spade."
-          },
-          "oldAnnotationId": {
-            "default": null,
-            "description": "Temporary field for migration purposes. Id of corresponding legacy annotation.",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "vertices": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.PolyLine"
-              }
-            ],
-            "default": null,
-            "description": "Stores the (x,y) coordinate pairs of a line or polyline."
-          }
-        },
-        "title": "isoplan.IsoPlanAnnotation",
-        "type": "object"
-      },
-      "Annotations.Junction": {
-        "additionalProperties": false,
-        "description": "Models a junction between lines in an engineering diagram",
-        "properties": {
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "position": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.Point"
-              }
-            ],
-            "description": "The point representing the junction"
-          }
-        },
-        "required": [
-          "position"
-        ],
-        "title": "diagrams.Junction",
-        "type": "object"
-      },
-      "Annotations.KeypointCollection": {
-        "additionalProperties": false,
-        "description": "Models a collection of keypoints represented by a label, a dictionary of\nkeypoints (mapping from a (unique) label name to a keypoint), and\noptionally a confidence value and an attributes dictionary.",
-        "properties": {
-          "attributes": {
-            "additionalProperties": {
-              "discriminator": {
-                "mapping": {
-                  "boolean": "#/components/schemas/Annotations.Boolean",
-                  "numerical": "#/components/schemas/Annotations.Numerical"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Annotations.Boolean"
-                },
-                {
-                  "$ref": "#/components/schemas/Annotations.Numerical"
-                }
-              ]
-            },
-            "default": null,
-            "description": "Additional attributes data for a compound.",
-            "type": "object"
-          },
-          "label": {
-            "description": "The label describing what type of object it is",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "keypoints": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/Annotations.Keypoint"
-            },
-            "description": "The detected keypoints",
-            "type": "object"
-          }
-        },
-        "required": [
-          "label",
-          "keypoints"
-        ],
-        "title": "images.KeypointCollection",
-        "type": "object"
-      },
-      "Annotations.Line": {
-        "additionalProperties": false,
-        "description": "Models a line in an engineering diagram",
-        "properties": {
-          "label": {
-            "description": "The label describing what type of object it is",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "polyline": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.PolyLine"
-              }
-            ],
-            "description": "The polyline representing the line"
-          }
-        },
-        "required": [
-          "label",
-          "polyline"
-        ],
-        "title": "diagrams.Line",
-        "type": "object"
-      },
-      "Annotations.ObjectDetection": {
-        "additionalProperties": false,
-        "description": "Models an image object detection represented by a label, a geometry, and\noptionally a confidence value.",
-        "properties": {
-          "attributes": {
-            "additionalProperties": {
-              "discriminator": {
-                "mapping": {
-                  "boolean": "#/components/schemas/Annotations.Boolean",
-                  "numerical": "#/components/schemas/Annotations.Numerical"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Annotations.Boolean"
-                },
-                {
-                  "$ref": "#/components/schemas/Annotations.Numerical"
-                }
-              ]
-            },
-            "default": null,
-            "description": "Additional attributes data for a compound.",
-            "type": "object"
-          },
-          "boundingBox": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "default": null
-          },
-          "polygon": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.Polygon"
-              }
-            ],
-            "default": null
-          },
-          "polyline": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.PolyLine"
-              }
-            ],
-            "default": null
-          },
-          "label": {
-            "description": "The label describing what type of object it is",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "title": "images.ObjectDetection",
-        "type": "object"
-      },
-      "Annotations.TextRegion": {
-        "additionalProperties": false,
-        "description": "Models an extracted text region in an image",
-        "properties": {
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "text": {
-            "description": "The extracted text",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the extracted text"
-          }
-        },
-        "required": [
-          "text",
-          "textRegion"
-        ],
-        "title": "images.TextRegion",
-        "type": "object"
-      },
-      "Annotations.UnhandledSymbolObject": {
-        "additionalProperties": false,
-        "description": "Models an extracted symbol region in an engineering diagram",
-        "properties": {
-          "description": {
-            "default": null,
-            "description": "The description of a primitive",
-            "maxLength": 500,
-            "type": "string"
-          },
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "symbolRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the symbol"
-          },
-          "symbol": {
-            "description": "The symbol found in the file",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "symbolRegion",
-          "symbol"
-        ],
-        "title": "diagrams.UnhandledSymbolObject",
-        "type": "object"
-      },
-      "Annotations.UnhandledTextObject": {
-        "additionalProperties": false,
-        "description": "Models an extracted text region in an engineering diagram",
-        "properties": {
-          "description": {
-            "default": null,
-            "description": "The description of a primitive",
-            "maxLength": 500,
-            "type": "string"
-          },
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the text"
-          },
-          "text": {
-            "description": "The extracted text",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "textRegion",
-          "text"
-        ],
-        "title": "diagrams.UnhandledTextObject",
-        "type": "object"
-      },
-      "Annotations.cognite__annotation_types__diagrams__AssetLink": {
-        "additionalProperties": false,
-        "description": "Models a link to a CDF Asset referenced in an engineering diagram",
-        "properties": {
-          "description": {
-            "default": null,
-            "description": "The description of a primitive",
-            "maxLength": 500,
-            "type": "string"
-          },
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "assetRef": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.AssetRef"
-              }
-            ],
-            "description": "The asset this annotation is pointing to"
-          },
-          "symbolRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "default": null,
-            "description": "The location of the symbol representing the asset"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the text mentioning the asset"
-          },
-          "text": {
-            "default": null,
-            "description": "The extracted text",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "symbol": {
-            "default": null,
-            "description": "The symbol representing the asset",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          }
-        },
-        "required": [
-          "assetRef",
-          "textRegion"
-        ],
-        "title": "diagrams.AssetLink",
-        "type": "object"
-      },
-      "Annotations.cognite__annotation_types__diagrams__InstanceLink": {
-        "additionalProperties": false,
-        "description": "Models a link to an FDM instance referenced in an engineering diagram",
-        "properties": {
-          "description": {
-            "default": null,
-            "description": "The description of a primitive",
-            "maxLength": 500,
-            "type": "string"
-          },
-          "pageNumber": {
-            "default": 1,
-            "description": "The number of the page on which this annotation is located. The first page has number 1.",
-            "maximum": 100000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "instanceRef": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.InstanceRef"
-              }
-            ],
-            "description": "The FDM instance this annotation is pointing to"
-          },
-          "symbolRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "default": null,
-            "description": "Optional location of a symbol"
-          },
-          "symbol": {
-            "default": null,
-            "description": "The symbol found in the file",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "text": {
-            "description": "The extracted text",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the text mentioning the file"
-          }
-        },
-        "required": [
-          "instanceRef",
-          "text",
-          "textRegion"
-        ],
-        "title": "diagrams.InstanceLink",
-        "type": "object"
-      },
-      "Annotations.cognite__annotation_types__images__AssetLink": {
-        "additionalProperties": false,
-        "description": "Models a link to a CDF Asset referenced in an image",
-        "properties": {
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "assetRef": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.AssetRef"
-              }
-            ],
-            "description": "The asset this annotation is pointing to"
-          },
-          "text": {
-            "description": "The extracted text",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the text mentioning the asset"
-          },
-          "objectRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.cognite__annotation_types__primitives__geometry2d__Geometry"
-              }
-            ],
-            "default": null,
-            "description": "The region of the object representing the asset"
-          }
-        },
-        "required": [
-          "assetRef",
-          "text",
-          "textRegion"
-        ],
-        "title": "images.AssetLink",
-        "type": "object"
-      },
-      "Annotations.cognite__annotation_types__images__InstanceLink": {
-        "additionalProperties": false,
-        "description": "Models a link to an FDM instance referenced in an image",
-        "properties": {
-          "confidence": {
-            "default": null,
-            "description": "The confidence score for the primitive. It should be between 0 and 1.",
-            "maximum": 1,
-            "minimum": 0,
-            "type": "number"
-          },
-          "instanceRef": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.InstanceRef"
-              }
-            ],
-            "description": "The FDM instance this annotation is pointing to"
-          },
-          "text": {
-            "description": "The extracted text",
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "textRegion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Annotations.BoundingBox"
-              }
-            ],
-            "description": "The location of the text mentioning the FDM instance"
-          }
-        },
-        "required": [
-          "instanceRef",
-          "text",
-          "textRegion"
-        ],
-        "title": "images.InstanceLink",
-        "type": "object"
+        "additionalProperties": false
       },
       "BatchDownloadRequestSeismic": {
         "type": "object",
@@ -56251,8 +56102,7 @@
         "type": "string",
         "description": "UUIDv4 identifier for a workflow execution.",
         "maxLength": 36,
-        "minLength": 36,
-        "example": "059edaa4-a17a-4102-910e-2c3591500cce"
+        "minLength": 36
       },
       "WorkflowFilter": {
         "type": "object",
@@ -56530,40 +56380,19 @@
         "description": "Input data to the workflow. The content of the input data can be used as input to the workflow tasks using references.   The input data should be in JSON format, and is limited to 100KB in size."
       },
       "CancelExecution": {
-        "title": "Workflow cancellation request",
+        "title": "Workflow cancelation request",
         "type": "object",
         "properties": {
+          "id": {
+            "$ref": "#/components/schemas/WorkflowExternalId"
+          },
           "reason": {
             "type": "string",
-            "description": "Human-readable reason for the cancellation.",
-            "default": "cancelled",
             "maxLength": 500
           }
-        }
-      },
-      "RetryExecution": {
-        "title": "Workflow retry request",
-        "type": "object",
-        "properties": {
-          "authentication": {
-            "$ref": "#/components/schemas/Authentication"
-          }
         },
         "required": [
-          "authentication"
-        ]
-      },
-      "Authentication": {
-        "type": "object",
-        "properties": {
-          "nonce": {
-            "type": "string",
-            "description": "The nonce of a sessions token, which can be obtained using client credentials authentication flow. The nonce's session must be a root session, i.e. it must not be a child of another session.  See [Sessions API](https://api-docs.cognite.com/20230101/tag/Sessions) documentation for more information.",
-            "example": "hOfy4Zop4N2SPRfl"
-          }
-        },
-        "required": [
-          "nonce"
+          "id"
         ]
       },
       "CertificateDetails": {
@@ -56901,8 +56730,8 @@
           "incrementalLoad": {
             "discriminator": {
               "mapping": {
-                "queryParam": "#/components/schemas/QueryParameterConfig",
-                "headerValue": "#/components/schemas/HeaderValueConfig"
+                "headerValue": "#/components/schemas/QueryParameterConfig",
+                "queryParam": "#/components/schemas/HeaderValueConfig"
               },
               "propertyName": "type"
             },
@@ -56920,8 +56749,8 @@
           "pagination": {
             "discriminator": {
               "mapping": {
-                "queryParam": "#/components/schemas/QueryParameterConfig",
-                "headerValue": "#/components/schemas/HeaderValueConfig",
+                "headerValue": "#/components/schemas/QueryParameterConfig",
+                "queryParam": "#/components/schemas/HeaderValueConfig",
                 "nextUrl": "#/components/schemas/NextUrlConfig"
               },
               "propertyName": "type"
@@ -57285,7 +57114,6 @@
             "type": "array",
             "maxItems": 20,
             "minItems": 1,
-            "description": "List of protobuf files as text.",
             "items": {
               "$ref": "#/components/schemas/CreateProtoFile"
             }
@@ -57293,34 +57121,21 @@
         },
         "required": [
           "messageName",
-          "file",
-          "type"
+          "file"
         ]
       },
       "CreateInputConfig": {
         "type": "object",
-        "description": "Optionally set input mapping input type. This defaults to json if left out. Each input type is converted to JSON before being passed to the mapping expression.",
+        "description": "Optionally set input mapping input type. This defaults to json if left out. Any input type is converted to JSON before being passed to the mapping expression.",
         "discriminator": {
           "mapping": {
-            "protobuf": "#/components/schemas/CreateProtobufConfig",
-            "csv": "#/components/schemas/CsvConfig",
-            "xml": "#/components/schemas/XmlConfig",
-            "json": "#/components/schemas/JsonConfig"
+            "protobuf": "#/components/schemas/CreateProtobufConfig"
           },
           "propertyName": "type"
         },
         "oneOf": [
           {
             "$ref": "#/components/schemas/CreateProtobufConfig"
-          },
-          {
-            "$ref": "#/components/schemas/CsvConfig"
-          },
-          {
-            "$ref": "#/components/schemas/XmlConfig"
-          },
-          {
-            "$ref": "#/components/schemas/JsonConfig"
           }
         ]
       },
@@ -57329,98 +57144,14 @@
         "description": "Optionally set input mapping input type. This defaults to json if left out. Any input type is converted to JSON before being passed to the mapping expression.",
         "discriminator": {
           "mapping": {
-            "protobuf": "#/components/schemas/ProtobufConfig",
-            "csv": "#/components/schemas/CsvConfig",
-            "xml": "#/components/schemas/XmlConfig",
-            "json": "#/components/schemas/JsonConfig"
+            "protobuf": "#/components/schemas/ProtobufConfig"
           },
           "propertyName": "type"
         },
         "oneOf": [
           {
             "$ref": "#/components/schemas/ProtobufConfig"
-          },
-          {
-            "$ref": "#/components/schemas/CsvConfig"
-          },
-          {
-            "$ref": "#/components/schemas/XmlConfig"
-          },
-          {
-            "$ref": "#/components/schemas/JsonConfig"
           }
-        ]
-      },
-      "CsvConfig": {
-        "additionalProperties": false,
-        "type": "object",
-        "description": "Transform the input from a CSV (Comma Separated Values) file to a list of JSON objects. The input to the mapping will be a list on the form `[{\\\"header1\\\": \\\"value1\\\", ...}, ...]`.\n",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "csv"
-            ],
-            "description": "Input type",
-            "title": "Type"
-          },
-          "delimiter": {
-            "type": "string",
-            "description": "A single ASCII character used as the separator in the CSV file. Defaults to `,`",
-            "maxLength": 1,
-            "minLength": 1,
-            "title": "Delimiter"
-          },
-          "customKeys": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 20,
-            "description": "List of headers. If this is not set, the headers will be retrieved from the CSV file.",
-            "items": {
-              "type": "string",
-              "description": "CSV file header value.",
-              "title": "CSV_Header"
-            }
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "XmlConfig": {
-        "additionalProperties": false,
-        "type": "object",
-        "description": "Transform the input from an XML file to a JSON object.\n",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "xml"
-            ],
-            "description": "Input type",
-            "title": "Type"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "JsonConfig": {
-        "additionalProperties": false,
-        "type": "object",
-        "description": "Treat the input as UTF-8 encoded JSON.",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "json"
-            ],
-            "description": "Input type",
-            "title": "Type"
-          }
-        },
-        "required": [
-          "type"
         ]
       },
       "ProtobufConfig": {
@@ -57452,8 +57183,7 @@
         },
         "required": [
           "messageName",
-          "file",
-          "type"
+          "file"
         ]
       },
       "UpdateItem_InputConfig_": {
@@ -58964,8 +58694,7 @@
           "mapping",
           "published",
           "lastUpdatedTime",
-          "createdTime",
-          "input"
+          "createdTime"
         ],
         "title": "Mapping",
         "type": "object"
@@ -62010,7 +61739,7 @@
                 "timeoutMinutes": {
                   "type": "integer",
                   "description": "Timeout of each function call.",
-                  "example": 9
+                  "example": 15
                 },
                 "cpuCores": {
                   "$ref": "#/components/schemas/CPURange"
@@ -64079,7 +63808,7 @@
   "tags": [
     {
       "name": "Changelog",
-      "description": "This article documents all notable changes to the Cognite Data Fusion (CDF) API v1.\n\n<!--\nGroup changes by release (and date), API area, and these types of changes:\n\n - **Added** for new features.\n - **Changed** for changes in existing functionality.\n - **Deprecated** for soon-to-be removed features.\n - **Removed** for now removed features.\n - **Fixed** for any bug fixes.\n - **Security** in case of vulnerabilities.-\n\nUse[ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) for dates: 2019-06-20\n\nAdd entries for new features on top of this page. Newest release goes on top.\nChanges only for API v1 series\n\nTemplate:\n\n## <YYYY-MM-DD>\n\n### <Core resource name>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n-->\n## 2024-05-01\n\n### Time series\n\n#### Added\n\n- Added support for [status codes](https://developer.cognite.com/dev/concepts/resource_types/timeseries#data-point-quality-status-codes) for data points.\n\n## 2024-04-02\n\n### Groups\n\n#### Added\n\n- Introduce the option to manage members of a group through CDF instead of through external groups in the identity provider. This is done through the new `members` field on the group object. Members can either be explicitly enumerated or one declare a group to include all users accounts. The latter is useful if one wants all existing users and new users who joins a project to automatically receive certain capabilities.\n\n## 2024-03-19\n\n### Engineering diagrams (beta)\n\n#### Added\n- Beta endpoint for retrieving ocr data for a file per page.\n  Currently, only files that have been run through diagram/detect will give any results.\n  This may be up for change in the future.\n  The endpoint replaces a previous playground endpoint which is no longer documented.\n\n## 2024-03-11\n\n### Default runtime in Cognite functions\n\n#### Changed\n- Default Python runtime in Cognite functions has been updated from Python 3.8 (py38) to Python 3.11 (py311) in response to the upcoming end of community support for Python 3.8 in October 14, 2024.\n\n## 2024-03-06\n\n### Files\n\n#### Updated\n- Files API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency rate limits added\n\n## 2024-02-29\n\n### Assets\n\n#### Updated\n- Assets API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency and items rate limits added\n\n## 2024-02-20\n\n### Data Modeling\n\n#### Added\n**Conversion between unit types for returned values during filter and query operations.**\n- Trigger conversion by setting the `targetUnit` by `externalId` or `unitSystemName` parameters for the data source in a query.\n- When using filters with unit conversion, the unit for filter value is determined by the corresponding property in the `source` object. When querying data in centimeters by setting `targetUnit` on a property in the `source`, the filter value for that property will also be considered to be in centimeters.\n- `typing` - `type.unit` on a property in a `typing` object is now always the same as the unit for the returned data.\n- Added `typing` to following endpoints:\n    - query\n    - sync\n    - aggregate\n    - search\n\n## 2024-02-19\n\n### Time series\n\n#### Added\n\n- Data point subscriptions reaches General Availability (GA).\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again.\n\n## 2024-02-08\n\n### Hosted Extractors\n\n#### Changed\n\n- `host` in kafka sources has been replaced with `bootstrapBrokers`, which is an array of objects with `host` and `port`.\n\n\n## 2024-02-01\n\n### Synthetic time series\n\n#### Added\n- Support for unit conversion by setting `targetUnit` or `targetUnitSystem` on time series or aggregates with a compatible `unitExternalId` field.\n\n\n## 2024-01-16\n\n### Sessions\n\n#### Added\n- Support for creating one-shot sessions by setting the `oneshotTokenExchange` flag. One-shot sessions are short-lived sessions that are not refreshed and do not require support for token exchange from the identity provider.\n\n## 2024-01-02\n\n### Data Modeling\n\n#### Added\n- Support for a `bySpace` flag on btree indexes and uniqueness constraints.\n\n\n## 2023-12-12\n\n### Data Modeling\n\n#### Added\n- **Units catalog support for container properties**: You can now specify a unit from [CDF units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) on `float32` and `float64` properties in containers.\n\n\n## 2023-12-11\n\n### Time series\n\n#### Changed\n\n- Data point subscriptions [list data (beta)](https://api-docs.cognite.com/20230101-beta/tag/Data-point-subscriptions/operation/listSubscriptionData/) now supports _long polling_ through the `pollTimeoutSeconds` parameter. The request will be kept active for the specified number of seconds, or until new data is available, whichever comes first.\n\n## 2023-12-06\n\n### Time series\n\n#### Added\n- [Units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) support to time series. This comes in addition to the existing free-text unit field.\n  - [Create timeseries](https://docs.cognite.com/api#tag/Time-series/operation/postTimeSeries) with a unitExternalId.\n  - [Update timeseries](https://docs.cognite.com/api#tag/Time-series/operation/alterTimeSeries) to add/remove unitExternalId.\n- Filter and aggregate time series by unitExternalId or unitQuantity (eg. \"volume\" or \"temperature\"). Both using regular filters and advanced filters.\n  - [Filter time series](https://docs.cognite.com/api#tag/Time-series/operation/listTimeSeries).\n  - [Aggregate time series](https://docs.cognite.com/api#tag/Time-series/operation/aggregateTimeSeries).\n  - [Search time series](https://docs.cognite.com/api#tag/Time-series/operation/searchTimeSeries).\n- Added unit conversion support to [retrieve data points/aggregates](https://docs.cognite.com/api#tag/Time-series/operation/getMultiTimeSeriesDatapoints) and [retrieve latest](https://docs.cognite.com/api#tag/Time-series/operation/getLatest). Specify a _targetUnit_ or _targetUnitSystem_ to convert the data points or aggregates to a different unit, or to the default unit of a given unit system.\n\n## 2023-11-30\n\n### Hosted extractors\n\n#### Changed\n\n- Hosted extractors API (Beta)\n  - Updates hosted extractor schema with tls certificate details hence users can now provide CA and authentication certificates for connection to MQTT brokers.\n  - Now includes schema requirements for connection to Kafka brokers i.e. connection to and extraction from Kafka brokers to Cognie Data fusion is not possible.\n\n## 2023-11-21\n\n### Units Catalog\n\n#### Added\n\n- Added the [Units Catalog](https://docs.cognite.com/api#tag/Units) API. The Units Catalog is a collection of units of measurement and their conversion factors. The Units Catalog is used within Cognite Data Fusion to easily convert between different units and unit systems when retrieving Time Series and Data Models.\n\n## 2023-11-17\n\n### Documents\n\n#### Added\n\n- Added support for sorting in the `/documents/list` endpoint. It works exactly the same as the sorting\n  in `/documents/search` except that you can not sort on search relevance.\n\n## 2023-11-08\n\n### Engineering diagrams\n\n#### Changed\n\n- Optional token mechanism for accessing detected results of engineering diagrams without read all access to assets.\n  See [diagram/detect](https://api-docs.cognite.com/20230101/tag/Engineering-diagrams/operation/diagramDetect) for details.\n\n## 2023-10-23\n\n### Files\n\n#### Added\n\n- Added multipart upload endpoints for the files API. This enables upload of files larger than 5 GiB, in a uniform way for all CDF cloud environments.\n  Optionally use parallel part upload, for greater upload speed.\n  See the documentation for the new endpoints at:\n  - [Upload multipart file](https://docs.cognite.com/api/20230101/#tag/Files/operation/initMultiPartUpload) and\n  - [Complete multipart upload](https://docs.cognite.com/api/20230101/#tag/Files/operation/completeMultiPartUpload) endpoints.\n\n## 2023-10-17\n### Events\n#### Added\n- New and old but previously undocumented API rate and concurrency limits have been documented.\nOverrides have been specified for existing customers, so that the new limits would not affect them.\n  - Service layer request rate and concurrency limits added.\n  - CRUD endpoints request rate and concurrency and items rate limits added\n\n## 2023-10-10\n\n### Entity matching\n\n#### Added\n\n- Entity matching pipelines are now in v1. We resuscitated the old playground API and made some changes.\n  We will keep the new v1 API in beta for the foreseeable future.\n\n### Vision (Contextualization)\n\n#### Added\n\n- New computer vision models (beta) are available in Vision extract service, including digital, dial and level gauge readers, valve state detection (open/closed) and model to segment objects in images.\n\n## 2023-10-05\n\n### Hosted extractors\n\n#### Added\n\n- Hosted extractors API (Beta)\n  - Use the new [Hosted extractors](https://docs.cognite.com/cdf/integration/guides/extraction/hosted_extractors)\n    feature to create simple streaming extractors running inside CDF, streaming data from sources available on the internet\n    directly into CDF.\n    Currently supports Azure Event Hub and MQTT. Support is planned for Kafka and REST APIs.\n\n## 2023-09-27\n\n### 3D\n\n#### Changed\n\n- If the 3d model processing is ongoing or has failed, the 3d api nodes endpoints will now return error code 400 with the response body \"Revision processing is not yet complete\" or \"Revision processing failed\" respectively.\n  The previous behavior was to return an empty or partial items list in these cases.\n  Before calling any 3d api nodes endpoints, clients should check that the model revision has \"status\":\"Done\".\n\n## 2023-08-25\n\n### Transformations\n\n#### Changed\n\n- Fixed wrong description for fields in \"transformations/update\" and \"/transformations/schedules/update\"\n\n## 2023-08-22\n\n### Functions\n\n#### Changed\n\n- Remove Functions runtime \"py37\".\n\n## 2023-08-22\n\n### Time series\n\n#### Added\n\n- Data point subscriptions (Beta)\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again. (Beta)\n\n## 2023-08-10\n\n### Time series\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-08-08\n\n### Assets\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-06-27\n\n### IAM (Identity and access management)\n\n#### Changed\n\n- Identity providers (IdP) are required to be compatible with the [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html) standard, and compliance will now be enforced by the [Projects](tag/Projects) API.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` can be entirely omitted when updating the OIDC configuration for a project.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` are preserved for backwards compatibility of the API. However, if these are specified as part of the request body, the value must match excatly the values that are specified in the OpenID provider configuration document for the configured issuer (can be found at `https://{issuer-url}/.well-known/openid-configuration`). If the values does not match, the API will return an error message.\n\n- The `oidcConfiguration.skewMs` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request. If included, it must always be set to `0`.\n\n- The `oidcConfiguration.isGroupCallbackEnabled` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request.\n  - For projects configured to use Azure Active Directory as the identity provider, if this value is specified in the request, it must always be set to `true`.\n\n## 2023-06-05\n\n### Data Modeling\n\n#### Added\n\n- Added support for an `autoCreateDirectRelations` option on the endpoint for ingesting instances.\nThis option lets the user specify whether to create missing target nodes of direct relations.\n\n#### Removed\n\n- Removed support for the deprecated per-item `sources` field on the `/instances/byids` endpoint.\n\n### Time series\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-05-19\n\n### Transformations\n\n#### Added\n\n- Adding support for data model centric and view centric schema.\n\n## 2023-04-24\n\n### Transformations\n\n#### Removed\n\n- Removing support for authentication via API keys when creating or updating transformations.\n\n## 2023-05-04\n\n### Annotations\n\n#### Added\n\n- Added `image.InstanceLink` and `diagrams.InstanceLink` annotation types to allow you to link from objects discovered in images and engineering diagrams to data model instances.\n\n## 2023-04-18\n\n### All resources\n\n#### Added\n\n- Added information about [Requests throttling](section/Requests-throttling).\n\n#### Changed\n\n- Updated the [Parallel retrieval](section/Parallel-retrieval) documentation.\n- Aligned endpoint naming within Assets, Data sets, Events, and Files.\n\n### Assets\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101-beta/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-04-12\n\n### Sessions\n\n#### Fixed\n\n- Fixed the API documentation for the request body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated the request body schema as specifying the list of session IDs to retrieve, in the form `{\"items\": [42]}` - it should in fact be `{\"items\": [{\"id\": 42}]}`. The documentation has been updated to reflect this.\n\n- Fixed the API documentation for the response body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated `nextCursor` and `previousCursor` fields as being returned from the response, which was not the case, and these fields have now been removed from the API documentation.\n\n## 2023-04-04\n\n### Transformations\n\n#### Change\n\n- Transformations support new target types for view-centric data model instances.\n\n#### Added\n\n- Added target types `nodes` and `edges`.\n\n## 2023-03-06\n\n### Documents\n\n#### Change\n\n- Renamed \"approximateCardinality\" aggregate to \"cardinalityValues\" to unify the search spec in Cognite.\n- \"uniqueProperties\" aggregate no longer supports pagination. It returns unique properties (up to 10000) in the specified path. The results are sorted by frequency.\n\n#### Added\n\n- Added \"allUniqueProperties\" aggregate that returns all unique properties. The response contains a cursor that can be used to fetch all pages of data.\n\n## 2023-02-03\n\n### Seismic\n\n#### Added\n\n- Batch downloading of seismics as a ZIP archive is now an experimental v1 endpoint. A user requires the experimental ACL to use this endpoint, and any other ACLs and scopes to read the downloadable seismics.\n\n#### Fixed\n\n- The documentation for downloading seismics as SEG-Y files is part of v1. The API documentation didn't reflect that the endpoint had been promoted to version 1.\n\n## 2023-02-07\n\n### Documents\n\n#### Added\n\n- Added `highlight` field in the `search` endpoint to indicate whether matches in search results should be highlighted.\n\n## 2023-01-18\n\n### 3D\n\n#### Added\n\n- Added support for using names filter in list nodes endpoint.\n\n## 2023-01-17\n\n### Authentication\n\n#### Removed\n\nWe've removed authentication via CDF service accounts and API keys, and user sign-in via `/login`.\n\n### 3D\n\n#### Added\n\n- Added support for storing translation and scale for model revision.\n\n## 2023-01-12\n\n### Documents\n\n#### Added\n\n- Added support for approximateCardinality aggregate.\n\n## 2023-01-10\n\n### Documents\n\n#### Added\n\n- Added the search leaf filter, to allow filtering by searching through specified properties.\n\n## 2023-01-09\n\n### Documents\n\n#### Added\n\n- Added the uniqueProperties aggregation, which can be used to find all the metadata keys in use.\n\n## 2023-01-06\n\n### Documents\n\n#### Added\n\n- Added inAssetSubtree filter to filter documents that have a related asset in a subtree rooted at any of the specified IDs.\n\n## 2023-01-02\n\n### Documents\n\n#### Added\n\n- Added advanced filters for metadata (prefix, in, equals)\n\n## 2022-12-06\n\n### 3D\n\n#### Added\n\n- Added get3DNodesById endpoint to be able to fetch 3D nodes mapped to an asset.\n\n## 2022-12-16\n\n### Time series\n\n#### Changed\n\n- Timestamps of data points may now be as large as 4102444799999 (23:59:59.999, December 31, 2099). The previous limit was the year 2050.\n\n## 2022-11-29\n\n### Events\n\n#### Added\n\n- Added `nulls` field to the sort property specification\n\n## 2022-11-17\n\n### Time series\n\n#### Added\n\n- Added `nextCursor` field to [Retrieve data points](tag/Time-series/operation/getMultiTimeSeriesDatapoints), to support cursor pagination\n\n## 2022-10-14\n\n### Geospatial\n\n#### Added\n\n- Added the [POST /projects/{project}/geospatial/compute](tag/Geospatial/operation/compute) endpoint.\n\n## 2022-10-11\n\n### Transformations\n\n#### Added\n\n- Added capability to run a transformation with Nonce credentials provided through the Run endpoint.\n\n## 2022-10-06\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\n\n## 2022-09-09\n\n### Vision (Contextualization)\n\n#### Added\n\n- Move Vision extract service from playground to V1.\n\n## 2022-08-12\n\n### Time series\n\n#### Changed\n\n- Updated datapoints timestamp range from 1971 - 2050 to 1900 - 2050.\n  Affected endpoints:\n  - [Insert data points](tag//Time-series/operation/postMultiTimeSeriesDatapoints)\n  - [Retrieve data points](tag//Time-series/operation/getMultiTimeSeriesDatapoints)\n  - [Delete data points](tag//Time-series/operation/deleteDatapoints)\n  - [Retrieve latest data point](tag//Time-series/operation/getLatest)\n  - [Synthetic query](tag//Synthetic-Time-Series/operation/querySyntheticTimeseries)\n\n## 2022-07-21\n\n### Transformations\n\n#### Added\n\n- Added authentication using nonce for transformation's exisiting endpoints.\n\n## 2022-06-21\n\n### Annotations (Data organization)\n\n#### Added\n\n- Moved the annotation service from playground to v1.\n\n## 2022-07-07\n\n### Events\n\n#### Removed\n\n- End-of-life for [filter.rootAssetIds](tag/Events/operation/advancedListEvents) filtering attribute.\n\n## 2022-06-13\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/revoke](tag/Sessions/operation/revokeSessions) endpoint.\n\n## 2022-05-20\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/aggregate` endpoint. The endpoint allows you to count documents optionally grouped by a property and also to retrieve all unique values of a property.\n\n## 2022-05-12\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/list` endpoint. The endpoint allows you to iterate through all the documents in a project.\n- Added the `POST /documents/{documentId}/content` endpoint. The endpoint lets you download the entire extracted plain text of a document.\n\n## 2022-04-11\n\n### Documents\n\n#### Added\n\n- Added the [GET /documents/{documentId}/preview/image/pages/{pageNumber}](tag/Document-preview/operation/documentsPreviewImagePage) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf](tag/Document-preview/operation/documentsPreviewPdf) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf/temporarylink](tag/Document-preview/operation/documentsPreviewPdfTemporaryLink) endpoint.\n\n## 2022-03-15\n\n### Sequences\n\n#### Changed\n\n- Changed sequences column limits. Old limit of maximum total 200 columns limits is updated to maximum 400 total columns, maximum 400 numeric columns and maximum 200 string columns.\n\n## 2022-03-02\n\n### Sequences\n\n#### Added\n\n- Added the [POST /sequences/data/latest](tag/Sequences/operation/getLatestSequenceRow) endpoint.\n\n## 2022-02-08\n\n### Time series\n\n#### Changed\n\n- Marked `isStep` parameter to be editable (i.e. removed description stating it is not updatable) in [POST /timeseries/create](tag/Time-series/operation/postTimeSeries).\n\n#### Added\n\n- Added `isStep` parameter to the `TimeSeriesPatch` object used in [POST /timeseries/update](tag/Time-series/operation/alterTimeSeries)\n\n## 2022-02-07\n\n### Documents\n\n#### Added\n\n- The [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint now supports pagination.\n\n## 2022-01-25\n\n### Documents\n\n#### Added\n\n- Added the [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint.\n\n## 2022-01-24\n\n### Time series\n\n#### Added\n\n- Added optional `ignoreUnknownIds` parameter to [POST /sequences/delete](tag/Sequences/operation/deleteSequences). Setting this to true will prevent the operation from failing if one or more of the given sequences do not exist; instead, those given sequences that do exist will be deleted.\n\n## 2021-12-07\n\n### Transformations\n\n#### Added\n\n- New [Transformations](tag//Transformations) APIs to v1 to create,retrieve,list and delete transformations\n- New [Transformation Jobs](tag//Transformation-Jobs) APIs to v1 to retrieve and list transformation jobs or job metrics\n- New [Transformation Schedule](tag//Transformation-Schedules) APIs to v1 to manage schedules of transformations\n- New [Transformation Notifications](tag//Transformation-Notifications) APIs to v1 to manage notifications from transformation job\n\n## 2021-11-22\n\n### Contextualization\n\n#### Added\n\n- Added [diagram detect](tag/Engineering-diagrams/operation/diagramDetect) endpoint to v1 to detect annotations in engineering diagrams\n- Added [diagram detect results](tag/Engineering-diagrams/operation/diagramDetectResults) endpoint to v1 to get the results from an engineering diagram detect job\n- Added [diagram convert](tag/Engineering-diagrams/operation/diagramConvert) endpoint to v1 to create interactive engineering diagrams in SVG format with highlighted annotations\n- Added [diagram convert results](tag/Engineering-diagrams/operation/diagramConvertResults) endpoint to v1 to get the results for a job converting engineering diagrams to SVGs\n\n## 2021-11-17\n\n### 3D\n\n#### Added\n\n- Added `dataSetId` support to 3D models enabling data access scoping of 3D data\n\n## 2021-10-13\n\n### Raw\n\n#### Changed\n\n- To align with Microsoft Azure clusters, table and database names are now sensitive to trailing spaces also in Google Cloud Platform clusters.\n\n## 2021-10-05\n\n### Extraction Pipelines\n\n#### Added\n\n- New [Extraction Pipelines](tag//Extraction-Pipelines) resource to document extractors and monitor the status of data ingestion to make sure reliable and trustworthy data are flowing into the CDF data sets.\n- API endpoints for creating, managing, and deleting extraction pipelines. Capture common attributes around extractors such as owners, contacts, schedule, destination RAW databases, and data set. Document structured metadata in the form of key-value attributes as well unstructured `documentation` attribute that supports Markdown (rendered as Markdown in Fusion).\n- Extraction Pipelines Runs are CDF objects to store statuses related to an extraction pipeline. The supported statuses are: `success`, `failure` and `seen`. They enable extractor developers to report status and error message after ingesting data. As well enables for reporting heartbeat through `seen` status by the extractor to easily identify issues related to crushed applications and scheduling issues.\n\n## 2021-09-28\n\n### Sequences\n\n#### Added\n\n- Added `partition` parameter to the [GET /sequences](tag/Sequences/operation/listSequences) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n- [POST /sequences/list](tag/Sequences/operation/advancedListSequences) now supports [parallel retrieval](section/Parallel-retrieval).\n\n### Time series\n\n#### Added\n\n- Added `partition` parameter to the [GET /timeseries](tag/Time-series/operation/getTimeSeries) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n\n## 2021-08-18\n\n### IAM (Identity and access management)\n\n#### Added\n\nAdded sessions to [v1](tag//Sessions). Sessions let you securely delegate access to CDF resources for CDF services (such as Functions) by an external principal and for an extended time.\n\n## 2021-08-12\n\n### Relationships\n\n#### Added\n\n- Relationships now support [Parallel Retrieval](section/Parallel-retrieval)\n\n## 2021-07-01\n\n### 3D\n\n#### Added\n\n- Added filter3dNodes endpoint to allow for more advanced filtering on node metadata\n\n## 2021-06-29\n\n### Labels\n\n#### Added\n\n- [Dataset scoping](tag/Labels/operation/listLabels) based on `dataSetIds`.\n\n## 2021-06-08\n\n### Sequences\n\n#### Added\n\n- Added [syntax for updating columns](tag/Sequences/operation/updateSequences) of existing sequences. Can `remove` columns, `modify` existing columns, and `add` new columns as well.\n\n## 2021-06-01\n\n### Assets\n\n#### Added\n\n- Added labels replace (set) method for [assets update](tag/Assets/operation/updateAssets).\n\n## 2021-04-28\n\n### Time series\n\n#### Changed granularity limits on hour aggreagates\n\nYou can now ask for a [granularity](https://docs.cognite.com/dev/concepts/aggregation/#granularity)\nof up to 100000 hours (previously 48 hours), both in normal aggregates and in synthetic time series.\n\n## 2021-04-12\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added a [projects list](tag/Projects/operation/listProjects) endpoint to v1\n- Added a [token inspection](tag/Token/operation/inspectToken) endpoint to v1\n\n## 2021-04-06\n\n### Authentication\n\n#### Deprecated\n\nWe are deprecating authentication via CDF service accounts and API keys, and user sign-in via `/login`, in favor of registering applications and services with your IdP (identity provider) and [using OpenID Connect](https://docs.cognite.com/cdf/access/) and the IdP framework to manage CDF access securely.\n\nThe legacy authentication flow is available for customers using Cognite Data Fusion (CDF) on GCP until further notice. We strongly encourage customers to adopt [the new authentication flows](https://docs.cognite.com/cdf/access/) as soon as possible.\n\nThe following API endpoints are deprecated:\n\n- `/api/v1/projects/*/apikeys`\n- `/api/v1/projects/*/serviceaccounts`\n- `/login`\n- `/logout`\n- `/api/v1/projects/*/groups/serviceaccounts` <sup>\\*</sup>\n\n<sup>\\*</sup>only the sub-resources for listing, adding, and removing members of groups.\n\n## 2021-03-22\n\nCDF API 0.5, 0.6 reached their end-of-life after its initial deprecation announcement in Summer 2019.\n\n## 2021-03-10\n\n### 3D\n\n#### Added\n\n- Added `partition` parameter to the List 3D Nodes endpoint for supporting parallel requests.\n- Added `sortByNodeId` parameter to the List 3D Nodes endpoint, improving request latency in most cases if set to `true`.\n\n## 2021-02-26\n\n### Entity matching\n\n#### Fixed\n\n- Fixed a bug in the documentation for Entity matching. The (job) `status` shall be capitalized string.\n\n## 2020-12-22\n\n### Files\n\n#### Added\n\n- New field `fileType` inside `derivedFields` to refer to a pre-defined subset of MIME types.\n- New filter `fileType` inside `derivedFields` to find files with a pre-defined subset of MIME types.\n\n## 2020-10-20\n\n### Files\n\n#### Added\n\n- New field `geoLocation` to refer to the geographic location of the file.\n- New filter `geoLocation` to find files matching a certain geographic location.\n\nTo learn how to leverage new geoLocation features, [follow our guide](https://developer.cognite.com/dev/concepts/resource_types/files.html).\n\n## 2020-08-29\n\n### Files\n\n#### Added\n\n- New field `directory` referring to the directory in the source containing the file.\n- New filter `directoryPrefix` allows you to find Files matching a certain directory prefix.\n\n## 2020-08-05\n\n### Files\n\n#### Added\n\n- New field `labels` allows you to attach labels to Files upon creation or updating.\n- New filter `labels` allows you to find Files that have been annotated with specific labels.\n\n## 2020-07-08\n\n### IAM (Identity and access management)\n\n#### Added\n\n- New project field `applicationDomains`. If this field is set, users only sign in to the project through applications hosted on\n  a whitelisted domain. [Read more](https://developer.cognite.com/dev/guides/iam/#application-domains).\n\n## 2020-07-01\n\n### Events\n\n#### Added\n\n- New aggregation [`uniqueValues`](tag/Events/operation/aggregateEvents) allows you to find different types, subtypes of events in your project.\n\n## 2020-06-29\n\n### Labels\n\n#### Added\n\n- New data organization resource: [labels](tag//Labels). Manage terms that you can use to annotate and group assets.\n\n### Assets\n\n#### Added\n\n- New filter `labels` allows you to find resources that have been annotated with specific labels.\n\n### Time series\n\n#### Added\n\n- Combine various input time series, constants and operators with on-the-fly [synthetic time series](https://developer.cognite.com/dev/concepts/resource_types/synthetic_timeseries.html).\n\n## 2020-04-28\n\n### Events\n\n#### Added\n\n- New filtering capabilities to find open events [`endTime=null`](tag/Events/operation/advancedListEvents).\n- New filtering capabilities to find all events intersecting a timespan using [activeAtTime](tag/Events/operation/advancedListEvents).\n\n## 2020-03-12\n\n### General\n\n#### Added\n\n- New data organization resource: [data sets](tag//Data-sets). Document and track data lineage, ensure data integrity, and allow 3rd parties to write their insights securely back to your Cognite Data Fusion (CDF) project.\n- New attribute `datasetId` introduced in assets, files, events, time series and sequences.\n- New filter `dataSetIds` allows you to narrow down results to resources containing `datasetId` by a list of ids or externalIds of a data set. Supported by assets, files, events, time series and sequences.\n- We have added a new aggregation endpoint for [time series](tag/Files/operation/aggregateFiles). With this endpoint, you can find out how many results in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Groups\n\n#### Added\n\n- Introduced a new capability: `datasetsAcl` for managing access to data set resources.\n- New scope `datasetScope` for assets, files, events, time series and sequences ACLs. Allows you to scope down access to resources contained within a specified set of data sets.\n\n## 2020-03-10\n\n### 3D\n\n#### Fixed\n\n- We fixed a bug in the documentation of [3D model revisions](tag/3D-Model-Revisions/operation/get3DNodesById). Applications should anticipate that 3D nodes may not have a bounding box.\n\n## 2020-02-25\n\n### Assets\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Assets/operation/aggregateAssets) for assets. With this endpoint, you can find out how many assets in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Events\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Events/operation/aggregateEvents) for events. With this endpoint, you can find out how many events in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n## 2020-02-12\n\n### Assets\n\n#### Added\n\n- We have added new aggregation properties: `depth` and `path`. You can use the properties in the filter and retrieve endpoints.\n\n## 2020-02-10\n\n### Assets\n\n#### Added\n\n- Added the property `parentExternalId` which is returned for all assets which have a parent with a defined `externalId`.\n\n## 2019-12-09\n\n### General\n\n#### Added\n\n- Added `assetSubtreeIds` as a parameter to filter, search, and list endpoints for all core resources. `assetSubtreeIds` allows you to specify assets that are subtree roots, and then only retrieve resources that are related to assets within those subtrees.\n\n## 2019-12-04\n\n### Assets\n\n#### Added\n\n- Added the ability to [filter](tag/Assets/operation/searchAssets) assets by parent external IDs.\n\n## 2019-11-18\n\n### Events\n\n#### Added\n\n- [Added the ability to filter events by the external ID of linked assets](tag/Events/operation/advancedListEvents)\n\n## 2019-11-12\n\n### Access control\n\n#### Removed\n\n- Groups can no longer be created with a permissions field in v0.5.\n\n## 2019-10-31\n\n### Assets\n\n#### Added\n\n- [Asset search](/api/v1/#operation/searchAssets) now has a `search.query` parameter. This uses an improved search algorithm that tries a wider range of variations of the input terms and gives much better relevancy ranking than the existing `search.name` and `search.description` fields.\n\n### Time Series\n\n#### Changed\n\n- The `search.query` parameter for [time series search](/api/v1/#operation/searchTimeSeries) now uses an improved search algorithm that tries a wider range of variations of the input terms, and gives much better relevancy ranking.\n\n## 2019-10-23\n\n### Files\n\n#### Added\n\n- Added support for updating the `mimeType` for existing files in files/update requests.\n\n## 2019-10-18\n\n### Time Series\n\n#### Added\n\n- Time series expanded their filtering capabilities with new `Filter time series` endpoint, allowing for additional filtering by:\n\n  - Name\n  - Unit\n  - Type of time series: string or step series\n  - Metadata objects\n  - ExternalId prefix filtering\n  - Create and last updated time ranges\n\n  Endpoint in addition support pagination and partitioning. Check out detailed API documentation [here](/api/v1/#operation/listTimeSeries).\n\n## 2019-10-16\n\n### Events\n\n#### Added\n\n- [Added the ability to sort events on startTime, endTime, createdTime, and lastUpdatedTime](tag/Events/operation/advancedListEvents)\n\n## 2019-10-02\n\n### Sequences\n\n#### Added\n\n- Introducing the new **sequences** core resource type that lets you store numerically indexed multi-column rows of data. Connect your sequences to physical assets and to their source systems through `externalId` and metadata support. Read more [here](https://developer.cognite.com/dev/concepts/resource_types/sequences.html).\n\n## 2019-09-30\n\n### 3D\n\n#### Added\n\n- Added endpoint to get multiple nodes for a 3D model by their IDs.\n- Added endpoint to get asset mappings for multiple node IDs or asset IDs.\n\n## 2019-09-23\n\n### Files\n\n#### Added\n\n- Added support for filter on `rootAssetIds` in files GET /files (using query parameter) and POST /files/list (in request body).\n\n## 2019-09-16\n\n### Assets and Events\n\n#### Added\n\n- Added support for `partition` in `/assets` and `/events` to support parallel retrieval. See guide for usage [here](./concepts/pagination)\n\n## 2019-08-22\n\n### 3D\n\n#### Added\n\n- Added the query parameter `intersectsBoundingBox` to the list asset mappings endpoint. The parameter filters asset mappings to the assets where the bounding box intersects (or is contained within) the specified bounding box.\n\n## 2019-08-21\n\n### Files\n\n#### Added\n\n- Added support for sourceCreatedTime and sourceModifiedTime fields in files v1 endpoints.\n\n### Assets\n\n#### Added\n\n- Allow the parent asset ID to be updated. The root asset ID must be preserved, and you can not convert a non-root asset to a root asset or vice versa.\n- Support for ignoreUnknownIds when deleting assets.\n\n## 2019-08-15\n\n### 3D\n\n#### Added\n\n- Properties field for 3D nodes, extracted from uploaded 3D files.\n- Ability to filter nodes with a specific set of properties.\n\n## 2019-07-24\n\n### Files\n\n#### Changed\n\n- Allow lookup of names with length up to 256 characters (was 50) for GET /files and POST /files/search operations.\n- Allow creating and retrieving files with mimeType length up to 256 characters (was 64).\n\n## 2019-07-15\n\n### Time series\n\n#### Added\n\n- Added query parameter `rootAssetIds` to list time series endpoint. Returns time series that are linked to an asset that has one of the root assets as an ancestor.\n\n## 2019-07-11\n\nList of changes for initial API v1 release in comparison to previous version - API 0.5\n\n### General\n\n#### Added\n\n- Support for `externalId` added across resource types. `externalId` lets you define a unique ID for a data object. Learn more: [External IDs](https://developer.cognite.com/dev/concepts/external_id.html)\n- `externalIdPrefix` added as a parameter to the list events, assets and files operations.\n- Richer filtering on the list assets, files and events operations.\n- Search, list and filter operations for assets, events and files now support filtering on source and metadata field values.\n\n#### Changed\n\n- Core resources standardize on HTTP methods and URI naming for common operations such as search, partial updates, delete, list and filter\n- API responses are no longer wrapped in a top level `data` object.\n- Standardized pagination across resources through `limit`, `cursor` and `nextCursor` parameters.\n- The `limit` parameter no longer implicitly rounds down requested page size to maximum page size.\n- Standardized error responses and codes across all resources. Errors across CDF can be parsed into a single model.\n- Overall improvements to reference documentation. Including documented input constraints, required fields, individual attribute descriptions.\n\n#### Removed\n\n- The `sourceId` field has been removed from resources. Use `externalId` instead of `sourceId`+`source` to define unique IDs for data objects.\n- Sorting is removed from the search operations for files, assets, events and time series. Results are sorted by relevance.\n- `offset` and `previousCursor` parameters are no longer supported for pagination across resources.\n- Fetching an asset subtree is no longer supported by files, assets, events and time series.\n\n### Assets\n\n#### Added\n\n- Ability to select only root assets though new `root` filter.\n- Added the `rootId` field to specify the top element in an asset hierarchy.\n- Added the ability to filter by the root asset ID. This allows you to scope queries for one or many asset hierarchies.\n- List Assets allows for filtering assets belonging to set of root assets, specified by list of asset internal ids. New query parameter: `rootIds`.\n- Filter and Search Assets allows or filtering assets belonging to a set of root assets, specified by combination of internal and external asset identifiers. New body attribute: `rootIds`.\n\n#### Changed\n\n- Updating a single asset is no longer supported through a separate endpoint. Use the update multiple endpoint instead.\n- Delete assets by default removes only leaf assets (assets without children). New parameter 'recursive' allows for enabling recursive removal of the entire subtree of the asset pointed by ID (API 0.5 behaviour).\n\n#### Removed\n\n- Overwriting assets is no longer supported.\n- Filtering assets by their complete description is no longer supported.\n- Locating assets fuzzily by name has been removed. Instead, search for assets on the `name` property.\n- When searching assets, querying over both name and description in the same query is no longer supported.\n- The experimental query parameter `boostName` has been removed from the search for assets operation.\n- Removed the `path` and `depth` fields.\n\n### Events\n\n#### Added\n\n- Events can now be filtered on asset ID in combination with other filters.\n- New filter `rootAssetIds` allows for narrowing down events belonging only to list or specified root assets. Supported by Filter and Search API\n\n#### Removed\n\n- Events can no longer be filtered by empty description.\n- The 'dir' parameter has been removed from the search events operation.\n\n### Files\n\n#### Added\n\n- Filtering files by `assetIds` in list files operations now support multiple assets in the same request.\n\n#### Changed\n\n- Download file content has changed from HTTP GET to HTTP POST method.\n- We have renamed the `fileType` field to `mimeType`. The field now requires a MIME formatted string (e.g. `text/plain`).\n- We have renamed the `uploadedAt` field to `uploadedTime`.\n- Resumable is now the default behavior for file uploads.\n- Update metadata for single files is no longer supported by a separate operation. Instead, use the update multiple operation.\n\n#### Removed\n\n- Replace files metadata endpoint has been removed.\n- Directory has been removed as a property of files.\n- Updating the `name` or `mimeType` of a file through the update multiple files operation is no longer supported.\n- Query parameter for specifying the sort direction has been removed from list all files operations.\n\n### Raw\n\n#### Changed\n\n- Raw has changed structure to become resource-oriented. The URL structure has changed.\n- Recursively delete of tables and rows when deleting a database is now the default behavior without a control parameter.\n\n### Time series\n\n#### Added\n\n- Support for adding datapoints by `id` and `externalId` of time series. Adding datapoints to time series by `name` has been removed.\n- Add ability to update the new `externalId` attribute for time series.\n- Allow to set `externalId` during creation of time series. `ExternalId` requires uniqueness across time series.\n- Consolidate multiple APIs to allow adding datapoints into a single endpoint. Allows datapoints to be added to multiple time series at the same time.\n- Retrieve data points by using `id` and `externalId` of the time series.\n- Time series created through API v1 are not discoverable by API 0.3, 0.4, 0.5 and 0.6 by default. Introduce the option to enable this compatibility by setting new attribute - `legacyName` on time series creation. Value is required to be unique.\n\n#### Changed\n\n- Get latest datapoints has been reworked. Introduces support for `id` and `externalId` lookup as well retrieval for multiple time series within the same request.\n- Time series name is no longer limited by uniqueness. Note that time series (meta objects) created by API v1 will not be discoverable by older API versions.\n- Delete time series endpoint has been redesigned to allow deletion of multiple time series by `id` and `externalId`.\n- Delete single and multiple datapoints endpoint has been redesigned and consolidated into a single endpoint. New delete allows selection of multiple time series and time ranges by `id` and `externalId`. Selecting by `name` is no longer available.\n- Update multiple time series restructured to support lookup by `externalId`.\n- Retrieve time series by ID endpoint restructured adding the ability to get time series by `externalId`.\n- Set limit for data point value to min -1E100, max 1E100.\n\n#### Removed\n\n- Experimental feature for performing calculations across multiple time series (synthetic time series), function and alias attributes are no longer available.\n- The experimental query parameter `boostName` has been removed from search operation.\n- Short names for aggregate functions are no longer supported.\n- Ability to remove time series by `name` have been removed as names are no longer unique identifiers.\n- Select multiple time series and time ranges by `name` is no longer available.\n- The ability to update `isString` and `isStep` attributes is removed. The attributes are not intended to be modified after creation of time series.\n- The endpoint for updating single time series is removed. Use the update multiple time series endpoint instead.\n- Remove ability to overwrite time series object by `id`. Use the update multiple time series endpoint instead.\n- The ability to retrieve time series matching by `name` has been removed. Use `externalId` instead.\n- The ability to retrieve by `id` from a single time series has been removed. Use retrieve multiple datapoints for multiple time series instead.\n- The ability to retrieve time-aligned datapoints through \"dataframe\" API has been removed. Similar functionality is available through our supported SDKs.\n- The ability to add datapoints to time series by `name` has been removed.\n- The ability to look up by time series `name` has been removed.\n\n### IAM (Identity and access management)\n\n#### Added\n\n- The login status endpoint includes the ID of the API key making the request (new attribute: `apiKeyId`), if the request used an API key.\n\n#### Changed\n\n- The user resource type has been replaced with service accounts. Users from previous API versions are equivalent to service accounts.\n- Adding, listing and removing users from a group has been replaced by equivalent operations for service accounts.\n- Retrieve project returns a single object instead of a list.\n- API keys endpoints for list/create rename `userId` attribute to `serviceAccountId`.\n\n#### Removed\n\n- List and create groups no longer use the `permissions` and `source` attributes.\n\n### 3D\n\n#### Added\n\n- New 3D API lets you upload and process 3D models. Supported format: FBX.\n- Ability to create and maintain multiple revisions for the 3D models.\n- API for mapping relationships between 3D model nodes and asset hierarchy.\n"
+      "description": "This article documents all notable changes to the Cognite Data Fusion (CDF) API v1.\n\n<!--\nGroup changes by release (and date), API area, and these types of changes:\n\n - **Added** for new features.\n - **Changed** for changes in existing functionality.\n - **Deprecated** for soon-to-be removed features.\n - **Removed** for now removed features.\n - **Fixed** for any bug fixes.\n - **Security** in case of vulnerabilities.-\n\nUse[ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) for dates: 2019-06-20\n\nAdd entries for new features on top of this page. Newest release goes on top.\nChanges only for API v1 series\n\nTemplate:\n\n## <YYYY-MM-DD>\n\n### <Core resource name>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n-->\n## 2024-04-02\n\n### Groups\n\n#### Added\n\n- Introduce the option to manage members of a group through CDF instead of through external groups in the identity provider. This is done through the new `members` field on the group object. Members can either be explicitly enumerated or one declare a group to include all users accounts. The latter is useful if one wants all existing users and new users who joins a project to automatically receive certain capabilities.\n\n## 2024-03-19\n\n### Engineering diagrams (beta)\n\n#### Added\n- Beta endpoint for retrieving ocr data for a file per page. \n  Currently, only files that have been run through diagram/detect will give any results. \n  This may be up for change in the future. \n  The endpoint replaces a previous playground endpoint which is no longer documented.\n\n## 2024-03-11\n\n### Default runtime in Cognite functions\n\n#### Changed\n- Default Python runtime in Cognite functions has been updated from Python 3.8 (py38) to Python 3.11 (py311) in response to the upcoming end of community support for Python 3.8 in October 14, 2024.\n\n## 2024-03-06\n\n### Files\n\n#### Updated\n- Files API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency rate limits added\n\n## 2024-02-29\n\n### Assets\n\n#### Updated\n- Assets API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency and items rate limits added\n\n## 2024-02-20\n\n### Data Modeling\n\n#### Added\n**Conversion between unit types for returned values during filter and query operations.**\n- Trigger conversion by setting the `targetUnit` by `externalId` or `unitSystemName` parameters for the data source in a query.\n- When using filters with unit conversion, the unit for filter value is determined by the corresponding property in the `source` object. When querying data in centimeters by setting `targetUnit` on a property in the `source`, the filter value for that property will also be considered to be in centimeters.\n- `typing` - `type.unit` on a property in a `typing` object is now always the same as the unit for the returned data.\n- Added `typing` to following endpoints:\n    - query\n    - sync\n    - aggregate\n    - search\n\n## 2024-02-19\n\n### Time series\n\n#### Added\n\n- Data point subscriptions reaches General Availability (GA).\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again.\n\n## 2024-02-08\n\n### Hosted Extractors\n\n#### Changed\n\n- `host` in kafka sources has been replaced with `bootstrapBrokers`, which is an array of objects with `host` and `port`.\n\n\n## 2024-02-01\n\n### Synthetic time series\n\n#### Added\n- Support for unit conversion by setting `targetUnit` or `targetUnitSystem` on time series or aggregates with a compatible `unitExternalId` field.\n\n\n## 2024-01-16\n\n### Sessions\n\n#### Added\n- Support for creating one-shot sessions by setting the `oneshotTokenExchange` flag. One-shot sessions are short-lived sessions that are not refreshed and do not require support for token exchange from the identity provider.\n\n## 2024-01-02\n\n### Data Modeling\n\n#### Added\n- Support for a `bySpace` flag on btree indexes and uniqueness constraints.\n\n\n## 2023-12-12\n\n### Data Modeling\n\n#### Added\n- **Units catalog support for container properties**: You can now specify a unit from [CDF units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) on `float32` and `float64` properties in containers.\n\n\n## 2023-12-11\n\n### Time series\n\n#### Changed\n\n- Data point subscriptions [list data (beta)](https://api-docs.cognite.com/20230101-beta/tag/Data-point-subscriptions/operation/listSubscriptionData/) now supports _long polling_ through the `pollTimeoutSeconds` parameter. The request will be kept active for the specified number of seconds, or until new data is available, whichever comes first.\n\n## 2023-12-06\n\n### Time series\n\n#### Added\n- [Units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) support to time series. This comes in addition to the existing free-text unit field.\n  - [Create timeseries](https://docs.cognite.com/api#tag/Time-series/operation/postTimeSeries) with a unitExternalId.\n  - [Update timeseries](https://docs.cognite.com/api#tag/Time-series/operation/alterTimeSeries) to add/remove unitExternalId.\n- Filter and aggregate time series by unitExternalId or unitQuantity (eg. \"volume\" or \"temperature\"). Both using regular filters and advanced filters.\n  - [Filter time series](https://docs.cognite.com/api#tag/Time-series/operation/listTimeSeries).\n  - [Aggregate time series](https://docs.cognite.com/api#tag/Time-series/operation/aggregateTimeSeries).\n  - [Search time series](https://docs.cognite.com/api#tag/Time-series/operation/searchTimeSeries).\n- Added unit conversion support to [retrieve data points/aggregates](https://docs.cognite.com/api#tag/Time-series/operation/getMultiTimeSeriesDatapoints) and [retrieve latest](https://docs.cognite.com/api#tag/Time-series/operation/getLatest). Specify a _targetUnit_ or _targetUnitSystem_ to convert the data points or aggregates to a different unit, or to the default unit of a given unit system.\n\n## 2023-11-30\n\n### Hosted extractors\n\n#### Changed\n\n- Hosted extractors API (Beta)\n  - Updates hosted extractor schema with tls certificate details hence users can now provide CA and authentication certificates for connection to MQTT brokers.\n  - Now includes schema requirements for connection to Kafka brokers i.e. connection to and extraction from Kafka brokers to Cognie Data fusion is not possible.\n\n## 2023-11-21\n\n### Units Catalog\n\n#### Added\n\n- Added the [Units Catalog](https://docs.cognite.com/api#tag/Units) API. The Units Catalog is a collection of units of measurement and their conversion factors. The Units Catalog is used within Cognite Data Fusion to easily convert between different units and unit systems when retrieving Time Series and Data Models.\n\n## 2023-11-17\n\n### Documents\n\n#### Added\n\n- Added support for sorting in the `/documents/list` endpoint. It works exactly the same as the sorting\n  in `/documents/search` except that you can not sort on search relevance.\n\n## 2023-11-08\n\n### Engineering diagrams\n\n#### Changed\n\n- Optional token mechanism for accessing detected results of engineering diagrams without read all access to assets.\n  See [diagram/detect](https://api-docs.cognite.com/20230101/tag/Engineering-diagrams/operation/diagramDetect) for details.\n  \n## 2023-10-23\n\n### Files\n\n#### Added\n\n- Added multipart upload endpoints for the files API. This enables upload of files larger than 5 GiB, in a uniform way for all CDF cloud environments.\n  Optionally use parallel part upload, for greater upload speed.\n  See the documentation for the new endpoints at:\n  - [Upload multipart file](https://docs.cognite.com/api/20230101/#tag/Files/operation/initMultiPartUpload) and\n  - [Complete multipart upload](https://docs.cognite.com/api/20230101/#tag/Files/operation/completeMultiPartUpload) endpoints.\n\n## 2023-10-17\n### Events\n#### Added\n- New and old but previously undocumented API rate and concurrency limits have been documented. \nOverrides have been specified for existing customers, so that the new limits would not affect them.\n  - Service layer request rate and concurrency limits added. \n  - CRUD endpoints request rate and concurrency and items rate limits added\n\n## 2023-10-10\n\n### Entity matching\n\n#### Added\n\n- Entity matching pipelines are now in v1. We resuscitated the old playground API and made some changes.\n  We will keep the new v1 API in beta for the foreseeable future.\n\n### Vision (Contextualization)\n\n#### Added\n\n- New computer vision models (beta) are available in Vision extract service, including digital, dial and level gauge readers, valve state detection (open/closed) and model to segment objects in images.\n\n## 2023-10-05\n\n### Hosted extractors\n\n#### Added\n\n- Hosted extractors API (Beta)\n  - Use the new [Hosted extractors](https://docs.cognite.com/cdf/integration/guides/extraction/hosted_extractors)\n    feature to create simple streaming extractors running inside CDF, streaming data from sources available on the internet\n    directly into CDF.\n    Currently supports Azure Event Hub and MQTT. Support is planned for Kafka and REST APIs.\n\n## 2023-09-27\n\n### 3D\n\n#### Changed\n\n- If the 3d model processing is ongoing or has failed, the 3d api nodes endpoints will now return error code 400 with the response body \"Revision processing is not yet complete\" or \"Revision processing failed\" respectively.\n  The previous behavior was to return an empty or partial items list in these cases.\n  Before calling any 3d api nodes endpoints, clients should check that the model revision has \"status\":\"Done\".\n\n## 2023-08-25\n\n### Transformations\n\n#### Changed\n\n- Fixed wrong description for fields in \"transformations/update\" and \"/transformations/schedules/update\"\n\n## 2023-08-22\n\n### Functions\n\n#### Changed\n\n- Remove Functions runtime \"py37\".\n\n## 2023-08-22\n\n### Time series\n\n#### Added\n\n- Data point subscriptions (Beta)\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again. (Beta)\n\n## 2023-08-10\n\n### Time series\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-08-08\n\n### Assets\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-06-27\n\n### IAM (Identity and access management)\n\n#### Changed\n\n- Identity providers (IdP) are required to be compatible with the [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html) standard, and compliance will now be enforced by the [Projects](tag/Projects) API.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` can be entirely omitted when updating the OIDC configuration for a project.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` are preserved for backwards compatibility of the API. However, if these are specified as part of the request body, the value must match excatly the values that are specified in the OpenID provider configuration document for the configured issuer (can be found at `https://{issuer-url}/.well-known/openid-configuration`). If the values does not match, the API will return an error message.\n\n- The `oidcConfiguration.skewMs` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request. If included, it must always be set to `0`.\n\n- The `oidcConfiguration.isGroupCallbackEnabled` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request.\n  - For projects configured to use Azure Active Directory as the identity provider, if this value is specified in the request, it must always be set to `true`.\n\n## 2023-06-05\n\n### Data Modeling\n\n#### Added\n\n- Added support for an `autoCreateDirectRelations` option on the endpoint for ingesting instances.\nThis option lets the user specify whether to create missing target nodes of direct relations.\n\n#### Removed\n\n- Removed support for the deprecated per-item `sources` field on the `/instances/byids` endpoint.\n\n### Time series\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-05-19\n\n### Transformations\n\n#### Added\n\n- Adding support for data model centric and view centric schema.\n\n## 2023-04-24\n\n### Transformations\n\n#### Removed\n\n- Removing support for authentication via API keys when creating or updating transformations.\n\n## 2023-05-04\n\n### Annotations\n\n#### Added\n\n- Added `image.InstanceLink` and `diagrams.InstanceLink` annotation types to allow you to link from objects discovered in images and engineering diagrams to data model instances.\n\n## 2023-04-18\n\n### All resources\n\n#### Added\n\n- Added information about [Requests throttling](section/Requests-throttling).\n\n#### Changed\n\n- Updated the [Parallel retrieval](section/Parallel-retrieval) documentation.\n- Aligned endpoint naming within Assets, Data sets, Events, and Files.\n\n### Assets\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101-beta/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-04-12\n\n### Sessions\n\n#### Fixed\n\n- Fixed the API documentation for the request body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated the request body schema as specifying the list of session IDs to retrieve, in the form `{\"items\": [42]}` - it should in fact be `{\"items\": [{\"id\": 42}]}`. The documentation has been updated to reflect this.\n\n- Fixed the API documentation for the response body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated `nextCursor` and `previousCursor` fields as being returned from the response, which was not the case, and these fields have now been removed from the API documentation.\n\n## 2023-04-04\n\n### Transformations\n\n#### Change\n\n- Transformations support new target types for view-centric data model instances.\n\n#### Added\n\n- Added target types `nodes` and `edges`.\n\n## 2023-03-06\n\n### Documents\n\n#### Change\n\n- Renamed \"approximateCardinality\" aggregate to \"cardinalityValues\" to unify the search spec in Cognite.\n- \"uniqueProperties\" aggregate no longer supports pagination. It returns unique properties (up to 10000) in the specified path. The results are sorted by frequency.\n\n#### Added\n\n- Added \"allUniqueProperties\" aggregate that returns all unique properties. The response contains a cursor that can be used to fetch all pages of data.\n\n## 2023-02-03\n\n### Seismic\n\n#### Added\n\n- Batch downloading of seismics as a ZIP archive is now an experimental v1 endpoint. A user requires the experimental ACL to use this endpoint, and any other ACLs and scopes to read the downloadable seismics.\n\n#### Fixed\n\n- The documentation for downloading seismics as SEG-Y files is part of v1. The API documentation didn't reflect that the endpoint had been promoted to version 1.\n\n## 2023-02-07\n\n### Documents\n\n#### Added\n\n- Added `highlight` field in the `search` endpoint to indicate whether matches in search results should be highlighted.\n\n## 2023-01-18\n\n### 3D\n\n#### Added\n\n- Added support for using names filter in list nodes endpoint.\n\n## 2023-01-17\n\n### Authentication\n\n#### Removed\n\nWe've removed authentication via CDF service accounts and API keys, and user sign-in via `/login`.\n\n### 3D\n\n#### Added\n\n- Added support for storing translation and scale for model revision.\n\n## 2023-01-12\n\n### Documents\n\n#### Added\n\n- Added support for approximateCardinality aggregate.\n\n## 2023-01-10\n\n### Documents\n\n#### Added\n\n- Added the search leaf filter, to allow filtering by searching through specified properties.\n\n## 2023-01-09\n\n### Documents\n\n#### Added\n\n- Added the uniqueProperties aggregation, which can be used to find all the metadata keys in use.\n\n## 2023-01-06\n\n### Documents\n\n#### Added\n\n- Added inAssetSubtree filter to filter documents that have a related asset in a subtree rooted at any of the specified IDs.\n\n## 2023-01-02\n\n### Documents\n\n#### Added\n\n- Added advanced filters for metadata (prefix, in, equals)\n\n## 2022-12-06\n\n### 3D\n\n#### Added\n\n- Added get3DNodesById endpoint to be able to fetch 3D nodes mapped to an asset.\n\n## 2022-12-16\n\n### Time series\n\n#### Changed\n\n- Timestamps of data points may now be as large as 4102444799999 (23:59:59.999, December 31, 2099). The previous limit was the year 2050.\n\n## 2022-11-29\n\n### Events\n\n#### Added\n\n- Added `nulls` field to the sort property specification\n\n## 2022-11-17\n\n### Time series\n\n#### Added\n\n- Added `nextCursor` field to [Retrieve data points](tag/Time-series/operation/getMultiTimeSeriesDatapoints), to support cursor pagination\n\n## 2022-10-14\n\n### Geospatial\n\n#### Added\n\n- Added the [POST /projects/{project}/geospatial/compute](tag/Geospatial/operation/compute) endpoint.\n\n## 2022-10-11\n\n### Transformations\n\n#### Added\n\n- Added capability to run a transformation with Nonce credentials provided through the Run endpoint.\n\n## 2022-10-06\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\n\n## 2022-09-09\n\n### Vision (Contextualization)\n\n#### Added\n\n- Move Vision extract service from playground to V1.\n\n## 2022-08-12\n\n### Time series\n\n#### Changed\n\n- Updated datapoints timestamp range from 1971 - 2050 to 1900 - 2050.\n  Affected endpoints:\n  - [Insert data points](tag//Time-series/operation/postMultiTimeSeriesDatapoints)\n  - [Retrieve data points](tag//Time-series/operation/getMultiTimeSeriesDatapoints)\n  - [Delete data points](tag//Time-series/operation/deleteDatapoints)\n  - [Retrieve latest data point](tag//Time-series/operation/getLatest)\n  - [Synthetic query](tag//Synthetic-Time-Series/operation/querySyntheticTimeseries)\n\n## 2022-07-21\n\n### Transformations\n\n#### Added\n\n- Added authentication using nonce for transformation's exisiting endpoints.\n\n## 2022-06-21\n\n### Annotations (Data organization)\n\n#### Added\n\n- Moved the annotation service from playground to v1.\n\n## 2022-07-07\n\n### Events\n\n#### Removed\n\n- End-of-life for [filter.rootAssetIds](tag/Events/operation/advancedListEvents) filtering attribute.\n\n## 2022-06-13\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/revoke](tag/Sessions/operation/revokeSessions) endpoint.\n\n## 2022-05-20\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/aggregate` endpoint. The endpoint allows you to count documents optionally grouped by a property and also to retrieve all unique values of a property.\n\n## 2022-05-12\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/list` endpoint. The endpoint allows you to iterate through all the documents in a project.\n- Added the `POST /documents/{documentId}/content` endpoint. The endpoint lets you download the entire extracted plain text of a document.\n\n## 2022-04-11\n\n### Documents\n\n#### Added\n\n- Added the [GET /documents/{documentId}/preview/image/pages/{pageNumber}](tag/Document-preview/operation/documentsPreviewImagePage) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf](tag/Document-preview/operation/documentsPreviewPdf) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf/temporarylink](tag/Document-preview/operation/documentsPreviewPdfTemporaryLink) endpoint.\n\n## 2022-03-15\n\n### Sequences\n\n#### Changed\n\n- Changed sequences column limits. Old limit of maximum total 200 columns limits is updated to maximum 400 total columns, maximum 400 numeric columns and maximum 200 string columns.\n\n## 2022-03-02\n\n### Sequences\n\n#### Added\n\n- Added the [POST /sequences/data/latest](tag/Sequences/operation/getLatestSequenceRow) endpoint.\n\n## 2022-02-08\n\n### Time series\n\n#### Changed\n\n- Marked `isStep` parameter to be editable (i.e. removed description stating it is not updatable) in [POST /timeseries/create](tag/Time-series/operation/postTimeSeries).\n\n#### Added\n\n- Added `isStep` parameter to the `TimeSeriesPatch` object used in [POST /timeseries/update](tag/Time-series/operation/alterTimeSeries)\n\n## 2022-02-07\n\n### Documents\n\n#### Added\n\n- The [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint now supports pagination.\n\n## 2022-01-25\n\n### Documents\n\n#### Added\n\n- Added the [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint.\n\n## 2022-01-24\n\n### Time series\n\n#### Added\n\n- Added optional `ignoreUnknownIds` parameter to [POST /sequences/delete](tag/Sequences/operation/deleteSequences). Setting this to true will prevent the operation from failing if one or more of the given sequences do not exist; instead, those given sequences that do exist will be deleted.\n\n## 2021-12-07\n\n### Transformations\n\n#### Added\n\n- New [Transformations](tag//Transformations) APIs to v1 to create,retrieve,list and delete transformations\n- New [Transformation Jobs](tag//Transformation-Jobs) APIs to v1 to retrieve and list transformation jobs or job metrics\n- New [Transformation Schedule](tag//Transformation-Schedules) APIs to v1 to manage schedules of transformations\n- New [Transformation Notifications](tag//Transformation-Notifications) APIs to v1 to manage notifications from transformation job\n\n## 2021-11-22\n\n### Contextualization\n\n#### Added\n\n- Added [diagram detect](tag/Engineering-diagrams/operation/diagramDetect) endpoint to v1 to detect annotations in engineering diagrams\n- Added [diagram detect results](tag/Engineering-diagrams/operation/diagramDetectResults) endpoint to v1 to get the results from an engineering diagram detect job\n- Added [diagram convert](tag/Engineering-diagrams/operation/diagramConvert) endpoint to v1 to create interactive engineering diagrams in SVG format with highlighted annotations\n- Added [diagram convert results](tag/Engineering-diagrams/operation/diagramConvertResults) endpoint to v1 to get the results for a job converting engineering diagrams to SVGs\n\n## 2021-11-17\n\n### 3D\n\n#### Added\n\n- Added `dataSetId` support to 3D models enabling data access scoping of 3D data\n\n## 2021-10-13\n\n### Raw\n\n#### Changed\n\n- To align with Microsoft Azure clusters, table and database names are now sensitive to trailing spaces also in Google Cloud Platform clusters.\n\n## 2021-10-05\n\n### Extraction Pipelines\n\n#### Added\n\n- New [Extraction Pipelines](tag//Extraction-Pipelines) resource to document extractors and monitor the status of data ingestion to make sure reliable and trustworthy data are flowing into the CDF data sets.\n- API endpoints for creating, managing, and deleting extraction pipelines. Capture common attributes around extractors such as owners, contacts, schedule, destination RAW databases, and data set. Document structured metadata in the form of key-value attributes as well unstructured `documentation` attribute that supports Markdown (rendered as Markdown in Fusion).\n- Extraction Pipelines Runs are CDF objects to store statuses related to an extraction pipeline. The supported statuses are: `success`, `failure` and `seen`. They enable extractor developers to report status and error message after ingesting data. As well enables for reporting heartbeat through `seen` status by the extractor to easily identify issues related to crushed applications and scheduling issues.\n\n## 2021-09-28\n\n### Sequences\n\n#### Added\n\n- Added `partition` parameter to the [GET /sequences](tag/Sequences/operation/listSequences) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n- [POST /sequences/list](tag/Sequences/operation/advancedListSequences) now supports [parallel retrieval](section/Parallel-retrieval).\n\n### Time series\n\n#### Added\n\n- Added `partition` parameter to the [GET /timeseries](tag/Time-series/operation/getTimeSeries) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n\n## 2021-08-18\n\n### IAM (Identity and access management)\n\n#### Added\n\nAdded sessions to [v1](tag//Sessions). Sessions let you securely delegate access to CDF resources for CDF services (such as Functions) by an external principal and for an extended time.\n\n## 2021-08-12\n\n### Relationships\n\n#### Added\n\n- Relationships now support [Parallel Retrieval](section/Parallel-retrieval)\n\n## 2021-07-01\n\n### 3D\n\n#### Added\n\n- Added filter3dNodes endpoint to allow for more advanced filtering on node metadata\n\n## 2021-06-29\n\n### Labels\n\n#### Added\n\n- [Dataset scoping](tag/Labels/operation/listLabels) based on `dataSetIds`.\n\n## 2021-06-08\n\n### Sequences\n\n#### Added\n\n- Added [syntax for updating columns](tag/Sequences/operation/updateSequences) of existing sequences. Can `remove` columns, `modify` existing columns, and `add` new columns as well.\n\n## 2021-06-01\n\n### Assets\n\n#### Added\n\n- Added labels replace (set) method for [assets update](tag/Assets/operation/updateAssets).\n\n## 2021-04-28\n\n### Time series\n\n#### Changed granularity limits on hour aggreagates\n\nYou can now ask for a [granularity](https://docs.cognite.com/dev/concepts/aggregation/#granularity)\nof up to 100000 hours (previously 48 hours), both in normal aggregates and in synthetic time series.\n\n## 2021-04-12\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added a [projects list](tag/Projects/operation/listProjects) endpoint to v1\n- Added a [token inspection](tag/Token/operation/inspectToken) endpoint to v1\n\n## 2021-04-06\n\n### Authentication\n\n#### Deprecated\n\nWe are deprecating authentication via CDF service accounts and API keys, and user sign-in via `/login`, in favor of registering applications and services with your IdP (identity provider) and [using OpenID Connect](https://docs.cognite.com/cdf/access/) and the IdP framework to manage CDF access securely.\n\nThe legacy authentication flow is available for customers using Cognite Data Fusion (CDF) on GCP until further notice. We strongly encourage customers to adopt [the new authentication flows](https://docs.cognite.com/cdf/access/) as soon as possible.\n\nThe following API endpoints are deprecated:\n\n- `/api/v1/projects/*/apikeys`\n- `/api/v1/projects/*/serviceaccounts`\n- `/login`\n- `/logout`\n- `/api/v1/projects/*/groups/serviceaccounts` <sup>\\*</sup>\n\n<sup>\\*</sup>only the sub-resources for listing, adding, and removing members of groups.\n\n## 2021-03-22\n\nCDF API 0.5, 0.6 reached their end-of-life after its initial deprecation announcement in Summer 2019.\n\n## 2021-03-10\n\n### 3D\n\n#### Added\n\n- Added `partition` parameter to the List 3D Nodes endpoint for supporting parallel requests.\n- Added `sortByNodeId` parameter to the List 3D Nodes endpoint, improving request latency in most cases if set to `true`.\n\n## 2021-02-26\n\n### Entity matching\n\n#### Fixed\n\n- Fixed a bug in the documentation for Entity matching. The (job) `status` shall be capitalized string.\n\n## 2020-12-22\n\n### Files\n\n#### Added\n\n- New field `fileType` inside `derivedFields` to refer to a pre-defined subset of MIME types.\n- New filter `fileType` inside `derivedFields` to find files with a pre-defined subset of MIME types.\n\n## 2020-10-20\n\n### Files\n\n#### Added\n\n- New field `geoLocation` to refer to the geographic location of the file.\n- New filter `geoLocation` to find files matching a certain geographic location.\n\nTo learn how to leverage new geoLocation features, [follow our guide](https://developer.cognite.com/dev/concepts/resource_types/files.html).\n\n## 2020-08-29\n\n### Files\n\n#### Added\n\n- New field `directory` referring to the directory in the source containing the file.\n- New filter `directoryPrefix` allows you to find Files matching a certain directory prefix.\n\n## 2020-08-05\n\n### Files\n\n#### Added\n\n- New field `labels` allows you to attach labels to Files upon creation or updating.\n- New filter `labels` allows you to find Files that have been annotated with specific labels.\n\n## 2020-07-08\n\n### IAM (Identity and access management)\n\n#### Added\n\n- New project field `applicationDomains`. If this field is set, users only sign in to the project through applications hosted on\n  a whitelisted domain. [Read more](https://developer.cognite.com/dev/guides/iam/#application-domains).\n\n## 2020-07-01\n\n### Events\n\n#### Added\n\n- New aggregation [`uniqueValues`](tag/Events/operation/aggregateEvents) allows you to find different types, subtypes of events in your project.\n\n## 2020-06-29\n\n### Labels\n\n#### Added\n\n- New data organization resource: [labels](tag//Labels). Manage terms that you can use to annotate and group assets.\n\n### Assets\n\n#### Added\n\n- New filter `labels` allows you to find resources that have been annotated with specific labels.\n\n### Time series\n\n#### Added\n\n- Combine various input time series, constants and operators with on-the-fly [synthetic time series](https://developer.cognite.com/dev/concepts/resource_types/synthetic_timeseries.html).\n\n## 2020-04-28\n\n### Events\n\n#### Added\n\n- New filtering capabilities to find open events [`endTime=null`](tag/Events/operation/advancedListEvents).\n- New filtering capabilities to find all events intersecting a timespan using [activeAtTime](tag/Events/operation/advancedListEvents).\n\n## 2020-03-12\n\n### General\n\n#### Added\n\n- New data organization resource: [data sets](tag//Data-sets). Document and track data lineage, ensure data integrity, and allow 3rd parties to write their insights securely back to your Cognite Data Fusion (CDF) project.\n- New attribute `datasetId` introduced in assets, files, events, time series and sequences.\n- New filter `dataSetIds` allows you to narrow down results to resources containing `datasetId` by a list of ids or externalIds of a data set. Supported by assets, files, events, time series and sequences.\n- We have added a new aggregation endpoint for [time series](tag/Files/operation/aggregateFiles). With this endpoint, you can find out how many results in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Groups\n\n#### Added\n\n- Introduced a new capability: `datasetsAcl` for managing access to data set resources.\n- New scope `datasetScope` for assets, files, events, time series and sequences ACLs. Allows you to scope down access to resources contained within a specified set of data sets.\n\n## 2020-03-10\n\n### 3D\n\n#### Fixed\n\n- We fixed a bug in the documentation of [3D model revisions](tag/3D-Model-Revisions/operation/get3DNodesById). Applications should anticipate that 3D nodes may not have a bounding box.\n\n## 2020-02-25\n\n### Assets\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Assets/operation/aggregateAssets) for assets. With this endpoint, you can find out how many assets in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Events\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Events/operation/aggregateEvents) for events. With this endpoint, you can find out how many events in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n## 2020-02-12\n\n### Assets\n\n#### Added\n\n- We have added new aggregation properties: `depth` and `path`. You can use the properties in the filter and retrieve endpoints.\n\n## 2020-02-10\n\n### Assets\n\n#### Added\n\n- Added the property `parentExternalId` which is returned for all assets which have a parent with a defined `externalId`.\n\n## 2019-12-09\n\n### General\n\n#### Added\n\n- Added `assetSubtreeIds` as a parameter to filter, search, and list endpoints for all core resources. `assetSubtreeIds` allows you to specify assets that are subtree roots, and then only retrieve resources that are related to assets within those subtrees.\n\n## 2019-12-04\n\n### Assets\n\n#### Added\n\n- Added the ability to [filter](tag/Assets/operation/searchAssets) assets by parent external IDs.\n\n## 2019-11-18\n\n### Events\n\n#### Added\n\n- [Added the ability to filter events by the external ID of linked assets](tag/Events/operation/advancedListEvents)\n\n## 2019-11-12\n\n### Access control\n\n#### Removed\n\n- Groups can no longer be created with a permissions field in v0.5.\n\n## 2019-10-31\n\n### Assets\n\n#### Added\n\n- [Asset search](/api/v1/#operation/searchAssets) now has a `search.query` parameter. This uses an improved search algorithm that tries a wider range of variations of the input terms and gives much better relevancy ranking than the existing `search.name` and `search.description` fields.\n\n### Time Series\n\n#### Changed\n\n- The `search.query` parameter for [time series search](/api/v1/#operation/searchTimeSeries) now uses an improved search algorithm that tries a wider range of variations of the input terms, and gives much better relevancy ranking.\n\n## 2019-10-23\n\n### Files\n\n#### Added\n\n- Added support for updating the `mimeType` for existing files in files/update requests.\n\n## 2019-10-18\n\n### Time Series\n\n#### Added\n\n- Time series expanded their filtering capabilities with new `Filter time series` endpoint, allowing for additional filtering by:\n\n  - Name\n  - Unit\n  - Type of time series: string or step series\n  - Metadata objects\n  - ExternalId prefix filtering\n  - Create and last updated time ranges\n\n  Endpoint in addition support pagination and partitioning. Check out detailed API documentation [here](/api/v1/#operation/listTimeSeries).\n\n## 2019-10-16\n\n### Events\n\n#### Added\n\n- [Added the ability to sort events on startTime, endTime, createdTime, and lastUpdatedTime](tag/Events/operation/advancedListEvents)\n\n## 2019-10-02\n\n### Sequences\n\n#### Added\n\n- Introducing the new **sequences** core resource type that lets you store numerically indexed multi-column rows of data. Connect your sequences to physical assets and to their source systems through `externalId` and metadata support. Read more [here](https://developer.cognite.com/dev/concepts/resource_types/sequences.html).\n\n## 2019-09-30\n\n### 3D\n\n#### Added\n\n- Added endpoint to get multiple nodes for a 3D model by their IDs.\n- Added endpoint to get asset mappings for multiple node IDs or asset IDs.\n\n## 2019-09-23\n\n### Files\n\n#### Added\n\n- Added support for filter on `rootAssetIds` in files GET /files (using query parameter) and POST /files/list (in request body).\n\n## 2019-09-16\n\n### Assets and Events\n\n#### Added\n\n- Added support for `partition` in `/assets` and `/events` to support parallel retrieval. See guide for usage [here](./concepts/pagination)\n\n## 2019-08-22\n\n### 3D\n\n#### Added\n\n- Added the query parameter `intersectsBoundingBox` to the list asset mappings endpoint. The parameter filters asset mappings to the assets where the bounding box intersects (or is contained within) the specified bounding box.\n\n## 2019-08-21\n\n### Files\n\n#### Added\n\n- Added support for sourceCreatedTime and sourceModifiedTime fields in files v1 endpoints.\n\n### Assets\n\n#### Added\n\n- Allow the parent asset ID to be updated. The root asset ID must be preserved, and you can not convert a non-root asset to a root asset or vice versa.\n- Support for ignoreUnknownIds when deleting assets.\n\n## 2019-08-15\n\n### 3D\n\n#### Added\n\n- Properties field for 3D nodes, extracted from uploaded 3D files.\n- Ability to filter nodes with a specific set of properties.\n\n## 2019-07-24\n\n### Files\n\n#### Changed\n\n- Allow lookup of names with length up to 256 characters (was 50) for GET /files and POST /files/search operations.\n- Allow creating and retrieving files with mimeType length up to 256 characters (was 64).\n\n## 2019-07-15\n\n### Time series\n\n#### Added\n\n- Added query parameter `rootAssetIds` to list time series endpoint. Returns time series that are linked to an asset that has one of the root assets as an ancestor.\n\n## 2019-07-11\n\nList of changes for initial API v1 release in comparison to previous version - API 0.5\n\n### General\n\n#### Added\n\n- Support for `externalId` added across resource types. `externalId` lets you define a unique ID for a data object. Learn more: [External IDs](https://developer.cognite.com/dev/concepts/external_id.html)\n- `externalIdPrefix` added as a parameter to the list events, assets and files operations.\n- Richer filtering on the list assets, files and events operations.\n- Search, list and filter operations for assets, events and files now support filtering on source and metadata field values.\n\n#### Changed\n\n- Core resources standardize on HTTP methods and URI naming for common operations such as search, partial updates, delete, list and filter\n- API responses are no longer wrapped in a top level `data` object.\n- Standardized pagination across resources through `limit`, `cursor` and `nextCursor` parameters.\n- The `limit` parameter no longer implicitly rounds down requested page size to maximum page size.\n- Standardized error responses and codes across all resources. Errors across CDF can be parsed into a single model.\n- Overall improvements to reference documentation. Including documented input constraints, required fields, individual attribute descriptions.\n\n#### Removed\n\n- The `sourceId` field has been removed from resources. Use `externalId` instead of `sourceId`+`source` to define unique IDs for data objects.\n- Sorting is removed from the search operations for files, assets, events and time series. Results are sorted by relevance.\n- `offset` and `previousCursor` parameters are no longer supported for pagination across resources.\n- Fetching an asset subtree is no longer supported by files, assets, events and time series.\n\n### Assets\n\n#### Added\n\n- Ability to select only root assets though new `root` filter.\n- Added the `rootId` field to specify the top element in an asset hierarchy.\n- Added the ability to filter by the root asset ID. This allows you to scope queries for one or many asset hierarchies.\n- List Assets allows for filtering assets belonging to set of root assets, specified by list of asset internal ids. New query parameter: `rootIds`.\n- Filter and Search Assets allows or filtering assets belonging to a set of root assets, specified by combination of internal and external asset identifiers. New body attribute: `rootIds`.\n\n#### Changed\n\n- Updating a single asset is no longer supported through a separate endpoint. Use the update multiple endpoint instead.\n- Delete assets by default removes only leaf assets (assets without children). New parameter 'recursive' allows for enabling recursive removal of the entire subtree of the asset pointed by ID (API 0.5 behaviour).\n\n#### Removed\n\n- Overwriting assets is no longer supported.\n- Filtering assets by their complete description is no longer supported.\n- Locating assets fuzzily by name has been removed. Instead, search for assets on the `name` property.\n- When searching assets, querying over both name and description in the same query is no longer supported.\n- The experimental query parameter `boostName` has been removed from the search for assets operation.\n- Removed the `path` and `depth` fields.\n\n### Events\n\n#### Added\n\n- Events can now be filtered on asset ID in combination with other filters.\n- New filter `rootAssetIds` allows for narrowing down events belonging only to list or specified root assets. Supported by Filter and Search API\n\n#### Removed\n\n- Events can no longer be filtered by empty description.\n- The 'dir' parameter has been removed from the search events operation.\n\n### Files\n\n#### Added\n\n- Filtering files by `assetIds` in list files operations now support multiple assets in the same request.\n\n#### Changed\n\n- Download file content has changed from HTTP GET to HTTP POST method.\n- We have renamed the `fileType` field to `mimeType`. The field now requires a MIME formatted string (e.g. `text/plain`).\n- We have renamed the `uploadedAt` field to `uploadedTime`.\n- Resumable is now the default behavior for file uploads.\n- Update metadata for single files is no longer supported by a separate operation. Instead, use the update multiple operation.\n\n#### Removed\n\n- Replace files metadata endpoint has been removed.\n- Directory has been removed as a property of files.\n- Updating the `name` or `mimeType` of a file through the update multiple files operation is no longer supported.\n- Query parameter for specifying the sort direction has been removed from list all files operations.\n\n### Raw\n\n#### Changed\n\n- Raw has changed structure to become resource-oriented. The URL structure has changed.\n- Recursively delete of tables and rows when deleting a database is now the default behavior without a control parameter.\n\n### Time series\n\n#### Added\n\n- Support for adding datapoints by `id` and `externalId` of time series. Adding datapoints to time series by `name` has been removed.\n- Add ability to update the new `externalId` attribute for time series.\n- Allow to set `externalId` during creation of time series. `ExternalId` requires uniqueness across time series.\n- Consolidate multiple APIs to allow adding datapoints into a single endpoint. Allows datapoints to be added to multiple time series at the same time.\n- Retrieve data points by using `id` and `externalId` of the time series.\n- Time series created through API v1 are not discoverable by API 0.3, 0.4, 0.5 and 0.6 by default. Introduce the option to enable this compatibility by setting new attribute - `legacyName` on time series creation. Value is required to be unique.\n\n#### Changed\n\n- Get latest datapoints has been reworked. Introduces support for `id` and `externalId` lookup as well retrieval for multiple time series within the same request.\n- Time series name is no longer limited by uniqueness. Note that time series (meta objects) created by API v1 will not be discoverable by older API versions.\n- Delete time series endpoint has been redesigned to allow deletion of multiple time series by `id` and `externalId`.\n- Delete single and multiple datapoints endpoint has been redesigned and consolidated into a single endpoint. New delete allows selection of multiple time series and time ranges by `id` and `externalId`. Selecting by `name` is no longer available.\n- Update multiple time series restructured to support lookup by `externalId`.\n- Retrieve time series by ID endpoint restructured adding the ability to get time series by `externalId`.\n- Set limit for data point value to min -1E100, max 1E100.\n\n#### Removed\n\n- Experimental feature for performing calculations across multiple time series (synthetic time series), function and alias attributes are no longer available.\n- The experimental query parameter `boostName` has been removed from search operation.\n- Short names for aggregate functions are no longer supported.\n- Ability to remove time series by `name` have been removed as names are no longer unique identifiers.\n- Select multiple time series and time ranges by `name` is no longer available.\n- The ability to update `isString` and `isStep` attributes is removed. The attributes are not intended to be modified after creation of time series.\n- The endpoint for updating single time series is removed. Use the update multiple time series endpoint instead.\n- Remove ability to overwrite time series object by `id`. Use the update multiple time series endpoint instead.\n- The ability to retrieve time series matching by `name` has been removed. Use `externalId` instead.\n- The ability to retrieve by `id` from a single time series has been removed. Use retrieve multiple datapoints for multiple time series instead.\n- The ability to retrieve time-aligned datapoints through \"dataframe\" API has been removed. Similar functionality is available through our supported SDKs.\n- The ability to add datapoints to time series by `name` has been removed.\n- The ability to look up by time series `name` has been removed.\n\n### IAM (Identity and access management)\n\n#### Added\n\n- The login status endpoint includes the ID of the API key making the request (new attribute: `apiKeyId`), if the request used an API key.\n\n#### Changed\n\n- The user resource type has been replaced with service accounts. Users from previous API versions are equivalent to service accounts.\n- Adding, listing and removing users from a group has been replaced by equivalent operations for service accounts.\n- Retrieve project returns a single object instead of a list.\n- API keys endpoints for list/create rename `userId` attribute to `serviceAccountId`.\n\n#### Removed\n\n- List and create groups no longer use the `permissions` and `source` attributes.\n\n### 3D\n\n#### Added\n\n- New 3D API lets you upload and process 3D models. Supported format: FBX.\n- Ability to create and maintain multiple revisions for the 3D models.\n- API for mapping relationships between 3D model nodes and asset hierarchy.\n"
     },
     {
       "name": "Token",
@@ -64123,7 +63852,7 @@
     },
     {
       "name": "Data point subscriptions",
-      "description": "A data point subscription is a way to listen to changes to time series data points, in ingestion order.\n\nA single subscription can listen to many time series, and a time series can be part of many subscriptions.\n\nYou listen to subscriptions by calling the “list subscription data“ endpoint. It will return\na list of data point upserts and deleted ranges, together with a cursor to retrieve the next\nbatch of updates. Updates written since the creation of the subscription, up to 7 days ago, can be\nretrieved through the subscription.\n\nSubscriptions can be defined explicitly through a list of time series external ids, or\nimplicitly through a filter. The filter is a subset of the advanced filter query in the regular\n“time series search“ endpoint.\n\nPartitions:\nSubscriptions can be further divided into a number of partitions, for the purpose of\nfetching subscription data in parallel. Each partition will return data in ingestion order,\nbut the order between partitions is not guaranteed.\n\nLimitations:\n- Each subscription can have at most 10000 time series\n- A time series can be part of at most 10 subscriptions\n- A project can have at most 1000 subscriptions, of which 100 filter subscriptions\n- Time series with security categories can not be shown in filter subscriptions\n- Time series without externalId cannot be added to non-filter subscriptions\n- The number of partitions cannot be changed after creation\n\nAccess control: You need READ access to subscriptions ACL to read/list\nsubscriptions or list data, and you need WRITE access to create/update/delete subscriptions.\nFurthermore, you need READ access to the time series you want to get updates from.\nFor filter subscriptions, you either need READ access to all time series, or the filter must\nbe restricted according to your access rights (e.g. by filtering on specific data set IDs).\n\nSubscriptions can have data sets that allow for more granular access\ncontrol. The data set on a subscription does not influence the data\nstream, but allows you to restrict who can read/update the subscription.\n\nExample capabilities:\n```\n[\n    {\"timeSeriesAcl\":{\"actions\":[\"READ\"], \"scope\":{\"all\":{}}}},\n    {\"timeSeriesSubscriptionsAcl\":{\"actions\":[\"WRITE\", \"READ\"], \"scope\":{\"all\":{}}}}\n]\n```"
+      "description": "A data point subscription is a way to listen to changes to time series data points, in ingestion order.\n\nA single subscription can listen to many time series, and a time series can be part of many subscriptions.\n\nYou listen to subscriptions by calling the “list subscription data“ endpoint. It will return\na list of data point upserts and deleted ranges, together with a cursor to retrieve the next\nbatch of updates. Updates written since the creation of the subscription, up to 7 days ago, can be \nretrieved through the subscription.\n\nSubscriptions can be defined explicitly through a list of time series external ids, or\nimplicitly through a filter. The filter is a subset of the advanced filter query in the regular\n“time series search“ endpoint.\n\nPartitions:\nSubscriptions can be further divided into a number of partitions, for the purpose of\nfetching subscription data in parallel. Each partition will return data in ingestion order,\nbut the order between partitions is not guaranteed.\n\nLimitations:\n- Each subscription can have at most 10000 time series\n- A time series can be part of at most 10 subscriptions\n- A project can have at most 1000 subscriptions, of which 100 filter subscriptions\n- Time series with security categories can not be shown in filter subscriptions\n- Time series without externalId cannot be added to non-filter subscriptions\n- The number of partitions cannot be changed after creation\n\nAccess control: You need READ access to subscriptions ACL to read/list\nsubscriptions or list data, and you need WRITE access to create/update/delete subscriptions.\nFurthermore, you need READ access to the time series you want to get updates from.\nFor filter subscriptions, you either need READ access to all time series, or the filter must\nbe restricted according to your access rights (e.g. by filtering on specific data set IDs).\n\nSubscriptions can have data sets that allow for more granular access\ncontrol. The data set on a subscription does not influence the data\nstream, but allows you to restrict who can read/update the subscription.\n\nExample capabilities:\n```\n[\n    {\"timeSeriesAcl\":{\"actions\":[\"READ\"], \"scope\":{\"all\":{}}}},\n    {\"timeSeriesSubscriptionsAcl\":{\"actions\":[\"WRITE\", \"READ\"], \"scope\":{\"all\":{}}}}\n]\n```"
     },
     {
       "name": "Synthetic Time Series",
@@ -64162,7 +63891,7 @@
     },
     {
       "name": "Entity matching",
-      "description": "The entity matching contextualization endpoints lets you match CDF resources. For example, you can match time series to assets. The model uses similarity between string-fields from the source and the target to find potential matches, for instance the source name and the target name. The exact algorithm may change over time."
+      "description": "The entity matching contextualization endpoints lets you match CDF resources.  For example, you can match time series to assets. The model uses similarity between string-fields from the source and the target to find potential matches, for instance the source name and the target name. The exact algorithm may change over time."
     },
     {
       "name": "Vision",

--- a/packages/stable/src/api/annotations/types.gen.ts
+++ b/packages/stable/src/api/annotations/types.gen.ts
@@ -7,7 +7,7 @@
 attribute.
 * @example {"assetRef":{"externalId":"abc"},"symbolRegion":{"xMin":0.1,"xMax":0.2,"yMin":0.1,"yMax":0.2},"textRegion":{"xMin":0.2,"xMax":0.3,"yMin":0.2,"yMax":0.3},"pageNumber":43}
 */
-export type AnnotationData = AnnotationsBoundingVolume | AnnotationsClassification | AnnotationsDetection | AnnotationsExtractedText | AnnotationsFileLink | AnnotationsIsoPlanAnnotation | AnnotationsJunction | AnnotationsKeypointCollection | AnnotationsLine | AnnotationsObjectDetection | AnnotationsTextRegion | AnnotationsUnhandledSymbolObject | AnnotationsUnhandledTextObject | AnnotationsCogniteAnnotationTypesDiagramsAssetLink | AnnotationsCogniteAnnotationTypesDiagramsInstanceLink | AnnotationsCogniteAnnotationTypesImagesAssetLink | AnnotationsCogniteAnnotationTypesImagesInstanceLink;
+export type AnnotationData = AnnotationsObjectDetection | AnnotationsClassification | AnnotationsKeypointCollection | AnnotationsCogniteAnnotationTypesImagesAssetLink | AnnotationsTextRegion | AnnotationsCogniteAnnotationTypesImagesInstanceLink | AnnotationsIsoPlanAnnotation | AnnotationsCogniteAnnotationTypesDiagramsAssetLink | AnnotationsFileLink | AnnotationsCogniteAnnotationTypesDiagramsInstanceLink | AnnotationsUnhandledTextObject | AnnotationsUnhandledSymbolObject | AnnotationsExtractedText | AnnotationsLine | AnnotationsJunction | AnnotationsBoundingVolume | AnnotationsDetection;
 /**
  * A reference to an asset. Either the internal ID or the external ID must be provided (exactly one).
  */
@@ -197,15 +197,28 @@ export interface AnnotationsCogniteAnnotationTypesImagesInstanceLink {
 PolyLine.
 */
 export interface AnnotationsCogniteAnnotationTypesPrimitivesGeometry2DGeometry {
+    /** A plain rectangle */
     boundingBox?: AnnotationsBoundingBox;
+    /**
+     * A _closed_ polygon represented by _n_ vertices. In other words, we assume
+     * that the first and last vertex are connected.
+     */
     polygon?: AnnotationsPolygon;
+    /** A polygonal chain consisting of _n_ vertices */
     polyline?: AnnotationsPolyLine;
 }
 /**
  * A 3D geometry model represented by exactly *one of* `cylinder` and `box`.
  */
 export interface AnnotationsCogniteAnnotationTypesPrimitivesGeometry3DGeometry {
+    /**
+     * A box in 3D space, defined by a 4x4 row-major homogeneous transformation matrix that rotates,
+     * translates and scales a box centered at the origin to its location and orientation in 3D space.
+     * The box that is transformed is the axis-aligned cube spanning the volume between
+     * the points (-1, -1, -1) and (1, 1, 1).
+     */
     box?: AnnotationsBox;
+    /** A cylinder in 3D space, defined by the centers of the two end surfaces and the radius. */
     cylinder?: AnnotationsCylinder;
 }
 /**
@@ -334,48 +347,34 @@ export interface AnnotationsInstanceRef {
  * Model a custom link in a engineering diagram where it capture details from the texts and linked to assets when necessary
  */
 export interface AnnotationsIsoPlanAnnotation {
-    /** Detail describing the equipment. */
+    /** The asset this annotation is pointing to */
+    assetRef?: AnnotationsAssetRef;
+    /** Detail describing the equipment, not identifying it. E..g 12V12 for a valve. */
     detail?: string;
-    /** Contains a link to a file in CDF. This is used to navigate between files. */
-    fileRef?: AnnotationsFileRef;
-    /** The indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. E.g. first valve upstreams of <indirectExternalId>. */
+    /** indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. E.g. this is the <indirectRelation> of <indirectExternalId> */
     indirectExternalId?: AnnotationsAssetRef;
-    /** Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'upstreams of'. This references the 'indirectExternalId'. */
+    /** Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'second valve upstreams of'. This references the 'indirectExternalId' */
     indirectRelation?: string;
-    /** The id of the Pipe that the hotspot belongs to. */
+    /** The id of the Pipe that the hotspot belongs to */
     lineExternalId?: AnnotationsAssetRef;
-    /** Stores Functional Location (FLOC) external ID represented by the hotspot. */
-    linkedResourceExternalId?: string;
-    /** Stores the Functional Location (FLOC) ID represented by the hotspot. */
-    linkedResourceInternalId?: number;
-    /** Whether the hotspot represents an asset (FLOC) or file. */
-    linkedResourceType?: "asset" | "file";
-    /** Temporary field for migration purposes. Id of corresponding legacy annotation. */
-    oldAnnotationId?: string;
     /**
      * The number of the page on which this annotation is located. The first page has number 1.
      * @min 1
      * @max 100000
      */
     pageNumber?: number;
-    /** Relative position of the relation connecting the hotspot to a tag. E.g. '2nd'. This references the 'indirectExternalId'. */
+    /** Indicate the relative position of an annotation */
     relativePosition?: string;
-    /** Revision number of the P&ID file that the hotspot is valid for. */
+    /** Keeps track of the modification to an annotation */
     revision?: string;
-    /** Stores the dimensions of a valve or spade. */
+    /** Store the dimensions of a valve or spade */
     sizeAndClass?: AnnotationsSizeAndClassType;
-    /** Marks the hotspot as user created or detected via pipeline. */
-    sourceType?: "pipeline" | "user";
-    /** Additional details, the fluid code for pipes e.g. LO for Lube oil etc. */
-    subDetail?: string;
-    /** Text found in the area, might be a FLOC, valve detail, pipe or diagram name. */
+    /** The text input */
     text?: string;
-    /** The location of the hotspot represented with a bounding box. */
+    /** The location of the hotspot represented with a bounding box */
     textRegion?: AnnotationsBoundingBox;
     /** Type of equipment, valve, pump etc. */
     type?: string;
-    /** Stores the (x,y) coordinate pairs of a line or polyline. */
-    vertices?: AnnotationsPolyLine;
 }
 /**
  * Models a junction between lines in an engineering diagram
@@ -457,6 +456,7 @@ optionally a confidence value.
 export interface AnnotationsObjectDetection {
     /** Additional attributes data for a compound. */
     attributes?: Record<string, AnnotationsBoolean | AnnotationsNumerical>;
+    /** A plain rectangle */
     boundingBox?: AnnotationsBoundingBox;
     /**
      * The confidence score for the primitive. It should be between 0 and 1.
@@ -466,7 +466,12 @@ export interface AnnotationsObjectDetection {
     confidence?: number;
     /** The label describing what type of object it is */
     label: string;
+    /**
+     * A _closed_ polygon represented by _n_ vertices. In other words, we assume
+     * that the first and last vertex are connected.
+     */
     polygon?: AnnotationsPolygon;
+    /** A polygonal chain consisting of _n_ vertices */
     polyline?: AnnotationsPolyLine;
 }
 /**

--- a/packages/stable/src/api/vision/types.gen.ts
+++ b/packages/stable/src/api/vision/types.gen.ts
@@ -79,8 +79,14 @@ export interface AnnotationsCogniteAnnotationTypesImagesAssetLink {
 PolyLine.
 */
 export interface AnnotationsCogniteAnnotationTypesPrimitivesGeometry2DGeometry {
+    /** A plain rectangle */
     boundingBox?: AnnotationsBoundingBox;
+    /**
+     * A _closed_ polygon represented by _n_ vertices. In other words, we assume
+     * that the first and last vertex are connected.
+     */
     polygon?: AnnotationsPolygon;
+    /** A polygonal chain consisting of _n_ vertices */
     polyline?: AnnotationsPolyLine;
 }
 /**
@@ -135,6 +141,7 @@ optionally a confidence value.
 export interface AnnotationsObjectDetection {
     /** Additional attributes data for a compound. */
     attributes?: Record<string, AnnotationsBoolean | AnnotationsNumerical>;
+    /** A plain rectangle */
     boundingBox?: AnnotationsBoundingBox;
     /**
      * The confidence score for the primitive. It should be between 0 and 1.
@@ -144,7 +151,12 @@ export interface AnnotationsObjectDetection {
     confidence?: number;
     /** The label describing what type of object it is */
     label: string;
+    /**
+     * A _closed_ polygon represented by _n_ vertices. In other words, we assume
+     * that the first and last vertex are connected.
+     */
     polygon?: AnnotationsPolygon;
+    /** A polygonal chain consisting of _n_ vertices */
     polyline?: AnnotationsPolyLine;
 }
 /**


### PR DESCRIPTION
Reverts cognitedata/cognite-sdk-js#1103

- This PR do not reflect the breaking change it introduces by making fileRef optional.
- A fix is made for the breaking change in this [PR](https://github.com/cognitedata/fusion/pull/6966/files)