### PR TITLE
test: fix test for pagination cursor

### DIFF
--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -228,7 +228,7 @@ describe('alerts api', () => {
 
   vi.setConfig({ testTimeout: 30_000 });
 
-  test.skip('cursor pagination', async () => {
+  test('cursor pagination', async () => {
     // create channel for the next test
     const channelsToCreate = [
       {
@@ -248,40 +248,19 @@ describe('alerts api', () => {
     });
     expect(response.items.length).toBe(1);
 
-    // create alerts in batches of 100
-    const totalAlerts = 1000; // Total number of alerts to create
-    const batchSize = 100; // Size of each batch
+    const totalAlerts = 50; // Total number of alerts to create
 
-    // Generate and create alerts in batches
     let alertCounter = Date.now(); // Counter to ensure unique externalId
 
-    // Function to create a batch of alerts
-    const createBatch = async () => {
-      const alerts = Array.from({ length: batchSize }, () => ({
-        source: 'smth',
-        channelExternalId,
-        externalId: `external_id_test_cursor_${alertCounter++}`,
-      }));
-      await client.alerts.create(alerts);
-    };
-
-    // Create alerts in batches
-    const batchPromises = [];
-    for (let i = 0; i < Math.floor(totalAlerts / batchSize); i++) {
-      batchPromises.push(createBatch());
-    }
-
-    // Wait for all batches to complete
-    await Promise.all(batchPromises);
-
-    // create one extra alert
-    await client.alerts.create([
-      {
-        source: 'smth',
-        channelExternalId,
-        externalId: `external_id_test_cursor_${alertCounter}`,
-      },
-    ]);
+    // Create alerts
+    const createdAlerts = Array.from({ length: totalAlerts },  () => ({
+      source: 'smth',
+      channelExternalId,
+      externalId: `external_id_test_cursor_${alertCounter++}`,
+    }));
+    await client.alerts.create(createdAlerts);
+    // Wait for all alerts to complete
+    await Promise.all(createdAlerts);
 
     const alerts = client.alerts
       .list({
@@ -290,9 +269,9 @@ describe('alerts api', () => {
           order: 'desc',
         },
       })
-      .autoPagingToArray({ limit: 1001 });
+      .autoPagingToArray({ limit: 50 });
 
-    expect((await alerts).length).toBeGreaterThan(1000);
+    expect((await alerts).length).toBe(50)
 
     // clean up created alerts
     await client.alerts.deleteChannels([{ externalId: channelExternalId }]);

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -268,7 +268,7 @@ describe('alerts api', () => {
           order: 'desc',
         },
         cursor: response.nextCursor,
-        limit: [10],
+        limit: 10,
       })
       .autoPagingToArray({ limit: 50 });
 

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test, vi } from 'vitest';
 import { setupLoggedInClient } from '../testUtils';
+import { CogniteClient, CogniteError } from '@cognite/sdk-beta';
 
 describe('alerts api', () => {
   const client: CogniteClient = setupLoggedInClient();
@@ -245,6 +246,7 @@ describe('alerts api', () => {
         order: 'desc',
       },
     });
+    console.log(response);
     expect(response.items.length).toBe(1);
 
     const totalAlerts = 50; // Total number of alerts to create
@@ -257,11 +259,10 @@ describe('alerts api', () => {
       channelExternalId,
       externalId: `external_id_test_cursor_${alertCounter++}`,
     }));
-    await client.alerts.create(createdAlerts);
-    // Wait for all alerts to complete
-    await Promise.all(createdAlerts);
 
-    const alerts = client.alerts
+    await client.alerts.create(createdAlerts);
+
+    const alerts = await client.alerts
       .list({
         sort: {
           property: 'createdTime',

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -1,8 +1,8 @@
 // Copyright 2020 Cognite AS
 
+import type { CogniteClient, CogniteError } from '@cognite/sdk-beta';
 import { describe, expect, test, vi } from 'vitest';
 import { setupLoggedInClient } from '../testUtils';
-import { CogniteClient, CogniteError } from '@cognite/sdk-beta';
 
 describe('alerts api', () => {
   const client: CogniteClient = setupLoggedInClient();
@@ -246,7 +246,6 @@ describe('alerts api', () => {
         order: 'desc',
       },
     });
-    console.log(response);
     expect(response.items.length).toBe(1);
 
     const totalAlerts = 50; // Total number of alerts to create

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -246,7 +246,6 @@ describe('alerts api', () => {
         order: 'desc',
       },
     });
-    expect(response.items.length).toBe(1);
 
     const totalAlerts = 50; // Total number of alerts to create
 

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -256,7 +256,6 @@ describe('alerts api', () => {
       source: 'smth',
       channelExternalId,
       externalId: `external_id_test_cursor_${alertCounter++}`,
-
     }));
     await client.alerts.create(createdAlerts);
     // Wait for all alerts to complete

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -253,7 +253,7 @@ describe('alerts api', () => {
     let alertCounter = Date.now(); // Counter to ensure unique externalId
 
     // Create alerts
-    const createdAlerts = Array.from({ length: totalAlerts },  () => ({
+    const createdAlerts = Array.from({ length: totalAlerts }, () => ({
       source: 'smth',
       channelExternalId,
       externalId: `external_id_test_cursor_${alertCounter++}`,
@@ -271,7 +271,7 @@ describe('alerts api', () => {
       })
       .autoPagingToArray({ limit: 50 });
 
-    expect((await alerts).length).toBe(50)
+    expect((await alerts).length).toBe(50);
 
     // clean up created alerts
     await client.alerts.deleteChannels([{ externalId: channelExternalId }]);

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -238,13 +238,13 @@ describe('alerts api', () => {
     ];
     await client.alerts.createChannels(channelsToCreate);
 
+    // 
     const response = await client.alerts.list({
       limit: 1,
       sort: {
         property: 'createdTime',
         order: 'desc',
       },
-      cursor: '',
     });
     expect(response.items.length).toBe(1);
 
@@ -257,6 +257,7 @@ describe('alerts api', () => {
       source: 'smth',
       channelExternalId,
       externalId: `external_id_test_cursor_${alertCounter++}`,
+
     }));
     await client.alerts.create(createdAlerts);
     // Wait for all alerts to complete
@@ -268,6 +269,8 @@ describe('alerts api', () => {
           property: 'createdTime',
           order: 'desc',
         },
+        cursor: response.nextCursor,
+        limit: [10],
       })
       .autoPagingToArray({ limit: 50 });
 

--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -238,7 +238,6 @@ describe('alerts api', () => {
     ];
     await client.alerts.createChannels(channelsToCreate);
 
-    // 
     const response = await client.alerts.list({
       limit: 1,
       sort: {


### PR DESCRIPTION
In the previous test of the pagination cursor in alert-api, 1001 alerts was created. This created 504s, so we reduced that number to 50. 
[Ticket](https://cognitedata.atlassian.net/browse/AH-3708).