### PR TITLE
chore: re-enable temporary disabled ci check

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,8 +126,8 @@ jobs:
       - name: Install 🔧
         run: yarn install --immutable
 
-      # - name: validateDocLinks
-      #   run: yarn validateDocLinks
+      - name: validateDocLinks
+        run: yarn validateDocLinks
 
       - name: Lint
         run: yarn lint

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,8 +3313,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-alpha@workspace:packages/alpha"
   dependencies:
-    "@cognite/sdk": "npm:^9.15.6"
-    "@cognite/sdk-core": "npm:^4.10.5"
+    "@cognite/sdk": "npm:^9.15.7"
+    "@cognite/sdk-core": "npm:^4.10.6"
   languageName: unknown
   linkType: soft
 
@@ -3322,8 +3322,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-beta@workspace:packages/beta"
   dependencies:
-    "@cognite/sdk": "npm:^9.15.6"
-    "@cognite/sdk-core": "npm:^4.10.5"
+    "@cognite/sdk": "npm:^9.15.7"
+    "@cognite/sdk-core": "npm:^4.10.6"
   languageName: unknown
   linkType: soft
 
@@ -3333,7 +3333,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk-core@npm:^4.10.5, @cognite/sdk-core@npm:^4.9.0, @cognite/sdk-core@workspace:packages/core":
+"@cognite/sdk-core@npm:^4.10.6, @cognite/sdk-core@npm:^4.9.0, @cognite/sdk-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-core@workspace:packages/core"
   dependencies:
@@ -3383,8 +3383,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-playground@workspace:packages/playground"
   dependencies:
-    "@cognite/sdk": "npm:^9.15.6"
-    "@cognite/sdk-core": "npm:^4.10.5"
+    "@cognite/sdk": "npm:^9.15.7"
+    "@cognite/sdk-core": "npm:^4.10.6"
   languageName: unknown
   linkType: soft
 
@@ -3397,11 +3397,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk@npm:^9, @cognite/sdk@npm:^9.15.6, @cognite/sdk@workspace:packages/stable":
+"@cognite/sdk@npm:^9, @cognite/sdk@npm:^9.15.7, @cognite/sdk@workspace:packages/stable":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk@workspace:packages/stable"
   dependencies:
-    "@cognite/sdk-core": "npm:^4.10.5"
+    "@cognite/sdk-core": "npm:^4.10.6"
     "@types/geojson": "npm:^7946.0.8"
     geojson: "npm:^0.5.0"
     lodash: "npm:^4.17.11"


### PR DESCRIPTION
We had to disable the test here to get the PR merged due to a bad deployment.
Let's re-enable it: https://github.com/cognitedata/cognite-sdk-js/pull/1139