### PR TITLE
chore: use a separate npm publish tag than 'latest'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,11 +91,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: yarn lerna publish from-package --yes --no-git-reset --no-verify-access
+        run: yarn lerna publish from-package --pre-dist-tag rc --yes --no-git-reset --no-verify-access
 
-      - name: Publish documentation
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs
+      # - name: Publish documentation
+      #   uses: JamesIves/github-pages-deploy-action@releases/v3
+      #   with:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     BRANCH: gh-pages # The branch the action should deploy to.
+      #     FOLDER: docs


### PR DESCRIPTION
Context: https://cognitedata.slack.com/archives/C0425G1JP2A/p1724673350421259

We published it to npm using the `latest` tag, which overrode the default version. We don't want to use the `latest` (default) tag for this release candidate. Instead we tag it with `rc`.

Jira: https://cognitedata.atlassian.net/browse/AUTH-3151