### PR TITLE
test: skip pagination test temporarily

### DIFF
--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -228,7 +228,7 @@ describe('alerts api', () => {
 
   vi.setConfig({ testTimeout: 30_000 });
 
-  test('cursor pagination', async () => {
+  test.skip('cursor pagination', async () => {
     // create channel for the next test
     const channelsToCreate = [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,8 +3313,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-alpha@workspace:packages/alpha"
   dependencies:
-    "@cognite/sdk": "npm:^9.15.3"
-    "@cognite/sdk-core": "npm:^4.10.3"
+    "@cognite/sdk": "npm:^9.15.4"
+    "@cognite/sdk-core": "npm:^4.10.4"
   languageName: unknown
   linkType: soft
 
@@ -3322,8 +3322,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-beta@workspace:packages/beta"
   dependencies:
-    "@cognite/sdk": "npm:^9.15.3"
-    "@cognite/sdk-core": "npm:^4.10.3"
+    "@cognite/sdk": "npm:^9.15.4"
+    "@cognite/sdk-core": "npm:^4.10.4"
   languageName: unknown
   linkType: soft
 
@@ -3333,7 +3333,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk-core@npm:^4.10.3, @cognite/sdk-core@npm:^4.9.0, @cognite/sdk-core@workspace:packages/core":
+"@cognite/sdk-core@npm:^4.10.4, @cognite/sdk-core@npm:^4.9.0, @cognite/sdk-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-core@workspace:packages/core"
   dependencies:
@@ -3383,8 +3383,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-playground@workspace:packages/playground"
   dependencies:
-    "@cognite/sdk": "npm:^9.15.3"
-    "@cognite/sdk-core": "npm:^4.10.3"
+    "@cognite/sdk": "npm:^9.15.4"
+    "@cognite/sdk-core": "npm:^4.10.4"
   languageName: unknown
   linkType: soft
 
@@ -3397,11 +3397,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk@npm:^9, @cognite/sdk@npm:^9.15.3, @cognite/sdk@workspace:packages/stable":
+"@cognite/sdk@npm:^9, @cognite/sdk@npm:^9.15.4, @cognite/sdk@workspace:packages/stable":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk@workspace:packages/stable"
   dependencies:
-    "@cognite/sdk-core": "npm:^4.10.3"
+    "@cognite/sdk-core": "npm:^4.10.4"
     "@types/geojson": "npm:^7946.0.8"
     geojson: "npm:^0.5.0"
     lodash: "npm:^4.17.11"


### PR DESCRIPTION
https://cognitedata.slack.com/archives/C05A4PX656F/p1724010276336469

After some discussion on the above thread, we have decided to skip this test until we find a fix.

Reason:
The cursor pagination test is creating more than 1000 alerts which is currently very slow.
Which could be a probably reason for 504 error.

We will later either try to make smaller page size and create less alerts or do a cleanup before all tests are run to clear all alerts which could help with sorting in database.