### PR TITLE
refactor(core): clean up Client constructor and deprecate getToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Before you begin, ensure that you have the following:
 ### Setting up OIDC Authentication
 
 - Initialize the SDK: Import and initialize the SDK in your application, providing the necessary configuration options such as the client ID, client secret, and redirect URI obtained from your OIDC IdP.
-- Pass your authentication method to `getToken` property of SDK.
+- Setup a token provider using the `oidcTokenProvider` property of SDK. Here you can provide a valid access token for the CDF API.
 
 For code example you can check [quickstart.ts](https://github.com/cognitedata/cognite-sdk-js/blob/master/samples/nodejs/oidc-typescript/quickstart.ts#L1)
 

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1,13 +1,16 @@
 # Authentication in browsers
 
-- [Use access tokens instead of API keys](#use-access-tokens-instead-of-api-keys)
-- [Accessing different clusters](#accessing-different-clusters)
-- [How to authenticate with the SDK?](#how-to-authenticate-with-the-sdk)
-- [OpenID Connect (OIDC)](#openid-connect-oidc)
-  - [OIDC authentication using code authorization w pkce.](#oidc-authentication-using-code-authorization-w-pkce)
-  - [OIDC authentication using client credentials](#oidc-authentication-using-client-credentials)
-- [Manually trigger authentication](#manually-trigger-authentication)
-- [Cache access tokens](#cache-access-tokens)
+- [Authentication in browsers](#authentication-in-browsers)
+  - [Use access tokens instead of API keys](#use-access-tokens-instead-of-api-keys)
+  - [Accessing different clusters](#accessing-different-clusters)
+  - [How to authenticate with the SDK?](#how-to-authenticate-with-the-sdk)
+  - [OpenID Connect (OIDC)](#openid-connect-oidc)
+    - [OIDC authentication using code authorization w pkce](#oidc-authentication-using-code-authorization-w-pkce)
+    - [OIDC authentication using client credentials](#oidc-authentication-using-client-credentials)
+      - [Example](#example)
+  - [Manually trigger authentication](#manually-trigger-authentication)
+  - [Cache access tokens](#cache-access-tokens)
+  - [More](#more)
 
 ## Use access tokens instead of API keys
 
@@ -28,18 +31,16 @@ const client = new CogniteClient({
   appId: 'sample-app',
   baseUrl: 'https://bluefield.cognitedata.com',
   project: 'demo-project',
-  getToken: ...
+  oidcTokenProvider: ...
 });
 ```
 
 ## How to authenticate with the SDK?
 
-Quickly summarized, the application passes a `getToken` callback to the SDK and uses it to
-get and renew tokens as needed. **Note** that the SDK comes with an implementation of the Cognite legacy
-authentication flow, **but it does not come with an implementation for all IDPs**. If you need to
-integrate your application and the SDK with, for example, Azure Active Directory, use the appropriate library
+Quickly summarized, the application passes a `oidcTokenProvider` callback to the SDK and uses it to
+get and renew tokens as needed. If you need to integrate your application and the SDK with, for example, Azure Active Directory, use the appropriate library
 from Microsoft. If you need to integrate with Auth0, use their libraries and integrate with the SDK
-via `getToken`.
+via `oidcTokenProvider`.
 
 ## OpenID Connect (OIDC)
 
@@ -73,7 +74,7 @@ const configuration: Configuration = {
 };
 
 const pca = new PublicClientApplication(configuration);
-const getToken = async () => {
+const oidcTokenProvider = async () => {
   const accountId = sessionStorage.getItem("account");
   const account = pca.getAccountByLocalId(accountId)!;
   const token = await pca.acquireTokenSilent({
@@ -92,7 +93,7 @@ const getToken = async () => {
 const client = new CogniteClient({
   project: "my-project",
   appId: "demo-sample",
-  getToken
+  oidcTokenProvider
 });
 
 ```
@@ -126,7 +127,7 @@ async function quickstart() {
     appId: 'Cognite SDK samples',
     project,
     baseUrl: "https://api.cognitedata.com",
-    getToken: () =>
+    oidcTokenProvider: () =>
       pca
         .acquireTokenByClientCredential({
           scopes: ['https://api.cognitedata.com/.default'],
@@ -176,7 +177,7 @@ If the token is invalid or timed out, the SDK triggers a standard auth-flow on t
 ```js
 const client = new CogniteClient({
   project: 'YOUR PROJECT NAME HERE',
-  getToken: () => Promise.resolve('ACCESS TOKEN FOR THE PROJECT HERE'),
+  oidcTokenProvider: () => Promise.resolve('ACCESS TOKEN FOR THE PROJECT HERE'),
 });
 ```
 

--- a/packages/alpha/src/__tests__/testUtils.ts
+++ b/packages/alpha/src/__tests__/testUtils.ts
@@ -8,7 +8,7 @@ export function setupLoggedInClient() {
     appId: 'JS SDK integration tests (alpha)',
     baseUrl: process.env.COGNITE_BASE_URL,
     project: process.env.COGNITE_PROJECT as string,
-    getToken: () =>
+    oidcTokenProvider: () =>
       login().then((account) => {
         return account.access_token;
       }),

--- a/packages/beta/src/__tests__/testUtils.ts
+++ b/packages/beta/src/__tests__/testUtils.ts
@@ -15,7 +15,7 @@ export function setupClient(baseUrl: string = Constants.BASE_URL) {
     appId: 'JS SDK integration tests (beta)',
     baseUrl: process.env.COGNITE_BASE_URL || baseUrl,
     project: process.env.COGNITE_PROJECT || (project as string),
-    getToken: () =>
+    oidcTokenProvider: () =>
       login().then((account) => {
         return account.access_token;
       }),
@@ -30,7 +30,7 @@ export function setupLoggedInClient() {
     appId: 'JS SDK integration tests (beta)',
     baseUrl: process.env.COGNITE_BASE_URL,
     project: process.env.COGNITE_PROJECT as string,
-    getToken: () =>
+    oidcTokenProvider: () =>
       login().then((account) => {
         return account.access_token;
       }),
@@ -52,7 +52,7 @@ export function setupLoggedInClientForUnitTest(
     appId: 'JS SDK integration tests (beta)',
     baseUrl: baseUrl || process.env.COGNITE_BASE_URL,
     project: process.env.COGNITE_PROJECT as string,
-    getToken: () =>
+    oidcTokenProvider: () =>
       login().then((account) => {
         return account.access_token;
       }),

--- a/packages/core/src/__tests__/testUtils.ts
+++ b/packages/core/src/__tests__/testUtils.ts
@@ -28,7 +28,8 @@ export function setupClient(baseUrl: string = BASE_URL) {
   return new BaseCogniteClient({
     appId: 'JS SDK integration tests',
     project: process.env.COGNITE_PROJECT as string,
-    getToken: () => Promise.resolve(process.env.COGNITE_CREDENTIALS as string),
+    oidcTokenProvider: () =>
+      Promise.resolve(process.env.COGNITE_CREDENTIALS as string),
     baseUrl,
   });
 }

--- a/packages/playground/src/__tests__/testUtils.ts
+++ b/packages/playground/src/__tests__/testUtils.ts
@@ -13,7 +13,7 @@ export function setupLoggedInClient(
 ) {
   return new CogniteClientPlayground({
     appId: 'JS SDK integration tests (playground)',
-    getToken: () =>
+    oidcTokenProvider: () =>
       login().then((account) => {
         return account.access_token;
       }),
@@ -25,7 +25,7 @@ export function setupLoggedInClient(
 export function setupMockableClient(baseUrl: string = mockBaseUrl) {
   return new CogniteClientPlayground({
     appId: 'JS SDK integration tests (playground)',
-    getToken: () => Promise.resolve(accessToken),
+    oidcTokenProvider: () => Promise.resolve(accessToken),
     project,
     baseUrl,
   });

--- a/packages/stable/README.md
+++ b/packages/stable/README.md
@@ -41,31 +41,18 @@ The SDK is written in native typescript, so no extra types need to be defined.
 ### Web
 
 ```js
-import { CogniteClient, CogniteAuthentication } from '@cognite/sdk';
+import { CogniteClient } from '@cognite/sdk';
 
 async function quickstart() {
   const project = 'publicdata';
-  const legacyInstance = new CogniteAuthentication({
-    project,
-  });
-
-  const getToken = async () => {
-    await legacyInstance.handleLoginRedirect();
-    let token = await legacyInstance.getCDFToken();
-    if (token) {
-      return token.accessToken;
-    }
-    token = await legacyInstance.login({ onAuthenticate: 'REDIRECT' });
-    if (token) {
-      return token.accessToken;
-    }
-    throw new Error('error');
+  const oidcTokenProvider = async () => {
+    return 'YOUR_OIDC_ACCESS_TOKEN';
   };
 
   const client = new CogniteClient({
     appId: 'YOUR APPLICATION NAME',
     project,
-    getToken,
+    oidcTokenProvider,
   });
 
   const assets = await client.assets.list().autoPagingToArray({ limit: 100 });
@@ -84,7 +71,7 @@ const { CogniteClient } = require('@cognite/sdk');
 async function quickstart() {
   const client = new CogniteClient({
     appId: 'YOUR APPLICATION NAME',
-    getToken: () => Promise.resolve('YOUR_OIDC_ACCESS_TOKEN'),
+    oidcTokenProvider: () => Promise.resolve('YOUR_OIDC_ACCESS_TOKEN'),
   });
 
   const assets = await client.assets.list().autoPagingToArray({ limit: 100 });

--- a/packages/stable/src/__tests__/testUtils.ts
+++ b/packages/stable/src/__tests__/testUtils.ts
@@ -13,7 +13,7 @@ function setupClient(baseUrl: string = process.env.COGNITE_BASE_URL as string) {
     appId: 'JS SDK integration tests',
     project: 'unit-test',
     baseUrl,
-    getToken: () => Promise.resolve('not logged in'),
+    oidcTokenProvider: () => Promise.resolve('not logged in'),
   });
 }
 
@@ -22,7 +22,7 @@ function setupLoggedInClient() {
     appId: 'JS SDK integration tests',
     baseUrl: process.env.COGNITE_BASE_URL,
     project: process.env.COGNITE_PROJECT as string,
-    getToken: () =>
+    oidcTokenProvider: () =>
       login().then((account) => {
         return account.access_token;
       }),
@@ -35,7 +35,7 @@ function setupMockableClient() {
     appId: 'JS SDK integration tests',
     project: process.env.COGNITE_PROJECT as string,
     baseUrl: mockBaseUrl,
-    getToken: () => Promise.resolve('test accessToken'),
+    oidcTokenProvider: () => Promise.resolve('test accessToken'),
   });
 }
 

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -22,8 +22,8 @@
     "test-snippets": "yarn extract-snippets && yarn g:tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/sdk": "^9",
-    "@cognite/sdk-core": "^4.9.0"
+    "@cognite/sdk": "^10.0.0-rc.0",
+    "@cognite/sdk-core": "^5.0.0-rc.0"
   },
   "files": [
     "dist"

--- a/packages/template/src/__tests__/testUtils.ts
+++ b/packages/template/src/__tests__/testUtils.ts
@@ -8,7 +8,7 @@ import { login } from './login';
 export function setupClient(baseUrl: string = Constants.BASE_URL) {
   return new CogniteClient({
     project: 'unknown',
-    getToken: () => Promise.reject(new Error('SDK not logged in')),
+    oidcTokenProvider: () => Promise.reject(new Error('SDK not logged in')),
     appId: `JS SDK integration tests (${name})`,
     baseUrl,
   });
@@ -17,7 +17,7 @@ export function setupClient(baseUrl: string = Constants.BASE_URL) {
 export function setupLoggedInClient() {
   return new CogniteClient({
     project: process.env.COGNITE_PROJECT as string,
-    getToken: () =>
+    oidcTokenProvider: () =>
       login().then((account) => {
         return account.access_token;
       }),

--- a/samples/nodejs/oidc-typescript/README.md
+++ b/samples/nodejs/oidc-typescript/README.md
@@ -70,7 +70,7 @@ async function quickstart() {
       appId: 'Cognite SDK samples',
       project,
       baseUrl: 'https://api.cognitedata.com',
-      getToken: () =>
+      oidcTokenProvider: () =>
         pca
           .acquireTokenByClientCredential({
             scopes: ['https://api.cognitedata.com/.default'],

--- a/samples/nodejs/oidc-typescript/quickstart.ts
+++ b/samples/nodejs/oidc-typescript/quickstart.ts
@@ -26,7 +26,7 @@ async function quickstart() {
     appId: 'Cognite SDK samples',
     project,
     baseUrl: 'https://api.cognitedata.com',
-    getToken: () =>
+    oidcTokenProvider: () =>
       pca
         .acquireTokenByClientCredential({
           scopes: ['https://api.cognitedata.com/.default'],

--- a/samples/nodejs/public-client-device-grant-flow/README.md
+++ b/samples/nodejs/public-client-device-grant-flow/README.md
@@ -72,7 +72,7 @@ async function deviceCodeGrantExample() {
     appId: 'Cognite SDK samples',
     project,
     baseUrl: 'https://api.cognitedata.com',
-    getToken: () =>
+    oidcTokenProvider: () =>
       pca
         .acquireTokenByDeviceCode({
           deviceCodeCallback: ({ message, userCode, verificationUri }) => {

--- a/samples/nodejs/public-client-device-grant-flow/device_grant.ts
+++ b/samples/nodejs/public-client-device-grant-flow/device_grant.ts
@@ -25,7 +25,7 @@ async function deviceCodeGrantExample() {
     appId: 'Cognite SDK samples',
     project,
     baseUrl: 'https://api.cognitedata.com',    
-    getToken: () =>
+    oidcTokenProvider: () =>
       pca
         .acquireTokenByDeviceCode({
           deviceCodeCallback: ({ message, userCode, verificationUri }) => {

--- a/samples/react/msal-advanced-browser-react/README.md
+++ b/samples/react/msal-advanced-browser-react/README.md
@@ -91,7 +91,7 @@ export const pca = new PublicClientApplication(configuration);
 7. Create a method that retrieve the access_token.
 
 ```ts
-export const getToken = async () => {
+export const oidcTokenProvider = async () => {
   // Verify if account are setted.
   const accountId = sessionStorage.getItem("account");
 

--- a/samples/react/msal-advanced-browser-react/src/AssetView.tsx
+++ b/samples/react/msal-advanced-browser-react/src/AssetView.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { CogniteClient } from "@cognite/sdk";
 import { useMsal } from "@azure/msal-react";
 import { useQuery, useMutation } from "react-query";
-import { getToken, baseUrl } from "./auth";
+import { oidcTokenProvider, baseUrl } from "./auth";
 
 const project = process.env.REACT_APP_CDF_PROJECT!;
 const appId = process.env.REACT_APP_AZURE_APP_ID!;
@@ -15,7 +15,7 @@ export default function ListAssets() {
       project: project,
       appId: appId,
       baseUrl,
-      getToken,
+      oidcTokenProvider,
     })
   );
 

--- a/samples/react/msal-advanced-browser-react/src/auth.ts
+++ b/samples/react/msal-advanced-browser-react/src/auth.ts
@@ -18,7 +18,7 @@ const configuration: Configuration = {
 };
 
 export const pca = new PublicClientApplication(configuration);
-export const getToken = async () => {
+export const oidcTokenProvider = async () => {
   const accountId = sessionStorage.getItem("account");
   if (!accountId) {
     throw new Error("no user_id found");

--- a/samples/react/msal-browser-react/README.md
+++ b/samples/react/msal-browser-react/README.md
@@ -92,7 +92,7 @@ export const pca = new PublicClientApplication(configuration);
 7. Create a method that retrieve the access_token.
 
 ```ts
-export const getToken = async () => {
+export const oidcTokenProvider = async () => {
   // Verify if account are setted.
   const accountId = sessionStorage.getItem("account");
 

--- a/samples/react/msal-browser-react/src/AssetView.tsx
+++ b/samples/react/msal-browser-react/src/AssetView.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { CogniteClient } from "@cognite/sdk";
 import { useMsal } from "@azure/msal-react";
 import { useQuery, useMutation } from "react-query";
-import { getToken, baseUrl } from "./auth";
+import { oidcTokenProvider, baseUrl } from "./auth";
 
 const project = process.env.REACT_APP_CDF_PROJECT!;
 const appId = process.env.REACT_APP_AZURE_APP_ID!;
@@ -15,7 +15,7 @@ export default function ListAssets() {
       project: project,
       appId: appId,
       baseUrl,
-      getToken,
+      oidcTokenProvider,
     })
   );
 

--- a/samples/react/msal-browser-react/src/auth.ts
+++ b/samples/react/msal-browser-react/src/auth.ts
@@ -25,7 +25,7 @@ if (!clientId || !tenantId) {
 }
 
 export const pca = new PublicClientApplication(configuration);
-export const getToken = async () => {
+export const oidcTokenProvider = async () => {
   const accountId = sessionStorage.getItem("account");
   if (!accountId) {
     throw new Error("no user_id found");

--- a/scripts/extractCodeSnippets.js
+++ b/scripts/extractCodeSnippets.js
@@ -89,7 +89,7 @@ codeSnippets.forEach((snippets, operationId) => {
     const client = new CogniteClient({
       appId: '[APP NAME]',
       project: '[PROJECT]',
-      getToken: () => Promise.resolve('[ACCESS_TOKEN]'),
+      oidcTokenProvider: () => Promise.resolve('[ACCESS_TOKEN]'),
     });
     (async () => {
       ${joinSnippets(snippets)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3297,7 +3297,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk-core@npm:^4.10.4, @cognite/sdk-core@npm:^4.9.0":
+"@cognite/sdk-core@npm:^4.10.4":
   version: 4.10.4
   resolution: "@cognite/sdk-core@npm:4.10.4"
   dependencies:
@@ -3363,8 +3363,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-template@workspace:packages/template"
   dependencies:
-    "@cognite/sdk": "npm:^9"
-    "@cognite/sdk-core": "npm:^4.9.0"
+    "@cognite/sdk": "npm:^10.0.0-rc.0"
+    "@cognite/sdk-core": "npm:^5.0.0-rc.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
As part of the v10 release, we are deprecating the `getToken` method. The name is confusing, and we instead rename it to `oidcTokenProvider` which is a more accurate description.

Jira: https://cognitedata.atlassian.net/browse/AUTH-3107