### PR TITLE
refactor(core): update autogenerated types

### DIFF
--- a/packages/stable/src/.cognite-openapi-snapshot.json
+++ b/packages/stable/src/.cognite-openapi-snapshot.json
@@ -25,10 +25,12 @@
             "asia-northeast1-1",
             "gc-dsm-gp-001"
           ],
-          "default": "api"
+          "default": "api",
+          "description": "The CDF cluster to connect to"
         },
         "project": {
-          "default": "publicdata"
+          "default": "publicdata",
+          "description": "The CDF project name."
         }
       }
     }
@@ -42,6 +44,7 @@
             "description": "The URL for the CDF cluster to connect to",
             "variables": {
               "cluster": {
+                "description": "The CDF cluster to connect to",
                 "default": "api",
                 "enum": [
                   "api",
@@ -92,7 +95,7 @@
           "Assets"
         ],
         "summary": "List assets",
-        "description": "List all assets, or only the assets matching the specified query.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage. \nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
+        "description": "List all assets, or only the assets matching the specified query.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
         "operationId": "getAssets",
         "parameters": [
           {
@@ -339,7 +342,7 @@
           "Assets"
         ],
         "summary": "Filter assets",
-        "description": "Retrieve a list of assets in the same project. This operation supports pagination by cursor.\nApply Filtering and Advanced filtering criteria to select a subset of assets.\n\n### Advanced filtering\nAdvanced filter lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, `exists`, etc., using boolean operators `and`, `or`, and `not`.\nIt applies to basic fields as well as metadata.\n\nSee the `advancedFilter` attribute in the example.\n\nSee more information about filtering DSL [here](https://docs.cognite.com/dev/concepts/resource_filtering_dsl/ \"filtering DSL\").\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields                   | Description  |\n|----------------|------------------------------------|--------------|\n| `containsAll`  | Array type fields                  | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `containsAny`  | Array type fields                  | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `equals`       | Non-array type fields              | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `exists`       | All fields                         | Only includes results where the specified property exists (has value). <br /> `{\"exists\": {\"property\": [\"property\"]}}` |\n| `in`           | Non-array type fields              | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `prefix`       | String type fields                 | Only includes results which start with the specified value. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `range`        | Non-array type fields              | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n| `search`       | `[\"name\"]`, `[\"description\"]`      | Introduced to provide functional parity with /assets/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n\n##### Search\nThe `search` leaf filter provides functional parity with the `/assets/search` endpoint.\nIt's available only for the `[\"description\"]` and `[\"name\"]` properties. When specifying only this filter with no explicit ordering,\nbehavior is the same as of the `/assets/search/` endpoint without specifying filters.\nExplicit sorting overrides the default ordering by relevance.\nIt's possible to use the `search` leaf filter as any other leaf filter for creating complex queries.\n\nSee the `search` filter in the `advancedFilter` attribute in the example.\n\n#### advancedFilter attribute limits\n- filter query max depth: 10\n- filter query max number of clauses: 100\n- `and` and `or` clauses must have at least one element\n- `property` array of each leaf filter has the following limitations:\n  - number of elements in the array is in the range [1, 2]\n  - elements must not be blank\n  - each element max length is 128 symbols\n  - property array must match one of the existing properties (static or dynamic metadata).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100]\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of a primitive type (number, string)\n- `range` filter must have at least one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n  At least one of the bounds must be specified.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be a primitive value\n- `search` filter `value` must not be blank and the length must be in the range [1, 128]\n- filter query may have maximum 2 search leaf filters\n- maximum leaf filter string value length is different depending on the property the filter is using:\n  - `externalId` - 255\n  - `name` - 128 for the `search` filter and 255 for other filters\n  - `description` - 128 for the `search` filter and 255 for other filters\n  - `labels` item - 255\n  - `source` - 128\n  - any `metadata` key - 128 \n\n### Sorting\nBy default, assets are sorted by `id` in the ascending order.\nUse the `search` leaf filter to sort the results by relevance.\nSorting by other fields can be explicitly requested. The `order` field is optional \nand defaults to `desc` for `_score_` and `asc` for all other fields.\nThe `nulls` field is optional and defaults to `auto`. `auto` is translated to \n`last` for the `asc` order and to `first` for the `desc` order by the service.\nPartitions are done independently of sorting; there's no guarantee of the sort order between elements from different partitions.\n\nSee the `sort` attribute in the example.\n\n#### Null values\nIn case the `nulls` attribute has the `auto` value or the attribute isn't specified,\nnull (missing) values are considered to be bigger than any other values.\nThey are placed last when sorting in the `asc` order and first when sorting in `desc`.\nOtherwise, missing values are placed according to the `nulls` attribute (last or first), and their placement doesn't depend on the `order` value.\nValues, such as empty strings, aren't considered as nulls.\n\n#### Sorting by score\nUse a special sort property `_score_` when sorting by relevance. \nThe more filters a particular asset matches, the higher its score is. This can be useful,\nfor example, when building UIs. Let's assume we want exact matches to be be displayed above matches by\nprefix as in the request below. An asset named `pump` will match both `equals` and `prefix`\nfilters and, therefore, have higher score than assets with names like `pump valve` that match only `prefix` filter.\n\n```\n\"advancedFilter\" : {\n  \"or\" : [\n    {\n      \"equals\": {\n        \"property\": [\"name\"], \n        \"value\": \"pump\"\n      }\n    },\n    {\n      \"prefix\": {\n        \"property\": [\"name\"], \n        \"value\": \"pump\"\n      }\n    }\n  ]\n},\n\"sort\": [\n  {\n    \"property\" : [\"_score_\"]\n  }\n]\n```\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
+        "description": "Retrieve a list of assets in the same project. This operation supports pagination by cursor.\nApply Filtering and Advanced filtering criteria to select a subset of assets.\n\n### Advanced filtering\nAdvanced filter lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, `exists`, etc., using boolean operators `and`, `or`, and `not`.\nIt applies to basic fields as well as metadata.\n\nSee the `advancedFilter` attribute in the example.\n\nSee more information about filtering DSL [here](https://docs.cognite.com/dev/concepts/resource_filtering_dsl/ \"filtering DSL\").\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields                   | Description  |\n|----------------|------------------------------------|--------------|\n| `containsAll`  | Array type fields                  | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `containsAny`  | Array type fields                  | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `equals`       | Non-array type fields              | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `exists`       | All fields                         | Only includes results where the specified property exists (has value). <br /> `{\"exists\": {\"property\": [\"property\"]}}` |\n| `in`           | Non-array type fields              | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `prefix`       | String type fields                 | Only includes results which start with the specified value. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `range`        | Non-array type fields              | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n| `search`       | `[\"name\"]`, `[\"description\"]`      | Introduced to provide functional parity with /assets/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n\n##### Search\nThe `search` leaf filter provides functional parity with the `/assets/search` endpoint.\nIt's available only for the `[\"description\"]` and `[\"name\"]` properties. When specifying only this filter with no explicit ordering,\nbehavior is the same as of the `/assets/search/` endpoint without specifying filters.\nExplicit sorting overrides the default ordering by relevance.\nIt's possible to use the `search` leaf filter as any other leaf filter for creating complex queries.\n\nSee the `search` filter in the `advancedFilter` attribute in the example.\n\n#### advancedFilter attribute limits\n- filter query max depth: 10\n- filter query max number of clauses: 100\n- `and` and `or` clauses must have at least one element\n- `property` array of each leaf filter has the following limitations:\n  - number of elements in the array is in the range [1, 2]\n  - elements must not be blank\n  - each element max length is 128 symbols\n  - property array must match one of the existing properties (static or dynamic metadata).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100]\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of a primitive type (number, string)\n- `range` filter must have at least one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n  At least one of the bounds must be specified.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be a primitive value\n- `search` filter `value` must not be blank and the length must be in the range [1, 128]\n- filter query may have maximum 2 search leaf filters\n- maximum leaf filter string value length is different depending on the property the filter is using:\n  - `externalId` - 255\n  - `name` - 128 for the `search` filter and 255 for other filters\n  - `description` - 128 for the `search` filter and 255 for other filters\n  - `labels` item - 255\n  - `source` - 128\n  - any `metadata` key - 128\n\n### Sorting\nBy default, assets are sorted by `id` in the ascending order.\nUse the `search` leaf filter to sort the results by relevance.\nSorting by other fields can be explicitly requested. The `order` field is optional\nand defaults to `desc` for `_score_` and `asc` for all other fields.\nThe `nulls` field is optional and defaults to `auto`. `auto` is translated to\n`last` for the `asc` order and to `first` for the `desc` order by the service.\nPartitions are done independently of sorting; there's no guarantee of the sort order between elements from different partitions.\n\nSee the `sort` attribute in the example.\n\n#### Null values\nIn case the `nulls` attribute has the `auto` value or the attribute isn't specified,\nnull (missing) values are considered to be bigger than any other values.\nThey are placed last when sorting in the `asc` order and first when sorting in `desc`.\nOtherwise, missing values are placed according to the `nulls` attribute (last or first), and their placement doesn't depend on the `order` value.\nValues, such as empty strings, aren't considered as nulls.\n\n#### Sorting by score\nUse a special sort property `_score_` when sorting by relevance.\nThe more filters a particular asset matches, the higher its score is. This can be useful,\nfor example, when building UIs. Let's assume we want exact matches to be be displayed above matches by\nprefix as in the request below. An asset named `pump` will match both `equals` and `prefix`\nfilters and, therefore, have higher score than assets with names like `pump valve` that match only `prefix` filter.\n\n```\n\"advancedFilter\" : {\n  \"or\" : [\n    {\n      \"equals\": {\n        \"property\": [\"name\"],\n        \"value\": \"pump\"\n      }\n    },\n    {\n      \"prefix\": {\n        \"property\": [\"name\"],\n        \"value\": \"pump\"\n      }\n    }\n  ]\n},\n\"sort\": [\n  {\n    \"property\" : [\"_score_\"]\n  }\n]\n```\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
         "operationId": "listAssets",
         "requestBody": {
           "content": {
@@ -389,7 +392,7 @@
           "Assets"
         ],
         "summary": "Aggregate assets",
-        "description": "The aggregation API lets you compute aggregated results on assets, \nsuch as getting the count of all assets in a project, checking\ndifferent names and descriptions of assets in your project, etc.\n\n#### Aggregate filtering\n##### Filter (filter & advancedFilter) data for aggregates\nFilters behave the same way as for the `Filter assets` endpoint.\nIn text properties, the values are aggregated in a case-insensitive manner.\n\n##### aggregateFilter to filter aggregate results\n`aggregateFilter` works similarly to `advancedFilter` but always applies to aggregate properties.\nFor instance, in case of an aggregation for the `source` property, only the values (aka buckets) of the `source` property can be filtered out. \n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.  \nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
+        "description": "The aggregation API lets you compute aggregated results on assets,\nsuch as getting the count of all assets in a project, checking\ndifferent names and descriptions of assets in your project, etc.\n\n#### Aggregate filtering\n##### Filter (filter & advancedFilter) data for aggregates\nFilters behave the same way as for the `Filter assets` endpoint.\nIn text properties, the values are aggregated in a case-insensitive manner.\n\n##### aggregateFilter to filter aggregate results\n`aggregateFilter` works similarly to `advancedFilter` but always applies to aggregate properties.\nFor instance, in case of an aggregation for the `source` property, only the values (aka buckets) of the `source` property can be filtered out.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\\\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
         "operationId": "aggregateAssets",
         "requestBody": {
           "content": {
@@ -543,7 +546,7 @@
           "Assets"
         ],
         "summary": "Search assets",
-        "description": "Fulltext search for assets based on result relevance. Primarily meant\nfor human-centric use-cases, not for programs, since matching and\nordering may change over time. Additional filters can also be\nspecified. This operation doesn't support pagination.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage. \nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
+        "description": "Fulltext search for assets based on result relevance. Primarily meant\nfor human-centric use-cases, not for programs, since matching and\nordering may change over time. Additional filters can also be\nspecified. This operation doesn't support pagination.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
         "operationId": "searchAssets",
         "requestBody": {
           "description": "Search query",
@@ -590,7 +593,7 @@
           "Assets"
         ],
         "summary": "Delete assets",
-        "description": "Delete assets. By default, `recursive=false` and the request would fail if attempting to delete assets that are referenced as parent by other assets. \nTo delete such assets and all its descendants, set recursive to true.\nThe limit of the request does not include the number of descendants that are deleted.\n\n### Request throttling\nThis endpoint is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
+        "description": "Delete assets. By default, `recursive=false` and the request would fail if attempting to delete assets that are referenced as parent by other assets.\nTo delete such assets and all its descendants, set recursive to true.\nThe limit of the request does not include the number of descendants that are deleted.\n\n### Request throttling\nThis endpoint is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Assets resource description](../../) for more information.",
         "operationId": "deleteAssets",
         "requestBody": {
           "content": {
@@ -805,7 +808,7 @@
           "Data models"
         ],
         "summary": "Create or update data models",
-        "description": "Add or update (upsert) data models. For unchanged data model specifications, the operation completes without  making any changes.  We will not update the ```lastUpdatedTime``` value for models that remain unchanged.",
+        "description": "Add or update (upsert) data models. For unchanged data model specifications, the operation completes without making any changes.  We will not update the ```lastUpdatedTime``` value for models that remain unchanged.",
         "operationId": "createDataModels",
         "requestBody": {
           "description": "List of data models to add",
@@ -951,7 +954,7 @@
           "Data models"
         ],
         "summary": "Delete data models",
-        "description": "Delete one or more data models.  Currently limited to 100 models at a time.  This does not delete the views,  nor the containers they reference.",
+        "description": "Delete one or more data models.  Currently limited to 100 models at a time.  This does not delete the views, nor the containers they reference.",
         "operationId": "deleteDataModels",
         "requestBody": {
           "description": "List of references to data models you wish to delete",
@@ -1136,7 +1139,7 @@
           "Views"
         ],
         "summary": "Delete views",
-        "description": "Delete one or more views.  Currently limited to 100 views at a time.  The service cannot delete a view  referenced by a data model.",
+        "description": "Delete one or more views.  Currently limited to 100 views at a time.",
         "operationId": "deleteViews",
         "requestBody": {
           "description": "List of references to views you want to delete.",
@@ -1175,7 +1178,7 @@
           "Containers"
         ],
         "summary": "Create or update containers",
-        "description": "Add or update (upsert) containers. For unchanged container specifications, the operation completes without  making any changes.  We will not update the ```lastUpdatedTime``` value for containers that remain unchanged.",
+        "description": "Add or update (upsert) containers. For unchanged container specifications, the operation completes without making any changes.  We will not update the ```lastUpdatedTime``` value for containers that remain unchanged.",
         "operationId": "ApplyContainers",
         "requestBody": {
           "description": "Containers to add or update.",
@@ -1303,7 +1306,7 @@
           "Containers"
         ],
         "summary": "Delete containers",
-        "description": "Delete one or more containers. Currently limited to 100 containers at a time. You cannot delete a container when  one or more data model(s) or view(s) references it.",
+        "description": "Delete one or more containers. Currently limited to 100 containers at a time.",
         "operationId": "deleteContainers",
         "requestBody": {
           "description": "List of the spaces and external-ids for the containers you want to delete.",
@@ -1414,13 +1417,44 @@
         ]
       }
     },
+    "/models/containers/inspect": {
+      "post": {
+        "tags": [
+          "Containers"
+        ],
+        "summary": "Inspect containers",
+        "operationId": "containerInspect",
+        "requestBody": {
+          "description": "Which containers to inspect and the inspection operations to run.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContainerInspectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "x-capability": [
+          "DataModelsAcl:READ"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ContainerInspectResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
     "/models/instances": {
       "post": {
         "tags": [
           "Instances"
         ],
         "summary": "Create or update nodes/edges",
-        "description": "Create or update nodes and edges in a transaction. The ```items``` field of the payload is an array of objects\nwhere each object describes a node or an edge to create, patch or replace. The ```instanceType``` field of\neach object must be ```node``` or ```edge``` and determines how the rest of the object is interpreted.\n\nThis operation is currently limited to 1000 nodes and/or edges at a time.\n\nIndividual nodes and edges are uniquely identified by their externalId and space.\n\nFor more details on ingesting instances into a graph, see [Ingesting instances] \n(https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion).\n\n### Creating new instances\n\nWhen there is no node or edge with the given externalId in the given space, a node will be created and the\nproperties provided for each of the containers or views in the ```sources``` array will be populated for the\nnode/edge. Nodes can also be created implicitly when an edge between them is created (if\n```autoCreateStartNodes``` and/or ``` autoCreateEndNodes``` is set), or when a direct relation\nproperty is set, the target node does not exist and ```autoCreateDirectRelations``` is set.\n\nTo add a node or edge, the user must have capabilities to access (write to) both the view(s) referenced in\n```sources``` and the container(s) underlying these views, as well as any directly referenced containers.\n\n### Updating (patching) or replacing instances\n\nWhen a node or edge (instance) with the given externalId already exists in a space, the\nproperties named in the ```sources``` field will be written to the instance. Other properties will remain\nunchanged. To replace the whole set of properties for an instance (a node or an edge) rather than patch the\ninstance, set the ```replace``` parameter to ```true```.\n\nIf you use a writable view to update properties (that is, the source you are referring to in ```sources```\nis a view), you must have write access to the view as well as all of its backing containers.\n\n### No-change patch operations\nWhen a node/edge item has no changes compared to the existing instance - that is, when the supplied property\nvalues are equal to the corresponding values in the existing node/edge, the node/edge will stay unchanged.\nIn this case, the ```lastUpdatedTime``` values for the nodes/edges in question will not change.\n",
+        "description": "Create or update nodes and edges in a transaction. The ```items``` field of the payload is an array of objects\nwhere each object describes a node or an edge to create, patch or replace. The ```instanceType``` field of\neach object must be ```node``` or ```edge``` and determines how the rest of the object is interpreted.\n\nThis operation is currently limited to 1000 nodes and/or edges at a time.\n\nIndividual nodes and edges are uniquely identified by their externalId and space.\n\nFor more details on ingesting instances into a graph, see [Ingesting instances]\n(https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion).\n\n### Creating new instances\n\nWhen there is no node or edge with the given externalId in the given space, a node will be created and the\nproperties provided for each of the containers or views in the ```sources``` array will be populated for the\nnode/edge. Nodes can also be created implicitly when an edge between them is created (if\n```autoCreateStartNodes``` and/or ``` autoCreateEndNodes``` is set), or when a direct relation\nproperty is set, the target node does not exist and ```autoCreateDirectRelations``` is set.\n\nTo add a node or edge, the user must have capabilities to access (write to) both the view(s) referenced in\n```sources``` and the container(s) underlying these views, as well as any directly referenced containers.\n\n### Updating (patching) or replacing instances\n\nWhen a node or edge (instance) with the given externalId already exists in a space, the\nproperties named in the ```sources``` field will be written to the instance. Other properties will remain\nunchanged. To replace the whole set of properties for an instance (a node or an edge) rather than patch the\ninstance, set the ```replace``` parameter to ```true```.\n\nNote: When using ```replace``` as ```true``` it will replace any omitted property to either it's default\nvalue as defined on the container(s) or null if no default value is set. All properties on the related\ncontainer(s) referenced in the provided ```sources``` view(s) will be replaced, so even when the provided\nview(s) only contains a subset of properties from a container all the properties in that container for that\ninstance will be replaced. If the underlying container(s) have any required properties that are not provided,\nthe operation will fail.\n\nIf you use a writable view to update properties (that is, the source you are referring to in ```sources```\nis a view), you must have write access to the view as well as all of its backing containers.\n\n### No-change patch operations\nWhen a node/edge item has no changes compared to the existing instance - that is, when the supplied property\nvalues are equal to the corresponding values in the existing node/edge, the node/edge will stay unchanged.\nIn this case, the ```lastUpdatedTime``` values for the nodes/edges in question will not change.\n",
         "operationId": "applyNodeAndEdges",
         "requestBody": {
           "description": "Nodes/edges to add or update.",
@@ -1472,7 +1506,7 @@
         "description": "Filter the instances - nodes and edges - in a project.",
         "operationId": "advancedListInstance",
         "requestBody": {
-          "description": "Filter based on the instance type, the name, the external-ids, and on properties. The filter  supports sorting and pagination. The instances must have data in all the views referenced by the sources field. Properties for up to 10 views can be retrieved in one query.",
+          "description": "Filter based on the instance type, the name, the external-ids, and on properties. The filter supports sorting and pagination. The instances must have data in all the views referenced by the sources field. Properties for up to 10 views can be retrieved in one query.",
           "content": {
             "application/json": {
               "schema": {
@@ -1547,7 +1581,7 @@
           "Instances"
         ],
         "summary": "Search for nodes/edges",
-        "description": "Search text fields in views for nodes or edge(s). The service will return up to 1000 results. This operation   orders the results by relevance, across the specified spaces.",
+        "description": "Search text fields in views for nodes or edge(s). The service will return up to 1000 results. This operation orders the results by relevance, across the specified spaces.",
         "operationId": "searchInstances",
         "requestBody": {
           "description": "The search specification.",
@@ -1586,7 +1620,7 @@
           "Instances"
         ],
         "summary": "Aggregate data across nodes/edges",
-        "description": "Aggregate data for nodes or edges in a project. You can use an optional query or filter specification to limit  the result.",
+        "description": "Aggregate data for nodes or edges in a project. You can use an optional query or filter specification to limit the result.",
         "operationId": "aggregateInstances",
         "requestBody": {
           "description": "Aggregation specification.",
@@ -1703,7 +1737,7 @@
           "Instances"
         ],
         "summary": "Sync nodes/edges",
-        "description": "Subscribe to changes for nodes and edges in a project, matching a supplied filter.  This endpoint will always  return a ```NextCursor```.  The sync specification mirrors the query interface, but sorting is not currently  supported. For more information, see [Query language](https://docs.cognite.com/cdf/dm/dm_concepts/dm_querying).",
+        "description": "Subscribe to changes for nodes and edges in a project, matching a supplied filter.  This endpoint will always return a ```NextCursor```.  The sync specification mirrors the query interface, but sorting is not currently supported. For more information, see [Query language](https://docs.cognite.com/cdf/dm/dm_concepts/dm_querying).",
         "operationId": "syncContent",
         "requestBody": {
           "description": "Change filter specification",
@@ -1734,6 +1768,37 @@
             "source": "from cognite.client.data_classes.data_modeling.instances import InstanceSort\nfrom cognite.client.data_classes.data_modeling.query import Query, Select, NodeResultSetExpression, EdgeResultSetExpression, SourceSelector\nfrom cognite.client.data_classes.filters import Range, Equals\nfrom cognite.client.data_classes.data_modeling.ids import ViewId\nmovie_id = ViewId(\"mySpace\", \"MovieView\", \"v1\")\nactor_id = ViewId(\"mySpace\", \"ActorView\", \"v1\")\nquery = Query(\n    with_ = {\n        \"movies\": NodeResultSetExpression(filter=Range(movie_id.as_property_ref(\"releaseYear\"), lt=2000)),\n        \"actors_in_movie\": EdgeResultSetExpression(from_=\"movies\", filter=Equals([\"edge\", \"type\"], {\"space\": movie_id.space, \"externalId\": \"Movie.actors\"})),\n        \"actors\": NodeResultSetExpression(from_=\"actors_in_movie\"),\n    },\n    select = {\n        \"actors\": Select(\n            [SourceSelector(actor_id, [\"name\"])], sort=[InstanceSort(actor_id.as_property_ref(\"name\"))]),\n    },\n)\nres = client.data_modeling.instances.sync(query)\nquery.cursors = res.cursors\nres_new = client.data_modeling.instances.sync(query)\n"
           }
         ]
+      }
+    },
+    "/models/instances/inspect": {
+      "post": {
+        "tags": [
+          "Instances"
+        ],
+        "summary": "Inspect instances",
+        "operationId": "instanceInspect",
+        "requestBody": {
+          "description": "Change filter specification",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceInspectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "x-capability": [
+          "DataModelsAcl:READ"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/InstanceInspectResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
       }
     },
     "/events": {
@@ -1792,7 +1857,7 @@
           "Events"
         ],
         "summary": "List events",
-        "description": "List events optionally filtered on query parameters\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage. \nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Events resource description](../../) for more information.",
+        "description": "List events optionally filtered on query parameters\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Events resource description](../../) for more information.",
         "operationId": "listEvents",
         "parameters": [
           {
@@ -2050,7 +2115,7 @@
           "Events"
         ],
         "summary": "Filter events",
-        "description": "Retrieve a list of events in the same project. This operation supports pagination by cursor.\nApply Filtering and Advanced filtering criteria to select a subset of events.\n\n### Advanced filtering\nAdvanced filter lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, `exists`, etc., using boolean operators `and`, `or`, and `not`.\nIt applies to basic fields as well as metadata.\n\nSee the `advancedFilter` attribute in the example.\n\nSee more information about filtering DSL [here](https://docs.cognite.com/dev/concepts/resource_filtering_dsl/ \"filtering DSL\").\n\n#### Supported leaf filters\n| Leaf filter    | Supported fields       | Description  |\n|----------------|------------------------|--------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `exists`       | All fields             | Only includes results where the specified property exists (has value). <br /> `{\"exists\": {\"property\": [\"property\"]}}` |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `prefix`       | String type fields     | Only includes results which start with the specified value. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n| `search`       | `[\"description\"]`      | Introduced to provide functional parity with /events/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n\n##### Search\nThe `search` leaf filter provides functional parity with the `/events/search` endpoint.\nIt's available only for the `[\"description\"]` field. When specifying only this filter with no explicit ordering,\nbehavior is the same as of the `/events/search/` endpoint without specifying filters.\nExplicit sorting overrides the default ordering by relevance.\nIt's possible to use the `search` leaf filter as any other leaf filter for creating complex queries.\n\nSee the `search` filter in the `advancedFilter` attribute in the example.\n\n#### advancedFilter attribute limits\n- filter query max depth: 10\n- filter query max number of clauses: 100\n- filter by metadata is case-insensitive, and it supports filtering on keys and values up to 256 characters\n- `and` and `or` clauses must have at least one element\n- `property` array of each leaf filter has the following limitations:\n  - number of elements in the array is in the range [1, 2]\n  - elements must not be blank\n  - each element max length is 128 symbols\n  - property array must match one of the existing properties (static or dynamic metadata)\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100]\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of a primitive type (number, string)\n- `range` filter must have at least one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n  For metadata, both upper and lower bounds must be specified.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be a primitive value\n- `search` filter `value` must not be blank and the length must be in the range [1, 128]\n- filter query may have maximum 2 search leaf filters\n- maximum leaf filter string value length is different depending on the property the filter is using:\n  - `externalId` - 255\n  - `description` - 128 for the `search` filter and 255 for other filters\n  - `type` - 64\n  - `subtype` - 64\n  - `source` - 128\n  - any `metadata` key - 128 \n\n### Sorting\nBy default, events are sorted by their creation time in the ascending order.\nUse the `search` leaf filter to sort the results by relevance.\nSorting by other fields can be explicitly requested. The `order` field is optional and defaults \nto `desc` for `_score_` and `asc` for all other fields.\nThe `nulls` field is optional and defaults to `auto`. `auto` is translated to `last` \nfor the `asc` order and to `first` for the `desc` order by the service.\nPartitions are done independently of sorting: there's no guarantee of the sort order between elements from different partitions.\n\nSee the `sort` attribute in the example.\n\n#### Null values\nIn case the `nulls` attribute has the `auto` value or the attribute isn't specified,\nnull (missing) values are considered to be bigger than any other values.\nThey are placed last when sorting in the `asc` order and first when sorting in `desc`.\nOtherwise, missing values are placed according to the `nulls` attribute (last or first), and their placement doesn't depend on the `order` value.\nValues, such as empty strings, aren't considered as nulls.\n\n#### Sorting by score\nUse a special sort property `_score_` when sorting by relevance. \nThe more filters a particular event matches, the higher its score is. This can be useful,\nfor example, when building UIs. Let's assume we want exact matches to be be displayed above matches by\nprefix as in the request below. An event with the type `fire` will match both `equals` and `prefix`\nfilters and, therefore, have higher score than events with names like `fire training` that match only the `prefix` filter.\n\n```\n\"advancedFilter\" : {\n  \"or\" : [\n    {\n      \"equals\": {\n        \"property\": [\"type\"], \n        \"value\": \"fire\"\n      }\n    },\n    {\n      \"prefix\": {\n        \"property\": [\"type\"], \n        \"value\": \"fire\"\n      }\n    }\n  ]\n},\n\"sort\": [\n  {\n    \"property\" : [\"_score_\"]\n  }\n]\n```\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage. \nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Events resource description](../../) for more information.",
+        "description": "Retrieve a list of events in the same project. This operation supports pagination by cursor.\nApply Filtering and Advanced filtering criteria to select a subset of events.\n\n### Advanced filtering\nAdvanced filter lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, `exists`, etc., using boolean operators `and`, `or`, and `not`.\nIt applies to basic fields as well as metadata.\n\nSee the `advancedFilter` attribute in the example.\n\nSee more information about filtering DSL [here](https://docs.cognite.com/dev/concepts/resource_filtering_dsl/ \"filtering DSL\").\n\n#### Supported leaf filters\n| Leaf filter    | Supported fields       | Description  |\n|----------------|------------------------|--------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `exists`       | All fields             | Only includes results where the specified property exists (has value). <br /> `{\"exists\": {\"property\": [\"property\"]}}` |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}` |\n| `prefix`       | String type fields     | Only includes results which start with the specified value. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n| `search`       | `[\"description\"]`      | Introduced to provide functional parity with /events/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}` |\n\n##### Search\nThe `search` leaf filter provides functional parity with the `/events/search` endpoint.\nIt's available only for the `[\"description\"]` field. When specifying only this filter with no explicit ordering,\nbehavior is the same as of the `/events/search/` endpoint without specifying filters.\nExplicit sorting overrides the default ordering by relevance.\nIt's possible to use the `search` leaf filter as any other leaf filter for creating complex queries.\n\nSee the `search` filter in the `advancedFilter` attribute in the example.\n\n#### advancedFilter attribute limits\n- filter query max depth: 10\n- filter query max number of clauses: 100\n- filter by metadata is case-insensitive, and it supports filtering on keys and values up to 256 characters\n- `and` and `or` clauses must have at least one element\n- `property` array of each leaf filter has the following limitations:\n  - number of elements in the array is in the range [1, 2]\n  - elements must not be blank\n  - each element max length is 128 symbols\n  - property array must match one of the existing properties (static or dynamic metadata)\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100]\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of a primitive type (number, string)\n- `range` filter must have at least one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n  For metadata, both upper and lower bounds must be specified.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be a primitive value\n- `search` filter `value` must not be blank and the length must be in the range [1, 128]\n- filter query may have maximum 2 search leaf filters\n- maximum leaf filter string value length is different depending on the property the filter is using:\n  - `externalId` - 255\n  - `description` - 128 for the `search` filter and 255 for other filters\n  - `type` - 64\n  - `subtype` - 64\n  - `source` - 128\n  - any `metadata` key - 128\n\n### Sorting\nBy default, events are sorted by their creation time in the ascending order.\nUse the `search` leaf filter to sort the results by relevance.\nSorting by other fields can be explicitly requested. The `order` field is optional and defaults\nto `desc` for `_score_` and `asc` for all other fields.\nThe `nulls` field is optional and defaults to `auto`. `auto` is translated to `last`\nfor the `asc` order and to `first` for the `desc` order by the service.\nPartitions are done independently of sorting: there's no guarantee of the sort order between elements from different partitions.\n\nSee the `sort` attribute in the example.\n\n#### Null values\nIn case the `nulls` attribute has the `auto` value or the attribute isn't specified,\nnull (missing) values are considered to be bigger than any other values.\nThey are placed last when sorting in the `asc` order and first when sorting in `desc`.\nOtherwise, missing values are placed according to the `nulls` attribute (last or first), and their placement doesn't depend on the `order` value.\nValues, such as empty strings, aren't considered as nulls.\n\n#### Sorting by score\nUse a special sort property `_score_` when sorting by relevance.\nThe more filters a particular event matches, the higher its score is. This can be useful,\nfor example, when building UIs. Let's assume we want exact matches to be be displayed above matches by\nprefix as in the request below. An event with the type `fire` will match both `equals` and `prefix`\nfilters and, therefore, have higher score than events with names like `fire training` that match only the `prefix` filter.\n\n```\n\"advancedFilter\" : {\n  \"or\" : [\n    {\n      \"equals\": {\n        \"property\": [\"type\"],\n        \"value\": \"fire\"\n      }\n    },\n    {\n      \"prefix\": {\n        \"property\": [\"type\"],\n        \"value\": \"fire\"\n      }\n    }\n  ]\n},\n\"sort\": [\n  {\n    \"property\" : [\"_score_\"]\n  }\n]\n```\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Events resource description](../../) for more information.",
         "operationId": "advancedListEvents",
         "requestBody": {
           "content": {
@@ -2100,7 +2165,7 @@
           "Events"
         ],
         "summary": "Aggregate events",
-        "description": "The aggregation API lets you compute aggregated results on events, \nsuch as getting the count of all Events in a project, checking\ndifferent descriptions of events in your project, etc.\n\n#### Aggregate filtering\n##### Filter (filter & advancedFilter) data for aggregates\nFilters behave the same way as for the `Filter events` endpoint.\nIn text properties, the values are aggregated in a case-insensitive manner.\n\n##### aggregateFilter to filter aggregate results\n`aggregateFilter` works similarly to `advancedFilter` but always applies to aggregate properties.\nFor instance, in an aggregation for the `source` property, only the values (aka buckets) of the `source` property can be filtered out. \n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.  \nThe Aggregates endpoint, as with all endpoints in the Events API,  is subject to a request budget that applies \nlimits to both request rate and concurrency.\nPlease check [Events resource description](../../) for more information.",
+        "description": "The aggregation API lets you compute aggregated results on events,\nsuch as getting the count of all Events in a project, checking\ndifferent descriptions of events in your project, etc.\n\n#### Aggregate filtering\n##### Filter (filter & advancedFilter) data for aggregates\nFilters behave the same way as for the `Filter events` endpoint.\nIn text properties, the values are aggregated in a case-insensitive manner.\n\n##### aggregateFilter to filter aggregate results\n`aggregateFilter` works similarly to `advancedFilter` but always applies to aggregate properties.\nFor instance, in an aggregation for the `source` property, only the values (aka buckets) of the `source` property can be filtered out.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\\\nThe Aggregates endpoint, as with all endpoints in the Events API,  is subject to a request budget that applies\nlimits to both request rate and concurrency.\nPlease check [Events resource description](../../) for more information.",
         "operationId": "aggregateEvents",
         "requestBody": {
           "content": {
@@ -2254,7 +2319,7 @@
           "Events"
         ],
         "summary": "Search events",
-        "description": "Fulltext search for events based on result relevance. Primarily meant\nfor human-centric use-cases, not for programs, since matching and\nordering may change over time. Additional filters can also be\nspecified. This operation doesn't support pagination.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage. \nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Events resource description](../../) for more information.",
+        "description": "Fulltext search for events based on result relevance. Primarily meant\nfor human-centric use-cases, not for programs, since matching and\nordering may change over time. Additional filters can also be\nspecified. This operation doesn't support pagination.\n\n### Request throttling\nThis endpoint is meant for data analytics/exploration usage and is not suitable for high load data retrieval usage.\nIt is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Events resource description](../../) for more information.",
         "operationId": "searchEvents",
         "requestBody": {
           "content": {
@@ -2669,6 +2734,88 @@
         ]
       }
     },
+    "/files/uploadlink": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get upload file link",
+        "description": "Get an uploadUrl for a file.\n\nTo upload the file, send an HTTP PUT request to the uploadUrl from the response, with the relevant 'Content-Type' and 'Content-Length' headers.\n\nIf the uploadUrl contains the string '/v1/files/gcs_proxy/', you can make a Google Cloud Storage (GCS) resumable upload request\nas documented in https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload.\n\nThe uploadUrl expires after one week.\nAny file info entry that does not have the actual file uploaded within one week will be automatically deleted.\n\nNote: The uploadUrl from getUploadLink supports files smaller than 5 GiB.\n\nThe getMultiPartUploadLink and completeMultiPartUpload endpoints provides an alternative way to upload files, both small and large, up to 1 TiB in size.\nThese endpoints exposes a uniform multipart upload API for all cloud vendor environments for CDF. Optionally parallel part uploads can be used, for faster uploads.\n\n### Request throttling\nThis endpoint is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Files resource description](../../) for more information.",
+        "operationId": "getUploadLink",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Origin",
+            "description": "The 'Origin' header parameter is required if there is a Cross Origin issue.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Fields to be set for the file.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileDataUploadIds"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/UploadFileMetadataResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/files/multiuploadlink": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get multipart file upload link",
+        "description": "Multipart file upload enables upload of files larger than 5 GiB, using a uniform API on all cloud environments for CDF.\n\nEach file part must be larger than 5 MiB, and smaller than 4000 MiB. The file part for the last uploadURL can be smaller than 5 MiB. Maximum 250 upload URLs can be requested.\nThe supported maximum size for each file uploaded with the multi-part upload API is therefore 1000 GiB (1.073 TB / 0.976 TiB).\nThe client should calculate the ideal number of parts depending on predetermined or estimated file size, between 1 and the maximum.\nSpecify the number of parts in the `parts` URL query parameter. The `parts` parameter is required.\n\nThe request returns in addition to the file `id`, also a `uploadId`, and a list of `uploadUrls` for uploading the file contents.\nTo upload a file, send an HTTP PUT request to each of the uploadUrls, with the corresponding part of the file in the request body.\nYou may use a 'Content-Length' header in the PUT request for each part, but this is not required.\nA failed part PUT upload can be retried.\n\nThe client must ensure that the parts of the source file are stored in the correct order, using the order of the `uploadUrls` as specified in the response.\nThis to avoid ending up with a corrupt final file.\n\nThe parts can optionally be uploaded in parallel, preferably on a subset of parts at a time, for example maximum 3 concurrent PUT operations.\n\nOnce all file parts have been uploaded, the client should call the 'files/completemultipartupload' endpoint,\nwith the required file ID (as `id` or `externalId`) and `uploadId` fields in the request body. This will assemble the parts into one file.\nThe file's `uploaded` flag will then eventually be set to `true`.\n\nA standard sequence of calls to upload a large file with multipart upload would be for example as follows:\n1. POST files/initmultipartupload?parts=8, to start a multipart upload session with 8 parts. Expect a 201 CREATED response code, and a response body with information to be used in the part uploads and completemultipartupload requests.\n2. PUT `uploadUrl`, for each of the `uploadUrls` in the response from files/initmultipartupload. Expect a 200 OK or 201 CREATED response for each PUT request.\n3. POST files/completemultipartupload, with request body '{ \"id\":123456789, \"uploadId\":\"ABCD4321EFGH\" }'. This will assemble the file. Expect a 200 OK response.\n\nConsider verifying that the file is eventually marked as uploaded with a call to the getFileByInternalId endpoint.\n\nNOTE: The uploadUrls expires after one week.\nA file that does not have the file content parts uploaded and completed within one week will be automatically deleted.\n\n### Request throttling\nThis endpoint is a subject of the new throttling schema (limited request rate and concurrency).\nPlease check [Files resource description](../../) for more information.",
+        "operationId": "getMultiPartUploadLink",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "parts",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 250
+            },
+            "description": "The 'parts' parameter specifies how many uploadURLs should be returned, for uploading the file contents in parts. See main endpoint description for more details."
+          }
+        ],
+        "requestBody": {
+          "description": "Fields to be set for the file.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileDataUploadIds"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/MultiPartUploadFileMetadataResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
     "/files/{id}": {
       "get": {
         "tags": [
@@ -2865,7 +3012,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FileDataIds"
+                "$ref": "#/components/schemas/FileDeleteByIds"
               }
             }
           },
@@ -2982,6 +3129,20 @@
             "name": "externalId",
             "schema": {
               "$ref": "#/components/schemas/CogniteExternalId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "space",
+            "schema": {
+              "$ref": "#/components/schemas/InstanceSpace"
+            }
+          },
+          {
+            "in": "query",
+            "name": "instanceExternalId",
+            "schema": {
+              "$ref": "#/components/schemas/InstanceExternalId"
             }
           }
         ],
@@ -4135,7 +4296,7 @@
           "3D Files"
         ],
         "summary": "Retrieve a 3D directory file",
-        "description": "Retrieve the contents of a 3D file, for a blobId which is of a directory type. \nThis applies to the output types 'gltf-directory', 'reveal-directory', 'ept-pointcloud', 'tiles-directory', 'model-from-points'. \n\nThe 'subPath' elements, i.e. directory and/or file names, within each directory output type is subject to change and depends on each output type.\n- The 'gltf-directory' output is used by Reveal v3+ for visualizing CAD files and contains a 'scene.json' file, which describes what other files are available within the blobId.\n- The 'reveal-directory' output is used by Reveal v1-2 for visualizing CAD files and contains a 'scene.json' file, which describes what other files are available within the blobId.\n- The 'ept-pointcloud' output is used by Reveal for visualizing point clouds, and contains a 'ept.json' file. The 'ept.json' file contains general information for the point cloud data. The file named 'ept-hierarchy/0-0-0-0.json' for the same blobId lists all the output point files which can be retrieved from a 'ept-data' folder for the same blobId, e.g. 'ept-data/0-0-0-0.bin'. The '.bin' files are in a custom point cloud format following the schema in the 'ept.json' file. Additionally, a 'filterOptions.json' file contains a description of which options were used when processing the point cloud.\n\nExperimental outputs, normally not enabled:\nThe 'tiles-directory' output contains files for classification of the point cloud data. Retrieve the 'tiles.json' file from this output for a overview of the files within this output.\nThe 'model-from-points' output is used for storing a mesh based output file of some parts of the point cloud. This is stored as a 'model.ciff' file, in the Cognite internal file format.\n\nThis endpoint supports tag-based caching.\n\nThis endpoint is only compatible with 3D file IDs from the 3D API, and not compatible with\nfile IDs from the Files API.",
+        "description": "Retrieve the contents of a 3D file, for a blobId which is of a directory type.\nThis applies to the output types 'gltf-directory', 'reveal-directory', 'ept-pointcloud', 'tiles-directory', 'model-from-points'.\n\nThe 'subPath' elements, i.e. directory and/or file names, within each directory output type is subject to change and depends on each output type.\n- The 'gltf-directory' output is used by Reveal v3+ for visualizing CAD files and contains a 'scene.json' file, which describes what other files are available within the blobId.\n- The 'reveal-directory' output is used by Reveal v1-2 for visualizing CAD files and contains a 'scene.json' file, which describes what other files are available within the blobId.\n- The 'ept-pointcloud' output is used by Reveal for visualizing point clouds, and contains a 'ept.json' file. The 'ept.json' file contains general information for the point cloud data. The file named 'ept-hierarchy/0-0-0-0.json' for the same blobId lists all the output point files which can be retrieved from a 'ept-data' folder for the same blobId, e.g. 'ept-data/0-0-0-0.bin'. The '.bin' files are in a custom point cloud format following the schema in the 'ept.json' file. Additionally, a 'filterOptions.json' file contains a description of which options were used when processing the point cloud.\n\nExperimental outputs, normally not enabled:\nThe 'tiles-directory' output contains files for classification of the point cloud data. Retrieve the 'tiles.json' file from this output for a overview of the files within this output.\nThe 'model-from-points' output is used for storing a mesh based output file of some parts of the point cloud. This is stored as a 'model.ciff' file, in the Cognite internal file format.\n\nThis endpoint supports tag-based caching.\n\nThis endpoint is only compatible with 3D file IDs from the 3D API, and not compatible with\nfile IDs from the Files API.",
         "operationId": "get3DDirectoryFile",
         "parameters": [
           {
@@ -4907,7 +5068,7 @@
           {
             "name": "format",
             "in": "query",
-            "description": "Format identifier, e.g. 'ept-pointcloud' (point cloud). Well known formats are: \n'ept-pointcloud' (point cloud data) or 'reveal-directory' (output supported by Reveal). \n'all-outputs' can be used to retrieve all outputs for a 3D revision. Note that some of \nthe outputs are internal, where the format and availability might change without warning.\n",
+            "description": "Format identifier, e.g. 'ept-pointcloud' (point cloud). Well known formats are:\n'ept-pointcloud' (point cloud data) or 'reveal-directory' (output supported by Reveal).\n'all-outputs' can be used to retrieve all outputs for a 3D revision. Note that some of\nthe outputs are internal, where the format and availability might change without warning.\n",
             "schema": {
               "type": "string"
             }
@@ -5115,7 +5276,7 @@
           }
         ],
         "requestBody": {
-          "description": "The request body containing the IDs of the nodes to retrieve.  Will return error 400 if the revision is still being processed.",
+          "description": "The request body containing the IDs of the nodes to retrieve. Will return error 400 if the revision is still being processed.",
           "content": {
             "application/json": {
               "schema": {
@@ -5787,7 +5948,7 @@
           "Time series"
         ],
         "summary": "Filter time series",
-        "description": "<details>\n<summary>\nRetrieves a list of time series that match the given criteria.\n</summary>\n\n### Advanced filtering\n\nThe `advancedFilter`\nfield lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, and `exists`, by using the Boolean operators `and`, `or`, and `not`.\nFiltering applies to basic fields as well as metadata. See the `advancedFilter` syntax in the request example.\n\n\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields       | Description and example                                                                                                                                                            |\n|----------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                         |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                   |\n| `exists`       | All fields             | Only includes results where the specified property exists (has a value). <br /> `{\"exists\": {\"property\": [\"property\"]}}`                                                           |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                              |\n| `prefix`       | String type fields     | Only includes results which start with the specified text. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                     |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n | `search`       | `[\"name\"]` and `[\"description\"]` | Introduced to provide functional parity with the /timeseries/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}`                        |\n\n#### Supported properties\n\n| Property                          | Type               |\n|-----------------------------------|--------------------|\n| `[\"description\"]`                 | string             |\n| `[\"externalId\"]`                  | string             |\n| `[\"metadata\", \"<someCustomKey>\"]` | string             |\n| `[\"name\"]`                        | string             |\n| `[\"unit\"]`                        | string              |\n| `[\"unitExternalId\"]`              | string              |\n| `[\"unitQuantity\"]`                | string              |\n| `[\"assetId\"]`                     | number              |\n| `[\"assetRootId\"]`                 | number              |\n| `[\"createdTime\"]`                 | number              |\n| `[\"dataSetId\"]`                   | number              |\n| `[\"id\"]`                          | number              |\n| `[\"lastUpdatedTime\"]`             | number              |\n| `[\"isStep\"]`                      | Boolean             |\n| `[\"isString\"]`                    | Boolean             |\n| `[\"accessCategories\"]`            | array of strings    |\n| `[\"securityCategories\"]`          | array of numbers    |\n\n#### Limits\n\n- Filter query max depth: 10.\n- Filter query max number of clauses: 100.\n- `and` and `or` clauses must have at least one element (and at most 99, since each element counts\n  towards the total clause limit, and so does the `and`/`or` clause itself).\n- The `property` array of each leaf filter has the following limitations:\n  - Number of elements in the array is 1 or 2.\n  - Elements must not be null or blank.\n  - Each element max length is 256 characters.\n  - The `property` array must match one of the existing properties (static top-level property or dynamic metadata property).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100].\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of number or string type (matching the type of the given property).\n- `range` filter must have at lest one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be of number or string type (matching the type of the given property).\n- `search` filter `value` must not be blank, and the length must be in the range [1, 128], and there\n  may be at most two `search` filters in the entire filter query.\n- The maximum length of the `value` of a leaf filter that is applied to a string property is 256.\n\n### Sorting\n\nBy default, time series are sorted by their creation time in ascending order.\nSorting by another property or by several other properties can be explicitly requested via the\n`sort` field, which must contain a list\nof one or more sort specifications. Each sort specification indicates the `property` to sort on\nand, optionally, the `order` in which to sort (defaults to `asc`). If multiple sort specifications are\nsupplied, the results are sorted on the first property, and those with the same value for the first\nproperty are sorted on the second property, and so on.  \nPartitioning is done independently of sorting; there is no guarantee of sort order between elements from different partitions.\n\n#### Null values\n\nIn case the `nulls` field has the `auto` value, or the field isn't specified, null (missing) values\nare considered bigger than any other values. They are placed last when sorting in the `asc`\norder and first in the `desc` order. Otherwise, missing values are placed according to\nthe `nulls` field (`last` or `first`), and their placement won't depend on the `order`\nfield. Note that the number zero, empty strings, and empty lists are all considered\n_not_ null.\n\n#### Example\n\n```json\n{\n  \"sort\": [\n    {\n      \"property\" : [\"createdTime\"],\n      \"order\": \"desc\",\n      \"nulls\": \"last\"\n    },\n    {\n      \"property\" : [\"metadata\", \"<someCustomKey>\"]\n    }\n  ]\n}\n```\n\n\n#### Properties\n\nYou can sort on the following properties:\n\n| Property                          |\n|-----------------------------------|\n| `[\"assetId\"]`                     |\n| `[\"createdTime\"]`                 |\n| `[\"dataSetId\"]`                   |\n| `[\"description\"]`                 |\n| `[\"externalId\"]`                  |\n| `[\"lastUpdatedTime\"]`             |\n| `[\"metadata\", \"<someCustomKey>\"]` |\n| `[\"name\"]`                        |\n\n\n#### Limits\n\nThe `sort` array must contain 1 to 2 elements.\n</details>",
+        "description": "<details>\n<summary>\nRetrieves a list of time series that match the given criteria.\n</summary>\n\n### Advanced filtering\n\nThe `advancedFilter`\nfield lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, and `exists`, by using the Boolean operators `and`, `or`, and `not`.\nFiltering applies to basic fields as well as metadata. See the `advancedFilter` syntax in the request example.\n\n\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields       | Description and example                                                                                                                                                            |\n|----------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                         |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                   |\n| `exists`       | All fields             | Only includes results where the specified property exists (has a value). <br /> `{\"exists\": {\"property\": [\"property\"]}}`                                                           |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                              |\n| `prefix`       | String type fields     | Only includes results which start with the specified text. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                     |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n | `search`       | `[\"name\"]` and `[\"description\"]` | Introduced to provide functional parity with the /timeseries/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}`                        |\n\n#### Supported properties\n\n| Property                          | Type               |\n|-----------------------------------|--------------------|\n| `[\"description\"]`                 | string             |\n| `[\"externalId\"]`                  | string             |\n| `[\"metadata\", \"<someCustomKey>\"]` | string             |\n| `[\"name\"]`                        | string             |\n| `[\"unit\"]`                         | string              |\n| `[\"unitExternalId\"]`               | string              |\n| `[\"unitQuantity\"]`                 | string              |\n| `[\"instanceId\", \"space\"]`          | string              |\n| `[\"instanceId\", \"externalId\"]`     | string              |\n| `[\"assetId\"]`                      | number              |\n| `[\"assetRootId\"]`                  | number              |\n| `[\"createdTime\"]`                  | number              |\n| `[\"dataSetId\"]`                    | number              |\n| `[\"id\"]`                           | number              |\n| `[\"lastUpdatedTime\"]`              | number              |\n| `[\"isStep\"]`                       | Boolean             |\n| `[\"isString\"]`                     | Boolean             |\n| `[\"accessCategories\"]`             | array of strings    |\n| `[\"securityCategories\"]`           | array of numbers    |\n\n#### Limits\n\n- Filter query max depth: 10.\n- Filter query max number of clauses: 100.\n- `and` and `or` clauses must have at least one element (and at most 99, since each element counts\n  towards the total clause limit, and so does the `and`/`or` clause itself).\n- The `property` array of each leaf filter has the following limitations:\n  - Number of elements in the array is 1 or 2.\n  - Elements must not be null or blank.\n  - Each element max length is 256 characters.\n  - The `property` array must match one of the existing properties (static top-level property or dynamic metadata property).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100].\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of number or string type (matching the type of the given property).\n- `range` filter must have at lest one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be of number or string type (matching the type of the given property).\n- `search` filter `value` must not be blank, and the length must be in the range [1, 128], and there\n  may be at most two `search` filters in the entire filter query.\n- The maximum length of the `value` of a leaf filter that is applied to a string property is 256.\n\n### Sorting\n\nBy default, time series are sorted by their creation time in ascending order.\nSorting by another property or by several other properties can be explicitly requested via the\n`sort` field, which must contain a list\nof one or more sort specifications. Each sort specification indicates the `property` to sort on\nand, optionally, the `order` in which to sort (defaults to `asc`). If multiple sort specifications are\nsupplied, the results are sorted on the first property, and those with the same value for the first\nproperty are sorted on the second property, and so on.  \nPartitioning is done independently of sorting; there is no guarantee of sort order between elements from different partitions.\n\n#### Null values\n\nIn case the `nulls` field has the `auto` value, or the field isn't specified, null (missing) values\nare considered bigger than any other values. They are placed last when sorting in the `asc`\norder and first in the `desc` order. Otherwise, missing values are placed according to\nthe `nulls` field (`last` or `first`), and their placement won't depend on the `order`\nfield. Note that the number zero, empty strings, and empty lists are all considered\n_not_ null.\n\n#### Example\n\n```json\n{\n  \"sort\": [\n    {\n      \"property\" : [\"createdTime\"],\n      \"order\": \"desc\",\n      \"nulls\": \"last\"\n    },\n    {\n      \"property\" : [\"metadata\", \"<someCustomKey>\"]\n    }\n  ]\n}\n```\n\n\n#### Properties\n\nYou can sort on the following properties:\n\n| Property                          |\n|-----------------------------------|\n| `[\"assetId\"]`                     |\n| `[\"createdTime\"]`                 |\n| `[\"dataSetId\"]`                   |\n| `[\"description\"]`                 |\n| `[\"externalId\"]`                  |\n| `[\"lastUpdatedTime\"]`             |\n| `[\"metadata\", \"<someCustomKey>\"]` |\n| `[\"name\"]`                        |\n| `[\"instanceId\", \"space\"]`         |\n| `[\"instanceId\", \"externalId\"]`    |\n\n#### Limits\n\nThe `sort` array must contain 1 to 2 elements.\n</details>",
         "operationId": "listTimeSeries",
         "requestBody": {
           "content": {
@@ -6040,7 +6201,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TimeSeriesLookupById"
+                "$ref": "#/components/schemas/TimeSeriesLookupByIdWithoutInstanceId"
               }
             }
           },
@@ -6055,7 +6216,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResponse"
+                  "$ref": "#/components/schemas/NotFoundResponseWithoutInstanceId"
                 }
               }
             }
@@ -6125,7 +6286,7 @@
             "$ref": "#/components/responses/EmptyResponse"
           },
           "400": {
-            "description": "IDs or external IDs not found.",
+            "description": "IDs not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6269,7 +6430,7 @@
             }
           },
           "400": {
-            "description": "The time series doesn't exist.",
+            "description": "IDs not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6453,7 +6614,7 @@
           "Data point subscriptions"
         ],
         "summary": "List subscription members",
-        "description": "List all member time series for a subscription. Use nextCursor to paginate through the results.",
+        "description": "List all member time series for a subscription.\n\nFor non-filter subscriptions, either `externalId` or `instanceId` will be set. This is to be\nable to see if each time series was added by external id or instance id. If a time series\nhas been added to a subscription both by external id and by instance id, it will be listed\ntwice in the output. If a time series that belonged to the subscription has been deleted,\n`id` will not be set.\n\nUse `nextCursor` to paginate through the results.",
         "operationId": "listSubscriptionMembers",
         "parameters": [
           {
@@ -6553,7 +6714,7 @@
           "Data point subscriptions"
         ],
         "summary": "Update subscriptions",
-        "description": "Updates one or more subscriptions. Fields that are not included in the request, are not changed.",
+        "description": "Updates one or more subscriptions. Fields that are not included in the request, are not changed.\n\nIf both `instanceIds` and `timeSeriesIds` are set, they must either both be add/remove or\nboth be set operations.",
         "operationId": "updateSubscriptions",
         "requestBody": {
           "description": "The subscriptions to update",
@@ -7651,164 +7812,15 @@
         ]
       }
     },
-    "/projects": {
-      "get": {
-        "servers": [
-          {
-            "url": "https://{cluster}.cognitedata.com/api/v1",
-            "description": "The URL for the CDF cluster to connect to",
-            "variables": {
-              "cluster": {
-                "default": "api",
-                "enum": [
-                  "api",
-                  "az-tyo-gp-001",
-                  "az-eastus-1",
-                  "az-power-no-northeurope",
-                  "westeurope-1",
-                  "asia-northeast1-1",
-                  "gc-dsm-gp-001"
-                ]
-              }
-            }
-          }
-        ],
-        "tags": [
-          "Projects"
-        ],
-        "summary": "List projects",
-        "description": "The list of all projects that the user has the 'list projects' capability in.\nThe user may not have access to any resources in the listed projects, even if they have access to list the project itself.\n",
-        "operationId": "listProjects",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/ProjectListResponse"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Projects"
-        ],
-        "summary": "Create a project",
-        "description": "Creates new projects given project details.\nThis functionality is currently only available for Cognite and re-sellers of Cognite Data Fusion. Please contact Cognite Support for more information.\n",
-        "operationId": "createProject",
-        "requestBody": {
-          "description": "List of new project specifications",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DataProjectSpec"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "$ref": "#/components/responses/ProjectCreationResponse"
-          }
-        },
-        "x-capability": [
-          "projectsAcl:CREATE"
-        ]
-      }
-    },
+    "/projects": {},
     "/projects/{project}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/project"
         }
-      ],
-      "get": {
-        "servers": [
-          {
-            "url": "https://{cluster}.cognitedata.com/api/v1",
-            "description": "The URL for the CDF cluster to connect to",
-            "variables": {
-              "cluster": {
-                "default": "api",
-                "enum": [
-                  "api",
-                  "az-tyo-gp-001",
-                  "az-eastus-1",
-                  "az-power-no-northeurope",
-                  "westeurope-1",
-                  "asia-northeast1-1",
-                  "gc-dsm-gp-001"
-                ]
-              }
-            }
-          }
-        ],
-        "tags": [
-          "Projects"
-        ],
-        "summary": "Retrieve a project",
-        "description": "Retrieves information about a project given the project URL name.",
-        "operationId": "getProject",
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/ProjectResponse"
-          }
-        },
-        "x-capability": [
-          "projectsAcl:READ"
-        ],
-        "x-code-samples": [
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript SDK",
-            "source": "const projectInfo = await client.projects.retrieve('publicdata');"
-          }
-        ]
-      }
+      ]
     },
-    "/update": {
-      "post": {
-        "tags": [
-          "Projects"
-        ],
-        "summary": "Update a project",
-        "description": "Updates the project configuration.\n\n**Warning**: Updating a project will invalidate active [sessions](tag/Sessions) within that project.\n",
-        "operationId": "updateProject",
-        "requestBody": {
-          "description": "Object with updated project configuration.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Project Update Object",
-                "title": "ProjectUpdateDTO",
-                "type": "object",
-                "properties": {
-                  "update": {
-                    "$ref": "#/components/schemas/ProjectUpdateObjectDTO"
-                  }
-                },
-                "required": [
-                  "update"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/ProjectResponse"
-          }
-        },
-        "x-capability": [
-          "projectsAcl:UPDATE"
-        ],
-        "x-code-samples": [
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript SDK",
-            "source": "await client.projects.updateProject('new-project-name', {\n  update: {\n    name: {\n      set: 'New project display name',\n    }\n  }\n})"
-          }
-        ]
-      }
-    },
+    "/update": {},
     "/securitycategories": {
       "get": {
         "tags": [
@@ -8341,7 +8353,7 @@
           "Sequences"
         ],
         "summary": "Filter sequences",
-        "description": "<details>\n<summary>\nRetrieves a list of sequences that match the given criteria.\n</summary>\n\n### Advanced filtering\n\nThe `advancedFilter`\nfield lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, and `exists`, by using the Boolean operators `and`, `or`, and `not`.\nFiltering applies to basic fields as well as metadata. See the `advancedFilter` syntax in the request example.\n\n\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields       | Description and example                                                                                                                                                            |\n|----------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                         |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                   |\n| `exists`       | All fields             | Only includes results where the specified property exists (has a value). <br /> `{\"exists\": {\"property\": [\"property\"]}}`                                                           |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                              |\n| `prefix`       | String type fields     | Only includes results which start with the specified text. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                     |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n | `search`       | `[\"name\"]` and `[\"description\"]` | Introduced to provide functional parity with the /sequences/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}`                        |\n\n#### Supported properties\n\n| Property                          | Type               |\n|-----------------------------------|--------------------|\n| `[\"description\"]`                 | string             |\n| `[\"externalId\"]`                  | string             |\n| `[\"metadata\", \"<someCustomKey>\"]` | string             |\n| `[\"name\"]`                        | string             |\n| `[\"assetId\"]`                     | number              |\n| `[\"assetRootId\"]`                 | number              |\n| `[\"createdTime\"]`                 | number              |\n| `[\"dataSetId\"]`                   | number              |\n| `[\"id\"]`                          | number              |\n| `[\"lastUpdatedTime\"]`             | number              |\n| `[\"accessCategories\"]`            | array of strings    |\n\n#### Limits\n\n- Filter query max depth: 10.\n- Filter query max number of clauses: 100.\n- `and` and `or` clauses must have at least one element (and at most 99, since each element counts\n  towards the total clause limit, and so does the `and`/`or` clause itself).\n- The `property` array of each leaf filter has the following limitations:\n  - Number of elements in the array is 1 or 2.\n  - Elements must not be null or blank.\n  - Each element max length is 256 characters.\n  - The `property` array must match one of the existing properties (static top-level property or dynamic metadata property).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100].\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of number or string type (matching the type of the given property).\n- `range` filter must have at lest one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be of number or string type (matching the type of the given property).\n- `search` filter `value` must not be blank, and the length must be in the range [1, 128], and there\n  may be at most two `search` filters in the entire filter query.\n- The maximum length of the `value` of a leaf filter that is applied to a string property is 256.\n\n### Sorting\n\nBy default, sequences are sorted by their creation time in ascending order.\nSorting by another property or by several other properties can be explicitly requested via the\n`sort` field, which must contain a list\nof one or more sort specifications. Each sort specification indicates the `property` to sort on\nand, optionally, the `order` in which to sort (defaults to `asc`). If multiple sort specifications are\nsupplied, the results are sorted on the first property, and those with the same value for the first\nproperty are sorted on the second property, and so on.  \nPartitioning is done independently of sorting; there is no guarantee of sort order between elements from different partitions.\n\n#### Null values\n\nIn case the `nulls` field has the `auto` value, or the field isn't specified, null (missing) values\nare considered bigger than any other values. They are placed last when sorting in the `asc`\norder and first in the `desc` order. Otherwise, missing values are placed according to\nthe `nulls` field (`last` or `first`), and their placement won't depend on the `order`\nfield. Note that the number zero, empty strings, and empty lists are all considered\n_not_ null.\n\n#### Example\n\n```json\n{\n  \"sort\": [\n    {\n      \"property\" : [\"createdTime\"],\n      \"order\": \"desc\",\n      \"nulls\": \"last\"\n    },\n    {\n      \"property\" : [\"metadata\", \"<someCustomKey>\"]\n    }\n  ]\n}\n```\n\n\n#### Properties\n\nYou can sort on the following properties:\n\n| Property                          |\n|-----------------------------------|\n| `[\"assetId\"]`                     |\n| `[\"createdTime\"]`                 |\n| `[\"dataSetId\"]`                   |\n| `[\"description\"]`                 |\n| `[\"externalId\"]`                  |\n| `[\"lastUpdatedTime\"]`             |\n| `[\"metadata\", \"<someCustomKey>\"]` |\n| `[\"name\"]`                        |\n\n\n#### Limits\n\nThe `sort` array must contain 1 to 2 elements.\n</details>",
+        "description": "<details>\n<summary>\nRetrieves a list of sequences that match the given criteria.\n</summary>\n\n### Advanced filtering\n\nThe `advancedFilter`\nfield lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, and `exists`, by using the Boolean operators `and`, `or`, and `not`.\nFiltering applies to basic fields as well as metadata. See the `advancedFilter` syntax in the request example.\n\n\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields       | Description and example                                                                                                                                                            |\n|----------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                         |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                   |\n| `exists`       | All fields             | Only includes results where the specified property exists (has a value). <br /> `{\"exists\": {\"property\": [\"property\"]}}`                                                           |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                              |\n| `prefix`       | String type fields     | Only includes results which start with the specified text. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                     |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n | `search`       | `[\"name\"]` and `[\"description\"]` | Introduced to provide functional parity with the /sequences/search endpoint. <br /> `{\"search\": {\"property\": [\"property\"], \"value\": \"example\"}}`                        |\n\n#### Supported properties\n\n| Property                          | Type               |\n|-----------------------------------|--------------------|\n| `[\"description\"]`                 | string             |\n| `[\"externalId\"]`                  | string             |\n| `[\"metadata\", \"<someCustomKey>\"]` | string             |\n| `[\"name\"]`                        | string             |\n| `[\"assetId\"]`                      | number              |\n| `[\"assetRootId\"]`                  | number              |\n| `[\"createdTime\"]`                  | number              |\n| `[\"dataSetId\"]`                    | number              |\n| `[\"id\"]`                           | number              |\n| `[\"lastUpdatedTime\"]`              | number              |\n| `[\"accessCategories\"]`             | array of strings    |\n\n#### Limits\n\n- Filter query max depth: 10.\n- Filter query max number of clauses: 100.\n- `and` and `or` clauses must have at least one element (and at most 99, since each element counts\n  towards the total clause limit, and so does the `and`/`or` clause itself).\n- The `property` array of each leaf filter has the following limitations:\n  - Number of elements in the array is 1 or 2.\n  - Elements must not be null or blank.\n  - Each element max length is 256 characters.\n  - The `property` array must match one of the existing properties (static top-level property or dynamic metadata property).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100].\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of number or string type (matching the type of the given property).\n- `range` filter must have at lest one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be of number or string type (matching the type of the given property).\n- `search` filter `value` must not be blank, and the length must be in the range [1, 128], and there\n  may be at most two `search` filters in the entire filter query.\n- The maximum length of the `value` of a leaf filter that is applied to a string property is 256.\n\n### Sorting\n\nBy default, sequences are sorted by their creation time in ascending order.\nSorting by another property or by several other properties can be explicitly requested via the\n`sort` field, which must contain a list\nof one or more sort specifications. Each sort specification indicates the `property` to sort on\nand, optionally, the `order` in which to sort (defaults to `asc`). If multiple sort specifications are\nsupplied, the results are sorted on the first property, and those with the same value for the first\nproperty are sorted on the second property, and so on.  \nPartitioning is done independently of sorting; there is no guarantee of sort order between elements from different partitions.\n\n#### Null values\n\nIn case the `nulls` field has the `auto` value, or the field isn't specified, null (missing) values\nare considered bigger than any other values. They are placed last when sorting in the `asc`\norder and first in the `desc` order. Otherwise, missing values are placed according to\nthe `nulls` field (`last` or `first`), and their placement won't depend on the `order`\nfield. Note that the number zero, empty strings, and empty lists are all considered\n_not_ null.\n\n#### Example\n\n```json\n{\n  \"sort\": [\n    {\n      \"property\" : [\"createdTime\"],\n      \"order\": \"desc\",\n      \"nulls\": \"last\"\n    },\n    {\n      \"property\" : [\"metadata\", \"<someCustomKey>\"]\n    }\n  ]\n}\n```\n\n\n#### Properties\n\nYou can sort on the following properties:\n\n| Property                          |\n|-----------------------------------|\n| `[\"assetId\"]`                     |\n| `[\"createdTime\"]`                 |\n| `[\"dataSetId\"]`                   |\n| `[\"description\"]`                 |\n| `[\"externalId\"]`                  |\n| `[\"lastUpdatedTime\"]`             |\n| `[\"metadata\", \"<someCustomKey>\"]` |\n| `[\"name\"]`                        |\n\n#### Limits\n\nThe `sort` array must contain 1 to 2 elements.\n</details>",
         "operationId": "advancedListSequences",
         "requestBody": {
           "description": "Retrieves a list of sequences matching the given criteria.",
@@ -10283,7 +10295,7 @@
           "Vision"
         ],
         "summary": "Extract features from images",
-        "description": "Start an asynchronous prediction job for extracting features such as text, asset tags or industrial objects from images.\nThe response of the POST request contains a job ID, which can be used to make subsequent (GET) calls \nto check the status and retrieve the results of the job \n(see [Retrieve results from a feature extraction job](getVisionExtract)).\n\nIt is possible to have up to 20 concurrent jobs per CDF project.\n\nThe files referenced by `items` in the request body must fulfill the following requirements:\n\n* Must have file extension: `.jpeg`, `.jpg` or `.png`\n* Must have `image/png` or `image/jpeg` as `mimeType`\n\nNew feature extractors may be added in the future.\n",
+        "description": "Start an asynchronous prediction job for extracting features such as text, asset tags or industrial objects from images.\nThe response of the POST request contains a job ID, which can be used to make subsequent (GET) calls\nto check the status and retrieve the results of the job\n(see [Retrieve results from a feature extraction job](getVisionExtract)).\n\nIt is possible to have up to 20 concurrent jobs per CDF project.\n\nThe files referenced by `items` in the request body must fulfill the following requirements:\n\n* Must have file extension: `.jpeg`, `.jpg` or `.png`\n* Must have `image/png` or `image/jpeg` as `mimeType`\n\nNew feature extractors may be added in the future.\n",
         "operationId": "postVisionExtract",
         "parameters": [
           {
@@ -10360,8 +10372,14 @@
       }
     },
     "/context/vision/segment": {},
+    "/api/v1/projects/{projectName}/ai/services/availability": {},
+    "/api/v1/projects/{projectName}/ai/tools/documents/ask": {},
     "/api/v1/projects/{projectName}/ai/chat/completions": {},
+    "/api/v1/projects/{projectName}/ai/embeddings": {},
+    "/api/v1/projects/{projectName}/ai/tools/documents/summarize": {},
+    "/api/v1/projects/{projectName}/ai/tools/graphql/completions": {},
     "/api/v1/projects/{projectName}/ai/tools/pythonsdk/completions": {},
+    "/api/v1/projects/{projectName}/ai/tools/pythonsdk/edit": {},
     "/documents/search": {
       "post": {
         "tags": [
@@ -10390,7 +10408,8 @@
           }
         },
         "x-capability": [
-          "filesAcl:READ"
+          "filesAcl:READ",
+          null
         ],
         "x-code-samples": [
           {
@@ -11211,7 +11230,7 @@
           "Geospatial"
         ],
         "summary": "Filter all features",
-        "description": "List features based on the feature property filter passed in the body of the  request. This operation supports pagination by cursor.",
+        "description": "List features based on the feature property filter passed in the body of the request. This operation supports pagination by cursor.",
         "operationId": "listFeatures",
         "parameters": [
           {
@@ -11400,7 +11419,7 @@
           "Geospatial"
         ],
         "summary": "Search features",
-        "description": "Search for features based on the feature property filter passed in the body of the request. The result of the search is limited to a maximum of 1000 items. Results in excess of the limit are truncated. This means that the complete result set of the search cannot be retrieved with this method. However, for a given unmodified feature collection, the result of the search is deterministic  and does not change over time.",
+        "description": "Search for features based on the feature property filter passed in the body of the request. The result of the search is limited to a maximum of 1000 items. Results in excess of the limit are truncated. This means that the complete result set of the search cannot be retrieved with this method. However, for a given unmodified feature collection, the result of the search is deterministic and does not change over time.",
         "operationId": "searchFeatures",
         "parameters": [
           {
@@ -17659,7 +17678,7 @@
           "User profiles"
         ],
         "operationId": "listUserProfiles",
-        "summary": "List all user profiles",
+        "summary": "List all user profiles in the current project",
         "description": "List all user profiles in the current project. This operation supports pagination by cursor.\nThe results are ordered alphabetically by name.",
         "parameters": [
           {
@@ -17671,7 +17690,7 @@
           },
           {
             "name": "limit",
-            "description": "Limits the number of results to be returned. The server returns no more than 1000 results  even if the specified limit is larger. The default limit is 25.",
+            "description": "Limits the number of results to be returned. The server returns no more than 1000 results even if the specified limit is larger. The default limit is 25.",
             "in": "query",
             "schema": {
               "type": "integer",
@@ -17720,7 +17739,7 @@
         ],
         "operationId": "getRequesterUserProfile",
         "summary": "Get the user profile of the principal issuing the request",
-        "description": "Retrieves the user profile of the principal issuing the request.\nIf a principal doesn't have a user profile, you get a not found (404) response code.",
+        "description": "Retrieves the user profile of the principal issuing the request.\nIf a principal doesn't have a user profile, you get a not found (404) response code.\nNote: User profiles are created asyncronously, so the endpoint might return 404 for\na new principal for a while (usually seconds) until the profile has been created.",
         "responses": {
           "200": {
             "description": "",
@@ -17766,7 +17785,7 @@
           "User profiles"
         ],
         "operationId": "getUserProfilesByIds",
-        "summary": "Retrieve one or more user profiles by ID",
+        "summary": "Retrieve profiles by ID in the current project",
         "description": "Retrieve one or more user profiles indexed by the user identifier in the same CDF project.",
         "requestBody": {
           "description": "Specify a maximum of 1000 unique IDs.",
@@ -17823,8 +17842,8 @@
           "User profiles"
         ],
         "operationId": "userProfilesSearch",
-        "summary": "Search user profiles",
-        "description": "Search user profiles in the current project. The result set ordering and match criteria \nthreshold may change over time. This operation does not support pagination.",
+        "summary": "Search user profiles in the current project",
+        "description": "Search user profiles in the current project. The result set ordering and match criteria\nthreshold may change over time. This operation does not support pagination.",
         "requestBody": {
           "description": "Query for user profile search.",
           "content": {
@@ -17918,7 +17937,7 @@
                     "items": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/Workflow"
+                        "$ref": "#/components/schemas/WorkflowView"
                       }
                     }
                   }
@@ -17977,7 +17996,7 @@
                     "items": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/Workflow"
+                        "$ref": "#/components/schemas/WorkflowView"
                       }
                     },
                     "nextCursor": {
@@ -18096,7 +18115,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Workflow"
+                  "$ref": "#/components/schemas/WorkflowView"
                 }
               }
             }
@@ -18381,7 +18400,7 @@
       "post": {
         "operationId": "TriggerRunOfSpecificVersionOfWorkflow",
         "summary": "Run a workflow",
-        "description": "Trigger an execution of a specific version of a workflow.",
+        "description": "Start an execution of a specific version of a workflow.",
         "tags": [
           "Workflow executions"
         ],
@@ -18535,7 +18554,7 @@
       "post": {
         "operationId": "WorkflowExecutionCancellation",
         "summary": "Cancel a workflow execution",
-        "description": "Stops the specified execution from starting new workflow tasks and sets the workflow execution status to `TERMINATED`. Already running tasks will be marked as CANCELED.  Note that the actions taken by the canceled tasks won't be stopped, and these need to be canceled separately if desired. For example, to cancel a running transformation, use the [/transformations/cancel](#/Transformations/postApiV1ProjectsProjectTransformationsCancel) endpoint.",
+        "description": "Stops the specified execution from starting new workflow tasks and sets the workflow execution status to `TERMINATED`. Already running tasks will be marked as CANCELED. Note that the actions taken by the canceled tasks won't be stopped, and these need to be canceled separately if desired. For example, to cancel a running transformation, use the [/transformations/cancel](#/Transformations/postApiV1ProjectsProjectTransformationsCancel) endpoint.",
         "tags": [
           "Workflow executions"
         ],
@@ -18641,7 +18660,7 @@
       "post": {
         "operationId": "UpdateTaskStatus",
         "summary": "Update task status",
-        "description": "Update the status of a task that is defined to be completed asynchronously (i.e. task parameter `isAsyncComplete` is set to `true`). The status can be set to `COMPLETED`, `FAILED`, or `FAILED_WITH_TERMINAL_ERROR`.\n\n - `COMPLETED`: the workflow execution will continue according to the workflow definition.  \n - `FAILED`: the task will be retried according to the `retries` parameter for the task in the workflow definition.  \n - `FAILED_WITH_TERMINAL_ERROR`: the task won't be retried.  \nIf an `output` is provided, it'll be merged with the original output of the task.",
+        "description": "Update the status of a task that is defined to be completed asynchronously (i.e. task parameter `isAsyncComplete` is set to `true`). The status can be set to `COMPLETED`, `FAILED`, or `FAILED_WITH_TERMINAL_ERROR`.\n\n - `COMPLETED`: the workflow execution will continue according to the workflow definition.\\\n - `FAILED`: the task will be retried according to the `retries` parameter for the task in the workflow definition.\\\n - `FAILED_WITH_TERMINAL_ERROR`: the task won't be retried.\\\nIf an `output` is provided, it'll be merged with the original output of the task.",
         "tags": [
           "Tasks"
         ],
@@ -18698,6 +18717,300 @@
             "source": "res = client.workflows.tasks.update(\"000560bc-9080-4286-b242-a27bb4819253\", \"completed\")\n\nres = client.workflows.tasks.update(\"000560bc-9080-4286-b242-a27bb4819253\", \"failed\", output={\"a\": 1, \"b\": 2})\n\nres = client.workflows.executions.trigger(\"my workflow\", \"1\")\nres = client.workflows.executions.retrieve_detailed(res.id)\nres = client.workflows.tasks.update(res.tasks[1].id, \"completed\")\n"
           }
         ]
+      }
+    },
+    "/workflows/triggers": {
+      "get": {
+        "operationId": "FetchAllTriggers",
+        "summary": "List triggers",
+        "description": "List all triggers. The results are sorted by `externalId` in ascending order.",
+        "tags": [
+          "Workflow triggers"
+        ],
+        "x-capability": [
+          "workflowOrchestrationACL:READ"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of triggers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TriggerView"
+                      }
+                    },
+                    "nextCursor": {
+                      "$ref": "#/components/schemas/nextCursor"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "CreateOrUpdateTriggers",
+        "summary": "Create or update triggers",
+        "description": "Create or update a trigger.",
+        "tags": [
+          "Workflow triggers"
+        ],
+        "x-capability": [
+          "workflowOrchestrationACL:WRITE"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "externalId": {
+                          "$ref": "#/components/schemas/TriggerExternalId"
+                        },
+                        "triggerRule": {
+                          "$ref": "#/components/schemas/TriggerRule"
+                        },
+                        "input": {
+                          "$ref": "#/components/schemas/ExecutionInput"
+                        },
+                        "workflowExternalId": {
+                          "$ref": "#/components/schemas/WorkflowExternalId"
+                        },
+                        "workflowVersion": {
+                          "$ref": "#/components/schemas/Version"
+                        },
+                        "authentication": {
+                          "$ref": "#/components/schemas/Authentication"
+                        }
+                      },
+                      "required": [
+                        "externalId",
+                        "triggerRule",
+                        "workflowExternalId",
+                        "workflowVersion",
+                        "authentication"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of created or updated triggers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TriggerView"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/triggers/delete": {
+      "post": {
+        "operationId": "deleteTriggers",
+        "summary": "Delete triggers",
+        "description": "Delete a trigger.",
+        "tags": [
+          "Workflow triggers"
+        ],
+        "x-capability": [
+          "workflowOrchestrationACL:WRITE"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "externalId": {
+                          "$ref": "#/components/schemas/TriggerExternalId"
+                        }
+                      },
+                      "required": [
+                        "externalId"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/EmptyResponse"
+          }
+        }
+      }
+    },
+    "/workflows/triggers/{triggerExternalId}/history": {
+      "get": {
+        "parameters": [
+          {
+            "name": "triggerExternalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TriggerExternalId"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/cursor"
+            }
+          }
+        ],
+        "operationId": "getTriggerHistory",
+        "summary": "Get the run history of a trigger",
+        "description": "Get information about every run of a trigger. This includes timing information and a reference to the started execution (or an explanation as to why it failed). The returned items are sorted by `fireTime` in descending order (newest first), followed by `externalId` in ascending order.",
+        "tags": [
+          "Workflow triggers"
+        ],
+        "x-capability": [
+          "workflowOrchestrationACL:READ"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of runs of the trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "fireTime": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "format": "int64",
+                            "description": "The time that the trigger attempted to start the execution. Provided as epoch time in milliseconds (UTC)."
+                          },
+                          "externalId": {
+                            "$ref": "#/components/schemas/TriggerExternalId"
+                          },
+                          "workflowExternalId": {
+                            "$ref": "#/components/schemas/WorkflowExternalId"
+                          },
+                          "workflowVersion": {
+                            "$ref": "#/components/schemas/Version"
+                          },
+                          "workflowExecutionId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "maxLength": 36,
+                                "minLength": 36
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "UUIDv4 identifier for a workflow execution.",
+                            "example": "059edaa4-a17a-4102-910e-2c3591500cce"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "success",
+                              "failed"
+                            ],
+                            "description": "status of the trigger run, a being successful means that the execution has started, failure denotes that an execution could not be started."
+                          },
+                          "reasonForFailure": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "a human readable reason for the failure, null if the trigger run was successful"
+                          }
+                        },
+                        "required": [
+                          "fireTime",
+                          "externalId",
+                          "workflowExternalId",
+                          "workflowVersion",
+                          "status"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/hostedextractors/destinations": {
@@ -19678,6 +19991,1081 @@
         "summary": "Update Mappings"
       }
     },
+    "/postgresgateway": {
+      "get": {
+        "tags": [
+          "Postgres Gateway Users"
+        ],
+        "operationId": "list_users",
+        "x-capability": [
+          "postgresGateway:READ"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/100Limit_"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          }
+        ],
+        "description": "List all users in a given project. If more than `limit` users exist, a cursor for pagination will be returned with the response.",
+        "responses": {
+          "200": {
+            "description": "List of users paginated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_User_"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "List users"
+      },
+      "post": {
+        "tags": [
+          "Postgres Gateway Users"
+        ],
+        "operationId": "create_users",
+        "x-capability": [
+          "postgresGateway:WRITE"
+        ],
+        "description": "Create postgres users.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Items_CreateUser_"
+              }
+            }
+          },
+          "description": "List of postgres users to create"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_UserCreated_"
+                }
+              }
+            },
+            "description": "List of created users"
+          },
+          "400": {
+            "description": "Response of a failed request",
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "Create users"
+      }
+    },
+    "/postgresgateway/list": {
+      "post": {
+        "summary": "Filter users",
+        "tags": [
+          "Postgres Gateway Users"
+        ],
+        "operationId": "filter_users",
+        "description": "List all postgres users for a given project. If more than `limit` users exist, a cursor for pagination will be returned with the response.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FilterUsers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of users paginated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_User_"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ErrorResponse",
+            "description": "Validation Error"
+          }
+        }
+      }
+    },
+    "/postgresgateway/byids": {
+      "post": {
+        "tags": [
+          "Postgres Gateway Users"
+        ],
+        "operationId": "retreive_users",
+        "x-capability": "postgresGateway:READ",
+        "description": "Retreive a list of postgres users by their usernames, optionally ignoring unknown usernames",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemsWithIgnoreUnknown_Username_"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of users retrieved by their usernames",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithoutCursor_User_"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse",
+            "description": "Response of a failed request"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "Retrieve users"
+      }
+    },
+    "/postgresgateway/update": {
+      "post": {
+        "tags": [
+          "Postgres Gateway Users"
+        ],
+        "operationId": "update_users",
+        "x-capability": [
+          {
+            "postgresGateway": "postgresGateway:WRITE"
+          }
+        ],
+        "description": "Update postgres users",
+        "requestBody": {
+          "required": true,
+          "description": "Users to update",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Items_UserUpdate_"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns users with updates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_User_"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "Update users"
+      }
+    },
+    "/postgresgateway/delete": {
+      "post": {
+        "tags": [
+          "Postgres Gateway Users"
+        ],
+        "operationId": "delete_users",
+        "x-capability": [
+          {
+            "postgresGateway": "WRITE"
+          }
+        ],
+        "description": "Delete postgres users",
+        "requestBody": {
+          "required": true,
+          "description": "Postgres users to delete",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemsWithIgnoreUnknown_Username_"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/EmptyResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "Delete users"
+      }
+    },
+    "/postgresgateway/tables/{username}": {
+      "get": {
+        "tags": [
+          "Postgres Gateway Tables"
+        ],
+        "operationId": "list_tables",
+        "x-capability": [
+          "postgresGateway:READ"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Username"
+          },
+          {
+            "$ref": "#/components/parameters/100Limit_"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "in": "query",
+            "name": "includeBuiltIns",
+            "description": "Determines if API should return built-in tables or not",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "yes",
+                "no"
+              ],
+              "default": "no"
+            }
+          }
+        ],
+        "description": "List all tables in a given project. If more than `limit` tables exist, a cursor for pagination will be returned with the response.",
+        "responses": {
+          "200": {
+            "description": "List of tables paginated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_Table_"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "List tables"
+      },
+      "post": {
+        "tags": [
+          "Postgres Gateway Tables"
+        ],
+        "operationId": "create_tables",
+        "x-capability": [
+          "postgresGateway:WRITE"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Username"
+          }
+        ],
+        "description": "Create up to 10 tables.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Items_CreateTable_"
+              }
+            }
+          },
+          "description": "List of tables to create"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithoutCursor_TableCreated_"
+                }
+              }
+            },
+            "description": "List of created tables"
+          },
+          "400": {
+            "description": "Response of a failed request",
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "Create tables"
+      }
+    },
+    "/postgresgateway/tables/{username}/byids": {
+      "post": {
+        "tags": [
+          "Postgres Gateway Tables"
+        ],
+        "operationId": "retrieve_tables",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Username"
+          }
+        ],
+        "x-capability": "postgresGateway:READ",
+        "description": "Retreive a list of postgres tables for a user by their table names, optionally ignoring unknown table names",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemsWithIgnoreUnknown_Tablename_"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List postgres tables by table names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithoutCursor_Table_"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse",
+            "description": "Response of a failed request"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "Retrieve tables"
+      }
+    },
+    "/postgresgateway/tables/{username}/delete": {
+      "post": {
+        "tags": [
+          "Postgres Gateway Tables"
+        ],
+        "operationId": "delete_tables",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Username"
+          }
+        ],
+        "x-capability": [
+          {
+            "postgresGateway": "WRITE"
+          }
+        ],
+        "description": "Delete up to 10 tables",
+        "requestBody": {
+          "required": true,
+          "description": "Tables to delete",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemsWithIgnoreUnknown_Tablename_"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/EmptyResponse",
+            "description": "Empty response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError_"
+          }
+        },
+        "summary": "Delete tables"
+      }
+    },
+    "/writeback/sap/instances": {
+      "get": {
+        "tags": [
+          "SAP Instances"
+        ],
+        "operationId": "list_instances",
+        "x-capability": [
+          "SapWritebackAcl:READ"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Writeback100Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          }
+        ],
+        "description": "List all SAP instances in a given CDF project. If more instances exist than what the limit specifies, a pagination cursor is returned in the response body.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_Instance_"
+                }
+              }
+            },
+            "description": "List of SAP instances, and an optional cursor."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ErrorResponse",
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List SAP Instances"
+      },
+      "post": {
+        "tags": [
+          "SAP Instances"
+        ],
+        "operationId": "create_instances",
+        "x-capability": [
+          "SapWritebackAcl:WRITE"
+        ],
+        "description": "Create up to 100 SAP instances.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Items_CreateInstance_"
+              }
+            }
+          },
+          "required": true,
+          "description": "Instance to create."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_Instance_"
+                }
+              }
+            },
+            "description": "List of created instances"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse",
+            "description": "Response for a failed request"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Create SAP Instances"
+      }
+    },
+    "/writeback/sap/instances/byids": {
+      "post": {
+        "tags": [
+          "SAP Instances"
+        ],
+        "operationId": "retrieve_instances",
+        "x-capability": [
+          "SapWritebackAcl:READ"
+        ],
+        "description": "Retrieve a list of up to 100 SAP instances by their external ID, optionally ignoring unknown IDs.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WritebackItemsWithIgnoreUnknownIds_ExternalId_"
+              }
+            }
+          },
+          "required": true,
+          "description": "List of external IDs of SAP instances to retrieve."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_Instance_"
+                }
+              }
+            },
+            "description": "List of retrieved instances."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Retrieve SAP Instances"
+      }
+    },
+    "/writeback/sap/instances/delete": {
+      "post": {
+        "tags": [
+          "SAP Instances"
+        ],
+        "operationId": "delete_instances",
+        "x-capability": [
+          "SapWritebackAcl:WRITE"
+        ],
+        "description": "Delete a list of SAP instance configurations by their external ID. This operation will fail if any destination in the request is associated with an SAP endpoint configuration, unless the `force` query parameter is set to `true`.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WritebackItemsWithIgnoreUnknownIdsAndForce_ExternalId_"
+              }
+            }
+          },
+          "required": true,
+          "description": "List of SAP instance configuration external IDs to delete."
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/EmptyResponse",
+            "description": "Empty response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Delete SAP Instances"
+      }
+    },
+    "/writeback/sap/endpoints": {
+      "get": {
+        "tags": [
+          "SAP Endpoints"
+        ],
+        "operationId": "list_endpoints",
+        "x-capability": [
+          "SapWritebackAcl:READ"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Writeback100Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          }
+        ],
+        "description": "List all SAP endpoints in a given CDF project. If more instances exist than what the limit specifies, a pagination cursor is returned in the response body.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_Endpoint_"
+                }
+              }
+            },
+            "description": "List of endpoints and an optional cursor."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/ErrorResponse",
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List SAP Endpoints"
+      },
+      "post": {
+        "tags": [
+          "SAP Endpoints"
+        ],
+        "operationId": "create_endpoints",
+        "x-capability": [
+          "SapWritebackAcl:WRITE"
+        ],
+        "description": "Create up to 100 SAP endpoints.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Items_CreateEndpoint_"
+              }
+            }
+          },
+          "required": true,
+          "description": "Endpoint to create."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_Endpoint_"
+                }
+              }
+            },
+            "description": "List of created endpoints"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse",
+            "description": "Response for a failed request"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Create SAP Endpoints"
+      }
+    },
+    "/writeback/sap/endpoints/byids": {
+      "post": {
+        "tags": [
+          "SAP Endpoints"
+        ],
+        "operationId": "retrieve_endpoints",
+        "x-capability": [
+          "SapWritebackAcl:READ"
+        ],
+        "description": "Retrieve a list of up to 100 SAP endpoints by their external ID, optionally ignoring unknown IDs.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WritebackItemsWithIgnoreUnknownIds_ExternalId_"
+              }
+            }
+          },
+          "required": true,
+          "description": "List of external IDs of SAP endpoint configurations to retrieve."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_Endpoint_"
+                }
+              }
+            },
+            "description": "List of retrieved SAP endpoint configurations."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Retrieve SAP Endpoints"
+      }
+    },
+    "/writeback/sap/endpoints/delete": {
+      "post": {
+        "tags": [
+          "SAP Endpoints"
+        ],
+        "operationId": "delete_endpoints",
+        "x-capability": [
+          "SapWritebackAcl:WRITE"
+        ],
+        "description": "Delete a list of SAP endpoint configurations by their external ID. This operation will fail if any endpoint in the request is associated to a SAP instance configuration.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WritebackItemsWithIgnoreUnknownIds_ExternalId_"
+              }
+            }
+          },
+          "required": true,
+          "description": "A list of External IDs for SAP endpoint configurations to delete."
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/EmptyResponse",
+            "description": "Empty response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Delete SAP Endpoints"
+      }
+    },
+    "/writeback/sap/endpoints/verify": {
+      "post": {
+        "tags": [
+          "SAP Endpoints"
+        ],
+        "operationId": "verify_endpoints",
+        "x-capability": [
+          "SapWritebackAcl:WRITE"
+        ],
+        "description": "Verify the connectivity between the writeback API, and the SAP endpoint destination.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WritebackExternalIdWrapper"
+              }
+            }
+          },
+          "required": true,
+          "description": "SAP Endpoint external ID which the connection test should be verified."
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ConnectionCheck",
+            "description": "Connection Check Result"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Verify SAP Endpoint"
+      }
+    },
+    "/writeback/sap/mappings": {
+      "get": {
+        "tags": [
+          "Schema Mappings"
+        ],
+        "operationId": "list_schema_mappings",
+        "x-capability": [
+          "SapWritebackAcl:READ"
+        ],
+        "description": "List all mappings in a given CDF project. If more instances exist than what the limit specifies, a pagination cursor is returned in the response body.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Writeback100Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_SchemaMapping_"
+                }
+              }
+            },
+            "description": "List of mappings and an optional cursor."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "List Mappings"
+      },
+      "post": {
+        "tags": [
+          "Schema Mappings"
+        ],
+        "operationId": "create_schema_mappings",
+        "x-capability": [
+          "SapWritebackAcl:WRITE"
+        ],
+        "description": "Create a maximum of 100 mappings.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Items_CreateSchemaMapping_"
+              }
+            }
+          },
+          "required": true,
+          "description": "Mappings to create."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_SchemaMapping_"
+                }
+              }
+            },
+            "description": "List of created mappings"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Create Mappings"
+      }
+    },
+    "/writeback/sap/mappings/byids": {
+      "post": {
+        "operationId": "retrieve_schema_mappings",
+        "x-capability": [
+          "SapWritebackAcl:READ"
+        ],
+        "tags": [
+          "Schema Mappings"
+        ],
+        "description": "Retrieve a list of up to 100 mappings by their external ID, optionally ignoring unknown IDs.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "cdf-version",
+            "required": false,
+            "schema": {
+              "title": "Cdf-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WritebackItemsWithIgnoreUnknownIds_ExternalId_"
+              }
+            }
+          },
+          "required": true,
+          "description": "List of external IDs of mappings to retrieve."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_Mapping_"
+                }
+              }
+            },
+            "description": "List of retrieved mappings."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Retrieve Mappings"
+      }
+    },
+    "/writeback/sap/mappings/delete": {
+      "post": {
+        "operationId": "delete_schema_mappings",
+        "x-capability": [
+          "SapWritebackAcl:WRITE"
+        ],
+        "tags": [
+          "Schema Mappings"
+        ],
+        "description": "Delete a list of mappings by their external ID.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WritebackItemsWithIgnoreUnknownIds_ExternalId_"
+              }
+            }
+          },
+          "required": true,
+          "description": "List of external IDs of mappings to delete."
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/EmptyResponse",
+            "description": "Empty response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Delete Mappings"
+      }
+    },
+    "/writeback/sap/requests": {
+      "get": {
+        "tags": [
+          "Writeback Requests"
+        ],
+        "operationId": "list_writeback_requests",
+        "x-capability": [
+          "SapWritebackRequestsAcl:LIST"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Writeback100Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          }
+        ],
+        "description": "List all writeback requests in a given CDF project. If more instances exist than what the limit specifies, a pagination cursor is returned in the response body.",
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemsWithCursor_ListRequestMinimal_"
+                }
+              }
+            },
+            "description": "List of endpoints and an optional cursor."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError",
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Writeback Requests"
+      },
+      "post": {
+        "tags": [
+          "Writeback Requests"
+        ],
+        "operationId": "create_writeback_requests",
+        "x-capability": [
+          "SapWritebackRequestsAcl:WRITE"
+        ],
+        "description": "Create up to 100 writeback requests.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Items_CreateRequest_"
+              }
+            }
+          },
+          "required": true,
+          "description": "Request to create."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_CreateRequestResponse_"
+                }
+              }
+            },
+            "description": "List of created endpoints"
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse",
+            "description": "Response for a failed request"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Create Writeback Requests"
+      }
+    },
+    "/writeback/sap/requests/byids": {
+      "post": {
+        "tags": [
+          "Writeback Requests"
+        ],
+        "operationId": "retrieve_writeback_requests",
+        "x-capability": [
+          "SapWritebackRequestsAcl:WRITE"
+        ],
+        "description": "Retrieve a list of up to 100 writeback requests by their external ID, optionally ignoring unknown IDs.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemsWithIgnoreUnknownIds_RequestId_"
+              }
+            }
+          },
+          "required": true,
+          "description": "List of external IDs of writeback requests to retrieve."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Items_RequestFull_"
+                }
+              }
+            },
+            "description": "List of retrieved writeback requests."
+          },
+          "400": {
+            "$ref": "#/components/responses/400ErrorResponse"
+          },
+          "422": {
+            "$ref": "#/components/responses/WritebackValidationError"
+          }
+        },
+        "summary": "Retrieve Writeback Requests"
+      }
+    },
     "/simulators/run": {},
     "/simulators/runs/list": {},
     "/simulators/run/callback": {},
@@ -19685,9 +21073,11 @@
     "/simulators/runs/data/list": {},
     "/simulators/integrations/list": {},
     "/simulators/integrations/update": {},
+    "/simulators/integrations/delete": {},
     "/simulators/integrations": {},
     "/simulators/models": {},
     "/simulators/models/list": {},
+    "/simulators/models/aggregate": {},
     "/simulators/models/delete": {},
     "/simulators/models/update": {},
     "/simulators/models/byids": {},
@@ -19873,6 +21263,207 @@
           }
         ]
       }
+    },
+    "/api/v1/orgs/{org}/orgs": {
+      "servers": [
+        {
+          "url": "https://auth.cognite.com"
+        }
+      ],
+      "post": {
+        "operationId": "createChildOrg",
+        "summary": "Create an organization",
+        "security": [
+          {
+            "org-oidc-token": []
+          }
+        ],
+        "description": "Create a child organization under the specified organization.\n\n#### Access control\nRequires the caller to be an admin in the parent organization (i.e. the one on the path), or any of its ancestors.\nIn addition, the flag `adminsCanCreateOrgsInSubtree` must be set to `true` in that organization.\n\n_Example:_ Assume an organization hierarchy like: `org-a` -> `org-b` -> `org-c`.\nTo create a new organization under `org-c`, which means calling 'POST /api/v1/orgs/org-c/orgs', the caller must be an\nadmin in at least one of `org-a`, `org-b`, or `org-c`, and `adminsCanCreateOrgsInSubtree` must be `true` in that same organization.",
+        "tags": [
+          "Organizations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrgId"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/OrganizationRequestDto"
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/OrganizationResponseDto"
+          },
+          "403": {
+            "description": "Creation forbidden: The caller is not allowed to create sub-organizations."
+          }
+        }
+      },
+      "get": {
+        "operationId": "listChildOrgs",
+        "summary": "List child organizations",
+        "security": [
+          {
+            "org-oidc-token": []
+          }
+        ],
+        "description": "List all child organizations under the specified parent organization.\n\n#### Access control\nRequires the caller to be an admin in the parent organization (i.e. the one on the path), or any of its ancestors.\n\n_Example:_ Assume an organization hierarchy like: `org-a` -> `org-b` -> `org-c`.\nTo list child organizations under `org-b`, which means calling 'GET /api/v1/orgs/org-b/orgs', the caller must be an\nadmin in `org-a` or `org-b`.",
+        "tags": [
+          "Organizations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrgId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/OrganizationListResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/orgs/{org}": {
+      "servers": [
+        {
+          "url": "https://auth.cognite.com"
+        }
+      ],
+      "get": {
+        "operationId": "getOrg",
+        "summary": "Retrieve an organization",
+        "security": [
+          {
+            "org-oidc-token": []
+          }
+        ],
+        "description": "Retrieve an organization by its ID.\n\n#### Access control\nRequires the caller to be an admin in the organization, or any of its ancestors.\n\n_Example:_ Assume an organization hierarchy like: `org-a` -> `org-b` -> `org-c`.\nTo retrieve `org-c`, which means calling 'GET /api/v1/orgs/org-c', the caller must be an admin in `org-a`, `org-b` or\n`org-c`.",
+        "tags": [
+          "Organizations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrgId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/OrganizationWithContactPersonsResponseDto"
+          }
+        }
+      }
+    },
+    "/api/v1/orgs/{org}/delete": {
+      "servers": [
+        {
+          "url": "https://auth.cognite.com"
+        }
+      ],
+      "post": {
+        "operationId": "deleteOrg",
+        "summary": "Delete an organization",
+        "security": [
+          {
+            "org-oidc-token": []
+          }
+        ],
+        "description": "Delete an organization. Users will be locked out of the organization immediately. This also applies to the caller.\n\nThe organization cannot contain sub-organizations or projects at the time of deletion.\n\nThis is a soft-delete, so Cognite Support can restore the organization in case of accidents.\n\n#### Access control\nRequires the caller to be an admin in the organization, or any of its ancestors.\n\n_Example:_ Assume an organization hierarchy like: `org-a` -> `org-b` -> `org-c`.\nTo delete `org-c`, which means calling 'POST /api/v1/orgs/org-c/delete', the caller must be an admin in `org-a`, `org-b` or\n`org-c`.",
+        "tags": [
+          "Organizations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrgId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful deletion",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/orgs/{org}/projects": {
+      "servers": [
+        {
+          "url": "https://auth.cognite.com"
+        }
+      ],
+      "post": {
+        "operationId": "createChildProject",
+        "summary": "Create a project",
+        "security": [
+          {
+            "org-oidc-token": []
+          }
+        ],
+        "description": "Create a project in the specified organization, in the given cluster. The project is immediately available\nfor login in Cognite applications, for example through Cognite Data Fusion.\n\n#### Cluster placement\nThe chosen cluster must be one of the allowed clusters for the organization.\n\nThe project cannot be moved to a different cluster after creation, so make sure to choose the correct one\nwith respect to data locality requirements.\n\n#### Project OIDC configuration\nThe OIDC configuration will be copied from the immediate parent organization.\n\nThe caller can, and should, set an initial admin group ID for the project. That group is managed by the external\nidentity provider, as for the organization.\nIf that group is not set, the project will inherit the admin group ID of the organization it's created in.\nSee the `projectAdminGroupId` field in the request body for more details on this behavior.\n\n#### Access control\nRequires the caller to be an admin in the organization, or any of its ancestors.\nIn addition, the flag `adminsCanCreateProjectsInSubtree` must be set to `true` in that organization.\n\n_Example:_ Assume an organization hierarchy like: `org-a` -> `org-b` -> `org-c`.\nTo create a project in `org-c`, which means calling 'POST /api/v1/orgs/org-c/projects', the caller must be an admin in\n`org-a`, `org-b` or `org-c`.\nAlso, `adminsCanCreateProjectsInSubtree` must be `true` in that same organization.",
+        "tags": [
+          "Projects"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrgId"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/NewProjectListRequestDto"
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/NewProjectListResponseDto"
+          },
+          "403": {
+            "description": "Creation forbidden: The caller is not allowed to create projects."
+          }
+        }
+      },
+      "get": {
+        "operationId": "listChildProjects",
+        "summary": "List projects in an organization",
+        "security": [
+          {
+            "org-oidc-token": []
+          }
+        ],
+        "description": "List all projects in the specified organization.\n\n#### Access control\nIf `includeAdminProperties` is true, it requires the caller to be an admin in the organization, or any of its ancestors.\nOtherwise, it requires the caller to be a member of the organization.\n\n_Example:_ Assume an organization hierarchy like: `org-a` -> `org-b` -> `org-c`.\nTo list projects in `org-c`, which means calling 'GET /api/v1/orgs/org-c/projects?includeAdminProperties',\nthe caller must be an admin in `org-a`, `org-b` or `org-c`.",
+        "tags": [
+          "Projects"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrgId"
+          },
+          {
+            "name": "includeAdminProperties",
+            "in": "query",
+            "description": "Whether to include admin properties of the projects in the response.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ProjectResponseDto"
+          }
+        }
+      }
+    },
+    "/api/v0/orgs/{org}/projects": {
+      "servers": [
+        {
+          "url": "https://auth.cognite.com"
+        }
+      ]
     }
   },
   "components": {
@@ -19924,6 +21515,11 @@
         "type": "http",
         "description": "Users log in via an OpenID/OAuth flow. Use the /login/redirect flow to obtain a bearer access token. Use a header key of 'Authorization' with a value of 'Bearer: $accesstoken'",
         "scheme": "bearer"
+      },
+      "org-oidc-token": {
+        "type": "openIdConnect",
+        "openIdConnectUrl": "https://auth.cognite.com/.well-known/openid-configuration",
+        "description": "Access token issued by the Cognite authorization server, and valid for the target organization. The token must\nbe an OpenID Connect token, and it can be obtained by performing an OIDC login flow toward `auth.cognite.com`.\nThis is a single URL for all CDF organizations."
       }
     },
     "schemas": {
@@ -20148,6 +21744,17 @@
             }
           },
           {
+            "title": "Industrial Log Analytics Instances Capability",
+            "properties": {
+              "ilaInstancesAcl": {
+                "$ref": "#/components/schemas/cogniteilainstances_aclAcl"
+              },
+              "projectScope": {
+                "$ref": "#/components/schemas/ProjectScope"
+              }
+            }
+          },
+          {
             "title": "Relationships Capability",
             "properties": {
               "relationshipsAcl": {
@@ -20259,6 +21866,34 @@
           }
         ]
       },
+      "InstanceSpace": {
+        "type": "string",
+        "pattern": "^[a-zA-Z][a-zA-Z0-9_-]{0,41}[a-zA-Z0-9]?$",
+        "minLength": 1,
+        "maxLength": 43
+      },
+      "InstanceExternalId": {
+        "type": "string",
+        "pattern": "^[a-zA-Z]([a-zA-Z0-9_]{0,253}[a-zA-Z0-9])?$",
+        "minLength": 1,
+        "maxLength": 255
+      },
+      "SessionCredentials": {
+        "additionalProperties": false,
+        "properties": {
+          "nonce": {
+            "title": "Nonce",
+            "type": "string",
+            "description": "Session nonce for a recently created CDF Session."
+          }
+        },
+        "required": [
+          "nonce"
+        ],
+        "title": "SessionCredentials",
+        "type": "object",
+        "description": "Credentials for authenticating towards CDF using a CDF session."
+      },
       "ResourceDescription": {
         "type": "string",
         "description": "The description of the resource type.",
@@ -20366,7 +22001,7 @@
           },
           "message": {
             "type": "string",
-            "description": "The error message specifies which kind of throttling happened: \n  - Too many concurrent requests for a single project or an identity.\n  - Too high rate of requests for a single project or an identity.\n\nSee more [here](https://docs.cognite.com/dev/concepts/request_throttling/ \"requests throttling\").",
+            "description": "The error message specifies which kind of throttling happened:\n  - Too many concurrent requests for a single project or an identity.\n  - Too high rate of requests for a single project or an identity.\n\nSee more [here](https://docs.cognite.com/dev/concepts/request_throttling/ \"requests throttling\").",
             "example": "Project exceeded maximum number='50' of concurrent requests. Please try again later."
           }
         }
@@ -20802,7 +22437,7 @@
         }
       },
       "Partition": {
-        "description": "Splits the data set into `N` partitions. \nThe attribute is specified as a \"M/N\" string, where `M` is a natural number in the interval of `[1, N]`.\nYou need to follow the cursors within each partition in order to receive all the data.\n\nTo prevent unexpected problems and maximize read throughput, you should at most use 10 (N <= 10) partitions.\n\nWhen using more than 10 partitions, CDF may reduce the number of partitions silently.\nFor example, CDF may reduce the number of partitions to `K = 10` so if you specify an `X/N` `partition` value where `X = 8` and `N = 20` - i.e. `\"partition\": \"8/20\"`- then\nCDF will change `N` to `N = K = 10` and process the request. \nBut if you  specify the `X/N` `partition` value where `X = 11` (`X > K`) and `N = 20` - i.e. `\"partition\": \"11/20\"`- then\nCDF will reply with an empty result list and no cursor in the response.  \n\nIn future releases of the resource APIs, Cognite may reject requests if you specify more than 10 partitions.\nWhen Cognite enforces this behavior, the requests will result in a 400 Bad Request status.\n",
+        "description": "Splits the data set into `N` partitions.\nThe attribute is specified as a \"M/N\" string, where `M` is a natural number in the interval of `[1, N]`.\nYou need to follow the cursors within each partition in order to receive all the data.\n\nTo prevent unexpected problems and maximize read throughput, you should at most use 10 (N <= 10) partitions.\n\nWhen using more than 10 partitions, CDF may reduce the number of partitions silently.\nFor example, CDF may reduce the number of partitions to `K = 10` so if you specify an `X/N` `partition` value where `X = 8` and `N = 20` - i.e. `\"partition\": \"8/20\"`- then\nCDF will change `N` to `N = K = 10` and process the request.\nBut if you  specify the `X/N` `partition` value where `X = 11` (`X > K`) and `N = 20` - i.e. `\"partition\": \"11/20\"`- then\nCDF will reply with an empty result list and no cursor in the response.\\\n\nIn future releases of the resource APIs, Cognite may reject requests if you specify more than 10 partitions.\nWhen Cognite enforces this behavior, the requests will result in a 400 Bad Request status.\n",
         "type": "string",
         "example": "1/10"
       },
@@ -21324,6 +22959,26 @@
         "maxLength": 255,
         "example": "my.known.id"
       },
+      "CogniteInstanceId": {
+        "description": "The ID of an [instance in Cognite Data Models](https://docs.cognite.com/cdf/dm/dm_concepts/dm_spaces_instances#instance).",
+        "type": "object",
+        "required": [
+          "space",
+          "externalId"
+        ],
+        "properties": {
+          "space": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 43
+          },
+          "externalId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          }
+        }
+      },
       "CogniteExternalIdPrefix": {
         "description": "Filter by this (case-sensitive) prefix for the external ID.",
         "type": "string",
@@ -21405,6 +23060,15 @@
         "minimum": 1,
         "maximum": 9007199254740991,
         "format": "int64"
+      },
+      "DataModelingStatus": {
+        "type": "string",
+        "description": "Status of data modeling for a project.",
+        "enum": [
+          "DATA_MODELING_ONLY",
+          "DATA_MODELING_FIRST",
+          "HYBRID"
+        ]
       },
       "TimestampOrStringStart": {
         "oneOf": [
@@ -22072,7 +23736,7 @@
         }
       },
       "FilterProperty": {
-        "description": "Property you want to filter. Use a list of strings to specify nested properties.\n\n<u>Example:</u>\n\nYou have the object \n```\n{\n  \"room\": {\n    \"id\": \"b53\"\n  }, \n  \"roomId\": \"a23\"\n}\n```\n\nUse `[\"room\", \"id\"]` to return the value in the nested `id` property, which is a part of the `room` object. \n\nYou can also read the value(s) in the standalone property `roomId` with `[\"roomId\"]`.\n",
+        "description": "Property you want to filter. Use a list of strings to specify nested properties.\n\n<u>Example:</u>\n\nYou have the object\n```\n{\n  \"room\": {\n    \"id\": \"b53\"\n  },\n  \"roomId\": \"a23\"\n}\n```\n\nUse `[\"room\", \"id\"]` to return the value in the nested `id` property, which is a part of the `room` object.\n\nYou can also read the value(s) in the standalone property `roomId` with `[\"roomId\"]`.\n",
         "type": "array",
         "minItems": 1,
         "maxItems": 3,
@@ -22081,7 +23745,7 @@
         }
       },
       "AggregateProperty": {
-        "description": "Property you want to aggregate.\nUse a list of strings to specify nested properties.\nThe same way the properties are represented in aggregate responses.\n\n<u>Example:</u>\n\nYou have the object \n```\n{\n  \"metadata\": {\n    \"id\": \"b53\"\n  }, \n  \"source\": \"a23\"\n}\n```\n\nTo address \"id\" metadata key use `[\"metadata\", \"id\"]` property.         \nYou can also aggregate the value(s) for the standalone property `source` with `[\"source\"]`.\n",
+        "description": "Property you want to aggregate.\nUse a list of strings to specify nested properties.\nThe same way the properties are represented in aggregate responses.\n\n<u>Example:</u>\n\nYou have the object\n```\n{\n  \"metadata\": {\n    \"id\": \"b53\"\n  },\n  \"source\": \"a23\"\n}\n```\n\nTo address \"id\" metadata key use `[\"metadata\", \"id\"]` property.\\\nYou can also aggregate the value(s) for the standalone property `source` with `[\"source\"]`.\n",
         "type": "array",
         "minItems": 1,
         "maxItems": 2,
@@ -22120,6 +23784,7 @@
         }
       },
       "RangeValue": {
+        "title": "rangeBound",
         "description": "Value you wish to find in the provided property using a range clause.",
         "oneOf": [
           {
@@ -23653,7 +25318,7 @@
               "properties": {
                 "property": {
                   "type": "array",
-                  "description": "It's an array of strings to allow specifying nested properties.\n  Supported properties:           \n  | Property                        | Type                         |\n  |---------------------------------|------------------------------|\n  | `[\"dataSetId\"]`                 | number                       |\n  | `[\"description\"]`               | string                       |\n  | `[\"labels\"]`                    | array of [string]            |\n  | `[\"name\"]`                      | string                       |\n  | `[\"parentId\"]`                  | number                       |\n  | `[\"rootId\"]`                    | number                       |\n  | `[\"source\"]`                    | string                       |\n  | `[\"metadata\"]`                  | string                       |\n  | `[\"metadata\", <key>]`           | string                       |",
+                  "description": "It's an array of strings to allow specifying nested properties.\n  Supported properties:\\\n  | Property                        | Type                         |\n  |---------------------------------|------------------------------|\n  | `[\"dataSetId\"]`                 | number                       |\n  | `[\"description\"]`               | string                       |\n  | `[\"labels\"]`                    | array of [string]            |\n  | `[\"name\"]`                      | string                       |\n  | `[\"parentId\"]`                  | number                       |\n  | `[\"rootId\"]`                    | number                       |\n  | `[\"source\"]`                    | string                       |\n  | `[\"metadata\"]`                  | string                       |\n  | `[\"metadata\", <key>]`           | string                       |",
                   "minItems": 1,
                   "maxItems": 2,
                   "items": {
@@ -24381,7 +26046,7 @@
             ]
           },
           "source": {
-            "description": "Indicates on what type a referenced direct relation is expected to be (although not required).  Only applicable for direct relation properties.",
+            "description": "Indicates on what type a referenced direct relation is expected to be (although not required). Only applicable for direct relation properties.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ViewReference"
@@ -24482,7 +26147,7 @@
             "properties": {
               "views": {
                 "type": "array",
-                "description": "List of views included in this data model.  We can expand the views to use the full view definitions, \ni.e. with all the dependent views.  \n\nUse the ```InlineViews``` query parameter to request expansion.  If you do not set the \n```InlineViews``` query parameter, we will return the references to views instead.\n",
+                "description": "List of views included in this data model.  We can expand the views to use the full view definitions,\ni.e. with all the dependent views.\n\nUse the ```InlineViews``` query parameter to request expansion.  If you do not set the\n```InlineViews``` query parameter, we will return the references to views instead.\n",
                 "items": {
                   "$ref": "#/components/schemas/DataModelProperty"
                 }
@@ -24521,7 +26186,7 @@
             "properties": {
               "views": {
                 "type": "array",
-                "description": "List of views included in this data model.  You can use a reference to an existing view to specify  the new view.  Or you can create a new view/update an existing view by including an existing view  specification.",
+                "description": "List of views included in this data model.  You can use a reference to an existing view to specify the new view.  Or you can create a new view/update an existing view by including an existing view specification.",
                 "items": {
                   "$ref": "#/components/schemas/DataModelCreateProperty"
                 }
@@ -24566,7 +26231,7 @@
             "properties": {
               "properties": {
                 "type": "object",
-                "description": "View with included properties and expected edges, indexed by a unique space-local identifier.   The view identifier has to have a length of between 1 and 255 characters.  It must also match the  pattern ```^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$```, and it cannot be any of the following  reserved identifiers: ```space```, ```externalId```, ```createdTime```, ```lastUpdatedTime```, ```deletedTime```, ```edge_id```, ```node_id```, ```project_id```, ```property_group```, ```seq```, ```tg_table_name```, and ```extensions```. The maximum number of properties depends on the project subscription and is by default 100.",
+                "description": "View with included properties and expected edges, indexed by a unique space-local identifier. The view identifier has to have a length of between 1 and 255 characters.  It must also match the pattern ```^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$```, and it cannot be any of the following reserved identifiers: ```space```, ```externalId```, ```createdTime```, ```lastUpdatedTime```, ```deletedTime```, ```edge_id```, ```node_id```, ```project_id```, ```property_group```, ```seq```, ```tg_table_name```, and ```extensions```. The maximum number of properties depends on the project subscription and is by default 100.",
                 "additionalProperties": {
                   "x-additionalPropertiesName": "property-identifier",
                   "allOf": [
@@ -24581,7 +26246,7 @@
         ]
       },
       "ViewCreateDefinitionProperty": {
-        "description": "A reference to a container property (ViewProperty) or a connection describing edges that are expected to\nexist (ConnectionDefinition).\n\nIf the referenced container property is a direct relation, a view of the node can be specified. The view is\na hint to the consumer on what type of data is expected to be of interest in the context of this view.\n\nA connection describes the edges that are likely to exist to aid in discovery and documentation of the view. \nA listed edge is not required. i.e. It does not have to exist when included in this list. The target nodes of\nthis connection will match the view specified in the source property. A connection has a max distance of one hop\nin the underlying graph.\n",
+        "description": "A reference to a container property or a connection describing edges that are expected to\nexist (ConnectionDefinition).\n\nIf the referenced container property is a direct relation, a view of the node can be specified. The view is\na hint to the consumer on what type of data is expected to be of interest in the context of this view.\n\nA connection describes the edges that are likely to exist to aid in discovery and documentation of the view.\nA listed edge is not required. i.e. It does not have to exist when included in this list. The target nodes of\nthis connection will match the view specified in the source property. A connection has a max distance of one hop\nin the underlying graph.\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CreateViewProperty"
@@ -24618,9 +26283,11 @@
               "createdTime",
               "lastUpdatedTime",
               "writable",
+              "queryable",
               "properties",
               "usedFor",
-              "isGlobal"
+              "isGlobal",
+              "mappedContainers"
             ],
             "properties": {
               "createdTime": {
@@ -24631,7 +26298,11 @@
               },
               "writable": {
                 "type": "boolean",
-                "description": "Does the view support write operations, i.e. is it ```writable```?  You can write to a view if the  view maps all non-nullable properties."
+                "description": "Does the view support write operations, i.e. is it ```writable```?  You can write to a view if the view maps all non-nullable properties."
+              },
+              "queryable": {
+                "type": "boolean",
+                "description": "Does the view support queries, i.e. is it queryable? You can query a view if it either has a filter or at least one property mapped to a container."
               },
               "usedFor": {
                 "$ref": "#/components/schemas/UsedFor"
@@ -24642,7 +26313,7 @@
               },
               "properties": {
                 "type": "object",
-                "description": "List of properties and connections included in this view.  The view identifier has to have a length of between 1 and 255 characters.  It must also match the pattern  ```^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$```.",
+                "description": "List of properties and connections included in this view.  The view identifier has to have a length of between 1 and 255 characters.  It must also match the pattern ```^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$```.",
                 "additionalProperties": {
                   "x-additionalPropertiesName": "view-property-identifier",
                   "allOf": [
@@ -24650,6 +26321,13 @@
                       "$ref": "#/components/schemas/ViewDefinitionProperty"
                     }
                   ]
+                }
+              },
+              "mappedContainers": {
+                "type": "array",
+                "description": "List of containers with properties mapped by this view.",
+                "items": {
+                  "$ref": "#/components/schemas/ContainerReference"
                 }
               }
             }
@@ -24662,7 +26340,7 @@
             "$ref": "#/components/schemas/ViewPropertyDefinition"
           },
           {
-            "$ref": "#/components/schemas/ConnectionDefinition"
+            "$ref": "#/components/schemas/ConnectionDefinitionRead"
           }
         ]
       },
@@ -24696,7 +26374,7 @@
           },
           "implements": {
             "type": "array",
-            "description": "References to the views from where this view will inherit properties and edges.\n\n\nNote: The order you list the views in is significant. We use this order to deduce the priority when we encounter duplicate property references.\n\n\nIf you do not specify a view version, we will use the most recent version available at the time of creation. ",
+            "description": "References to the views from where this view will inherit properties - both mapped properties (properties pointing to container properties like text, integers, direct relations) and connection properties (like reverse direct relations). \n\n\nNote: The order you list the views in is significant. We use this order to deduce the priority when we encounter duplicate property references.\n\n\nIf you do not specify a view version, we will use the most recent version available at the time of creation. ",
             "items": {
               "$ref": "#/components/schemas/ViewReference"
             }
@@ -24713,6 +26391,16 @@
           },
           {
             "$ref": "#/components/schemas/ReverseDirectRelationConnection"
+          }
+        ]
+      },
+      "ConnectionDefinitionRead": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/EdgeConnection"
+          },
+          {
+            "$ref": "#/components/schemas/ReverseDirectRelationConnectionRead"
           }
         ]
       },
@@ -24817,6 +26505,25 @@
           }
         }
       },
+      "ReverseDirectRelationConnectionRead": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ReverseDirectRelationConnection"
+          },
+          {
+            "type": "object",
+            "required": [
+              "targetsList"
+            ],
+            "properties": {
+              "targetsList": {
+                "description": "Whether or not this reverse direct relation targets a _list_ of direct relations.",
+                "type": "boolean"
+              }
+            }
+          }
+        ]
+      },
       "ContainerDefinition": {
         "required": [
           "space",
@@ -24850,7 +26557,7 @@
       },
       "ContainerCreateDefinition": {
         "type": "object",
-        "description": "Container for properties you can access through views.  Container specifications give details about storage  related details. For instance, how to index the data, and what constraints should be present.     You can  define a single container to only contain nodes (```node```), only contain edges (```edge```), or to  contain both (```all```).",
+        "description": "Container for properties you can access through views.  Container specifications give details about storage related details. For instance, how to index the data, and what constraints should be present.     You can define a single container to only contain nodes (```node```), only contain edges (```edge```), or to contain both (```all```).",
         "required": [
           "space",
           "externalId",
@@ -24956,6 +26663,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "bySpace": {
+            "type": "boolean",
+            "description": "Whether to make the constraint space-specific",
+            "default": false
           }
         }
       },
@@ -24979,7 +26691,7 @@
       },
       "IndexDefinition": {
         "type": "object",
-        "description": "You can optimize query performance by defining an index to apply to a container.  You can only create an index across properties belonging to the same container.\n\n\nOrdering of the properties included in the index definition list is significant.  The order should match the queries you expect.  Once we create an index, you may only change its description.  We do not currently support removal of an index.\n\n\nIndexes have different requirements for the different property data types.  As a result, the create index operation will fail if you specify an invalid combination.\n\n\nUp to 10 indexes can be added on a container.' ",
+        "description": "You can optimize query performance by defining an index to apply to a container.  You can only create an index across properties belonging to the same container.\n\n\nOrdering of the properties included in the index definition list is significant.  The order should match the queries you expect. The properties of an index cannot be updated after creation. If you need to change the index, it must be recreated.\n\n\nIndexes have different requirements for the different property data types.  As a result, the create index operation will fail if you specify an invalid combination.\n\n\nUp to 10 indexes can be added on a container.' ",
         "oneOf": [
           {
             "$ref": "#/components/schemas/BtreeIndex"
@@ -25013,6 +26725,11 @@
           "cursorable": {
             "type": "boolean",
             "description": "Whether the index can be used for cursor-based pagination",
+            "default": false
+          },
+          "bySpace": {
+            "type": "boolean",
+            "description": "Whether to make the index space-specific",
             "default": false
           }
         }
@@ -25151,6 +26868,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/DirectNodeRelation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EnumProperty"
                   }
                 ]
               }
@@ -25161,6 +26881,11 @@
       "CorePropertyDefinition": {
         "type": "object",
         "properties": {
+          "immutable": {
+            "type": "boolean",
+            "description": "Should updates to this property be rejected after the initial population?",
+            "default": false
+          },
           "nullable": {
             "type": "boolean",
             "description": "Does this property need to be set to a value, or not?",
@@ -25168,7 +26893,7 @@
           },
           "autoIncrement": {
             "type": "boolean",
-            "description": "When set to ```true```, the API will increment the property based on its highest current value  (max value).  You can only use this functionality to increment properties of type `int32` or `int64`.  If the property has a different data type, the API will return an error.",
+            "description": "When set to ```true```, the API will increment the property based on its highest current value (max value).  You can only use this functionality to increment properties of type `int32` or `int64`. If the property has a different data type, the API will return an error.",
             "default": false
           },
           "defaultValue": {
@@ -25375,7 +27100,7 @@
             "$ref": "#/components/schemas/EpochTimestamp"
           },
           "deletedTime": {
-            "description": "Timestamp when the node was soft deleted. Note that deleted nodes are filtered out of query results, but  present in sync results. This means that this value will only be present in sync results.",
+            "description": "Timestamp when the node was soft deleted. Note that deleted nodes are filtered out of query results, but present in sync results. This means that this value will only be present in sync results.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/EpochTimestamp"
@@ -25464,7 +27189,7 @@
             "default": "node"
           },
           "existingVersion": {
-            "description": "Fail the ingestion request if the node's version is greater than this value. If no  existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the  specified container or view). If existingVersion is set to 0, the upsert will behave as an insert, so it  will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request,  then the item will be skipped instead of failing the ingestion request.",
+            "description": "Fail the ingestion request if the node's version is greater than this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the node (for the specified container or view). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.",
             "type": "integer"
           },
           "space": {
@@ -25573,7 +27298,7 @@
             "$ref": "#/components/schemas/EpochTimestamp"
           },
           "deletedTime": {
-            "description": "Timestamp when the edge was soft deleted. Note that deleted edges are filtered out of query results, but  present in sync results. This means that this value will only be present in sync results.",
+            "description": "Timestamp when the edge was soft deleted. Note that deleted edges are filtered out of query results, but present in sync results. This means that this value will only be present in sync results.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/EpochTimestamp"
@@ -25666,7 +27391,7 @@
             "default": "edge"
           },
           "existingVersion": {
-            "description": "Fail the ingestion request if the edge's version is greater than this value. If no  existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the  specified container or view). If existingVersion is set to 0, the upsert will behave as an insert, so it  will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request,  then the item will be skipped instead of failing the ingestion request.",
+            "description": "Fail the ingestion request if the edge's version is greater than this value. If no existingVersion is specified, the ingestion will always overwrite any existing data for the edge (for the specified container or view). If existingVersion is set to 0, the upsert will behave as an insert, so it will fail the bulk if the item already exists. If skipOnVersionConflict is set on the ingestion request, then the item will be skipped instead of failing the ingestion request.",
             "type": "integer"
           },
           "type": {
@@ -25782,7 +27507,7 @@
       },
       "TableExpressionChainToDefinition": {
         "type": "string",
-        "description": "Control which side of the edge to chain to. This option is only applicable if the view referenced in the `from` field consists of edges. \n- `source` will chain to `start` if you're following edges outwards i.e `direction=outwards`. If you're following edges inwards i.e `direction=inwards`, it will chain to `end`.\n- `destination (default)` will chain to `end` if you're following edges outwards i.e `direction=outwards`. If you're following edges inwards i.e `direction=inwards`, it will chain to `start`.",
+        "description": "Control which side of the edge to chain to. This option is only applicable if the view referenced in the `from` field consists of edges.\n- `source` will chain to `start` if you're following edges outwards i.e `direction=outwards`. If you're following edges inwards i.e `direction=inwards`, it will chain to `end`.\n- `destination (default)` will chain to `end` if you're following edges outwards i.e `direction=outwards`. If you're following edges inwards i.e `direction=inwards`, it will chain to `start`.",
         "enum": [
           "source",
           "destination"
@@ -26048,7 +27773,7 @@
                 "$ref": "#/components/schemas/SourceSelectorWithoutPropertiesV3"
               },
               "instanceType": {
-                "description": "The type of instance you are querying for; an edge or a node.  If the instance type isn't specified, we list nodes. When instanceType is `edge`, `property` can refer to any container and is defined as [\"edge\", \"type\"],  and `value` contains the value of the property.\n\n  <u>Example:</u>\n\n  ```\n  {\n      “includeTyping”: true,\n      “instanceType”: \"edge\",\n      “filter”: {\n                  “equals”: {\n                      \"property\": [\n                        \"edge\",\n                        \"type\" // VALID VALUES:[space, externalId, createdTime, lastUpdatedTime, startNode, endNode, type ]\n                      ],\n                      \"value\": {\n                      \"space\": \"apm_simple\",\n                      \"externalId\": \"WMT:23-FO-96187\"\n                      }\n                    }\n                }\n  } \n  ```",
+                "description": "The type of instance you are querying for; an edge or a node.  If the instance type isn't specified, we list nodes. When instanceType is `edge`, `property` can refer to any container and is defined as [\"edge\", \"type\"], and `value` contains the value of the property.\n\n  <u>Example:</u>\n\n  ```\n  {\n      “includeTyping”: true,\n      “instanceType”: \"edge\",\n      “filter”: {\n                  “equals”: {\n                      \"property\": [\n                        \"edge\",\n                        \"type\" // VALID VALUES:[space, externalId, createdTime, lastUpdatedTime, startNode, endNode, type ]\n                      ],\n                      \"value\": {\n                      \"space\": \"apm_simple\",\n                      \"externalId\": \"WMT:23-FO-96187\"\n                      }\n                    }\n                }\n  }\n  ```",
                 "default": "node",
                 "allOf": [
                   {
@@ -26161,7 +27886,7 @@
             }
           },
           "cursors": {
-            "description": "Cursors returned from the previous query request. These cursors match the result set expressions you  specified in the ```with``` clause for the query.",
+            "description": "Cursors returned from the previous query request. These cursors match the result set expressions you specified in the ```with``` clause for the query.",
             "type": "object",
             "maxProperties": 50,
             "additionalProperties": {
@@ -26188,7 +27913,7 @@
           },
           "parameters": {
             "type": "object",
-            "description": "Values in filters can be parameterised. Parameters are provided as part of the query  object, and referenced in the filter itself.",
+            "description": "Values in filters can be parameterised. Parameters are provided as part of the query object, and referenced in the filter itself.",
             "additionalProperties": {
               "x-additionalPropertiesName": "parameter-identifier",
               "allOf": [
@@ -26219,7 +27944,7 @@
             }
           },
           "cursors": {
-            "description": "Cursors returned from the previous sync request. These cursors match the result set expressions you  specified in the ```with``` clause for the sync.",
+            "description": "Cursors returned from the previous sync request. These cursors match the result set expressions you specified in the ```with``` clause for the sync.",
             "type": "object",
             "maxProperties": 50,
             "additionalProperties": {
@@ -26283,8 +28008,32 @@
           }
         ]
       },
+      "AggregationRequestV2": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CommonAggregationRequestV2"
+          },
+          {
+            "type": "object",
+            "required": [
+              "view"
+            ],
+            "properties": {
+              "view": {
+                "$ref": "#/components/schemas/ViewReference"
+              },
+              "targetUnits": {
+                "$ref": "#/components/schemas/TargetUnits"
+              },
+              "includeTyping": {
+                "$ref": "#/components/schemas/IncludeTyping"
+              }
+            }
+          }
+        ]
+      },
       "CommonAggregationRequest": {
-        "description": "Defines an aggregation request. This will let you group, and aggregate supported data types. The request    supports filters, and allows optional search matching.",
+        "description": "Defines an aggregation request. This will let you group, and aggregate supported data types. The request supports filters, and allows optional search matching.",
         "type": "object",
         "properties": {
           "query": {
@@ -26316,7 +28065,7 @@
           },
           "groupBy": {
             "type": "array",
-            "description": "The selection of fields to group the results by when doing aggregations. You can specify up to 5 items \nto group by.\n\nWhen you do not specify any aggregates, the fields listed in the `groupBy` clause will return the unique \nvalues stored for each field.\n",
+            "description": "The selection of fields to group the results by when doing aggregations. You can specify up to 5 items\nto group by.\n\nWhen you do not specify any aggregates, the fields listed in the `groupBy` clause will return the unique\nvalues stored for each field.\n",
             "minItems": 1,
             "maxItems": 5,
             "items": {
@@ -26327,6 +28076,560 @@
             "$ref": "#/components/schemas/FilterDefinition"
           }
         }
+      },
+      "CommonAggregationRequestV2": {
+        "description": "Defines an aggregation request. This will let you aggregate supported data types. The request supports filters, and allows optional search matching.",
+        "type": "object",
+        "required": [
+          "aggregates"
+        ],
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Optional query string. The API will parse the query string, and use it to match the text properties on elements to use for the aggregate(s)."
+          },
+          "properties": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 200,
+            "description": "Optional list (array) of properties you want to apply the query above to. If you do not list any properties, you search through text fields by default.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "aggregates": {
+            "$ref": "#/components/schemas/AggregatesDefinition"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/FilterDefinition"
+          }
+        }
+      },
+      "AggregatesDefinition": {
+        "type": "object",
+        "title": "aggregatesDictionary",
+        "description": "A dictionary of requested aggregates with client defined names/identifiers.\n\n<u>Example:</u>\n\n```\n{\n  \"my_aggr_1\": {\n    \"min\": {\"property\": [\"room\", \"size\"]}\n  },\n  \"my_aggr_2\": {\n    \"max\": {\"property\": [\"room\", \"size\"]}\n  },\n}\n```",
+        "minProperties": 1,
+        "maxProperties": 5,
+        "uniqueItems": true,
+        "additionalProperties": {
+          "x-additionalPropertiesName": "aggregate-id",
+          "title": "aggregateDictionary",
+          "type": "object",
+          "description": "An aggregate. It's an aggregate identifier which map to an aggregator function, and some fields to use for the aggregator function.\nThe identifiers should match the next constraints:\n  pattern: \"^[A-Za-z_][A-Za-z0-9_]*$\"\n  maxLength: 1000\n  minLength: 1",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/AvgAggregate"
+            },
+            {
+              "$ref": "#/components/schemas/CountAggregate"
+            },
+            {
+              "$ref": "#/components/schemas/MinAggregate"
+            },
+            {
+              "$ref": "#/components/schemas/MaxAggregate"
+            },
+            {
+              "$ref": "#/components/schemas/SumAggregate"
+            },
+            {
+              "$ref": "#/components/schemas/UniqueValuesAggregate"
+            },
+            {
+              "$ref": "#/components/schemas/NumberHistogramAggregate"
+            }
+          ]
+        },
+        "propertyNames": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "maxLength": 1000,
+          "minLength": 1
+        },
+        "example": {
+          "my_avg_aggregate1": {
+            "avg": {
+              "property": [
+                "mySpace",
+                "myContainer",
+                "manufacturer"
+              ]
+            }
+          },
+          "my_terms_aggregate2": {
+            "uniqueValues": {
+              "property": [
+                "mySpace",
+                "myContainer",
+                "manufacturer"
+              ],
+              "aggregates": {
+                "my_sub_aggregate1": {
+                  "min": {
+                    "property": [
+                      "mySpace",
+                      "myContainer",
+                      "price"
+                    ]
+                  }
+                },
+                "my_sub_aggregate2": {
+                  "max": {
+                    "property": [
+                      "mySpace",
+                      "myContainer",
+                      "price"
+                    ]
+                  }
+                },
+                "my_sub_aggregate3": {
+                  "uniqueValues": {
+                    "property": [
+                      "mySpace",
+                      "myContainer",
+                      "region"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "AvgAggregate": {
+        "type": "object",
+        "title": "avg",
+        "required": [
+          "avg"
+        ],
+        "properties": {
+          "avg": {
+            "type": "object",
+            "description": "Calculates the average from the data stored by the specified property. This aggregation uses an average mean calculation, and not an integral mean.",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/AggregatePropertyDms"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "CountAggregate": {
+        "title": "count",
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "object",
+            "description": "Counts the number of items. When you specify a property, it returns the number of non-null values for that property.",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/AggregatePropertyDms"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "MinAggregate": {
+        "type": "object",
+        "title": "min",
+        "required": [
+          "min"
+        ],
+        "properties": {
+          "min": {
+            "type": "object",
+            "description": "The function will calculate, and return, the lowest - min - value for a property.",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/AggregatePropertyDms"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "MaxAggregate": {
+        "type": "object",
+        "title": "max",
+        "required": [
+          "max"
+        ],
+        "properties": {
+          "max": {
+            "type": "object",
+            "description": "The function will calculate, and return, the highest - max - value for the property.",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/AggregatePropertyDms"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SumAggregate": {
+        "type": "object",
+        "title": "sum",
+        "required": [
+          "sum"
+        ],
+        "properties": {
+          "sum": {
+            "type": "object",
+            "description": "Calculates the sum from the values of the specified property.",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/AggregatePropertyDms"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "UniqueValuesAggregate": {
+        "type": "object",
+        "title": "uniqueValues",
+        "required": [
+          "uniqueValues"
+        ],
+        "properties": {
+          "uniqueValues": {
+            "type": "object",
+            "description": "Request unique value buckets aggregate on of the specified property.\nEach bucket is defined by `values` array and has the number of the `values` occurrences.",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/AggregatePropertyDms"
+              },
+              "aggregates": {
+                "$ref": "#/components/schemas/AggregatesDefinition"
+              },
+              "size": {
+                "type": "integer",
+                "description": "The number of top buckets returned. The default limit is 10 items.",
+                "minimum": 1,
+                "maximum": 2000,
+                "default": 10
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "NumberHistogramAggregate": {
+        "type": "object",
+        "title": "numberHistogram",
+        "required": [
+          "numberHistogram"
+        ],
+        "properties": {
+          "numberHistogram": {
+            "type": "object",
+            "description": "A histogram aggregator function. This function will generate a histogram from the values of the specified\nproperty. It uses the specified interval as defined in your `interval` argument.",
+            "required": [
+              "property",
+              "interval"
+            ],
+            "properties": {
+              "interval": {
+                "type": "number",
+                "description": "The interval between each bucket."
+              },
+              "property": {
+                "$ref": "#/components/schemas/AggregatePropertyDms"
+              },
+              "aggregates": {
+                "$ref": "#/components/schemas/AggregatesDefinition"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "AggregatePropertyDms": {
+        "title": "property",
+        "description": "Property you want to aggregate. Use a list of strings to specify nested properties.\n\n<u>Example:</u>\n\nYou have the object\n```\n{\n  \"room\": {\n    \"id\": \"b53\"\n  },\n  \"roomId\": \"a23\"\n}\n```\n\nUse `[\"room\", \"id\"]` to return the value in the nested `id` property, which is a part of the `room` object.\n\nYou can also read the value(s) in the standalone property `roomId` with `[\"roomId\"]`.\n",
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 3,
+        "items": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "example": [
+          "room",
+          "id"
+        ]
+      },
+      "AggregatesResultDefinition": {
+        "type": "object",
+        "title": "aggregatesResultDictionary",
+        "description": "A dictionary of the results for the requested aggregates mapped by the aggregates identifiers.\n\n<u>Example:</u>\n\n```\n{\n  \"my_aggr_1\": {\n    \"avg\": 42\n  },\n  \"my_aggr_2\": {\n    \"max\": 69\n  },\n}\n```",
+        "additionalProperties": {
+          "x-additionalPropertiesName": "aggregate-id",
+          "type": "object",
+          "title": "aggregateResultDictionary",
+          "description": "Requested aggregate result. It's the aggregate identifier from the request and a set of fields to represent aggregated data.",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/AvgAggregateResult"
+            },
+            {
+              "$ref": "#/components/schemas/CountAggregateResultDms"
+            },
+            {
+              "$ref": "#/components/schemas/MinAggregateResult"
+            },
+            {
+              "$ref": "#/components/schemas/MaxAggregateResult"
+            },
+            {
+              "$ref": "#/components/schemas/SumAggregateResult"
+            },
+            {
+              "$ref": "#/components/schemas/UniqueValuesAggregateResult"
+            },
+            {
+              "$ref": "#/components/schemas/NumberHistogramAggregateResult"
+            }
+          ]
+        },
+        "example": {
+          "my_avg_aggregate1": {
+            "avg": 42
+          },
+          "my_terms_aggregate2": {
+            "buckets": [
+              {
+                "value": "Cognite",
+                "count": 42,
+                "aggregates": {
+                  "my_sub_aggregate1": {
+                    "min": 13
+                  },
+                  "my_sub_aggregate2": {
+                    "max": 69
+                  },
+                  "my_sub_aggregate3": {
+                    "buckets": [
+                      {
+                        "value": "us1",
+                        "count": 42
+                      },
+                      {
+                        "value": "ie1",
+                        "count": 7
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "value": "AkerBP",
+                "count": 21,
+                "aggregates": {
+                  "my_sub_aggregate1": {
+                    "min": 99
+                  },
+                  "my_sub_aggregate2": {
+                    "max": 999
+                  },
+                  "my_sub_aggregate3": {
+                    "buckets": [
+                      {
+                        "value": "us1",
+                        "count": 11
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "AvgAggregateResult": {
+        "type": "object",
+        "title": "avgResult",
+        "required": [
+          "avg"
+        ],
+        "properties": {
+          "avg": {
+            "type": "number",
+            "description": "The average value from the data stored by the specified in the request property.",
+            "example": 42.7
+          }
+        }
+      },
+      "CountAggregateResultDms": {
+        "type": "object",
+        "title": "countResult",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of non-null values for specified in the request property.",
+            "example": 42
+          }
+        }
+      },
+      "MinAggregateResult": {
+        "type": "object",
+        "title": "minResult",
+        "required": [
+          "min"
+        ],
+        "properties": {
+          "min": {
+            "type": "number",
+            "description": "The lowest - min - value for the specified in the request property.",
+            "example": 42.7
+          }
+        }
+      },
+      "MaxAggregateResult": {
+        "type": "object",
+        "title": "maxResult",
+        "required": [
+          "max"
+        ],
+        "properties": {
+          "max": {
+            "type": "number",
+            "description": "The highest - max - value for the specified in the request property.",
+            "example": 42.7
+          }
+        }
+      },
+      "SumAggregateResult": {
+        "type": "object",
+        "title": "sumResult",
+        "required": [
+          "sum"
+        ],
+        "properties": {
+          "sum": {
+            "type": "number",
+            "description": "The sum from the values of the specified in the request property.",
+            "example": 42.7
+          }
+        }
+      },
+      "UniqueValuesAggregateResult": {
+        "type": "object",
+        "title": "uniqueValuesResult",
+        "properties": {
+          "buckets": {
+            "type": "array",
+            "description": "Unique value buckets on of the specified in the request property.",
+            "items": {
+              "type": "object",
+              "required": [
+                "count",
+                "value"
+              ],
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "The count of items with the value in the property.",
+                  "example": 42
+                },
+                "value": {
+                  "$ref": "#/components/schemas/AggregateValue"
+                },
+                "aggregates": {
+                  "$ref": "#/components/schemas/AggregatesResultDefinition"
+                }
+              }
+            }
+          }
+        }
+      },
+      "NumberHistogramAggregateResult": {
+        "type": "object",
+        "title": "numberHistogramResult",
+        "properties": {
+          "buckets": {
+            "type": "array",
+            "description": "The histogram from the values of the specified in the request property.",
+            "items": {
+              "type": "object",
+              "required": [
+                "count",
+                "intervalStart"
+              ],
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "The count of items with the value from the bucket interval in the property.",
+                  "example": 100
+                },
+                "intervalStart": {
+                  "type": "number",
+                  "description": "The number which represent the start of the bucket interval (the next bucket start point is the end point for this bucket).",
+                  "example": 42.7
+                },
+                "aggregates": {
+                  "$ref": "#/components/schemas/AggregatesResultDefinition"
+                }
+              }
+            }
+          }
+        }
+      },
+      "AggregateValue": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "A string which find in the provided property."
+          },
+          {
+            "type": "number",
+            "description": "A number which find in the provided property."
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "An integer number which find in the provided property."
+          },
+          {
+            "type": "boolean",
+            "description": "A boolean value which find in the provided property."
+          }
+        ]
       },
       "AggregatedResultItemCollection": {
         "required": [
@@ -26365,6 +28668,9 @@
                 },
                 {
                   "type": "boolean"
+                },
+                {
+                  "$ref": "#/components/schemas/DirectRelationReference"
                 }
               ]
             },
@@ -26495,7 +28801,7 @@
                 "description": "Query string that will be parsed and used for search."
               },
               "instanceType": {
-                "description": "Limit the search query to searching nodes or edges. Unless you set the item type to apply the search  to, the service will default to searching nodes within the view.",
+                "description": "Limit the search query to searching nodes or edges. Unless you set the item type to apply the search to, the service will default to searching nodes within the view.",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/InstanceType"
@@ -26504,7 +28810,7 @@
               },
               "properties": {
                 "type": "array",
-                "description": "Optional array of properties you want to search through.  If you do not specify one or more properties,  the service will search all text fields within the view.",
+                "description": "Optional array of properties you want to search through.  If you do not specify one or more properties, the service will search all text fields within the view.",
                 "items": {
                   "type": "string"
                 }
@@ -26605,22 +28911,22 @@
           },
           "autoCreateStartNodes": {
             "type": "boolean",
-            "description": "Should we create missing start nodes for edges when ingesting?  By default, the start node of an edge  must exist before we can ingest the edge.",
+            "description": "Should we create missing start nodes for edges when ingesting?  By default, the start node of an edge must exist before we can ingest the edge.",
             "default": false
           },
           "autoCreateEndNodes": {
             "type": "boolean",
             "default": false,
-            "description": "Should we create missing end nodes for edges when ingesting?  By default, the end node of an edge must  exist before we can ingest the edge."
+            "description": "Should we create missing end nodes for edges when ingesting?  By default, the end node of an edge must exist before we can ingest the edge."
           },
           "skipOnVersionConflict": {
             "type": "boolean",
             "default": false,
-            "description": "If existingVersion is specified on any of the nodes/edges in the input, the default behaviour is that the  entire ingestion will fail when version conflicts occur. If skipOnVersionConflict is set to true, items  with version conflicts will be skipped instead. If no version is specified for nodes/edges, it will do  the write directly."
+            "description": "If existingVersion is specified on any of the nodes/edges in the input, the default behaviour is that the entire ingestion will fail when version conflicts occur. If skipOnVersionConflict is set to true, items with version conflicts will be skipped instead. If no version is specified for nodes/edges, it will do the write directly."
           },
           "replace": {
             "type": "boolean",
-            "description": "How do we behave when a property value exists? Do we replace all matching and existing values with  the supplied values (`true`)?  Or should we merge in new values for properties together with the  existing values (`false`)?  Note: This setting applies for all nodes or edges specified in the ingestion  call.",
+            "description": "How do we behave when a property value exists? Do we replace all matching and existing values with the supplied values (`true`)?  Or should we merge in new values for properties together with the existing values (`false`)?  Note: This setting applies for all nodes or edges specified in the ingestion call.",
             "default": false
           }
         }
@@ -26884,6 +29190,218 @@
           }
         }
       },
+      "InstanceInspectRequest": {
+        "type": "object",
+        "required": [
+          "inspectionOperations",
+          "items"
+        ],
+        "properties": {
+          "inspectionOperations": {
+            "type": "object",
+            "properties": {
+              "involvedViews": {
+                "type": "object",
+                "properties": {
+                  "allVersions": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              },
+              "involvedContainers": {
+                "type": "object",
+                "properties": {
+                  "allVersions": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1000,
+            "items": {
+              "type": "object",
+              "required": [
+                "instanceType",
+                "space",
+                "externalId"
+              ],
+              "properties": {
+                "instanceType": {
+                  "description": "The type of instance being returned, an edge or a node.",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/InstanceType"
+                    }
+                  ]
+                },
+                "externalId": {
+                  "description": "External ids for the requested items",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/NodeOrEdgeExternalId"
+                    }
+                  ]
+                },
+                "space": {
+                  "$ref": "#/components/schemas/SpaceSpecification"
+                }
+              }
+            }
+          }
+        }
+      },
+      "InstanceInspectResultItem": {
+        "type": "object",
+        "required": [
+          "instanceType",
+          "externalId",
+          "space",
+          "inspectionResults"
+        ],
+        "properties": {
+          "instanceType": {
+            "description": "The type of instance being returned, an edge or a node.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceType"
+              }
+            ]
+          },
+          "externalId": {
+            "description": "External ids for the requested items",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NodeOrEdgeExternalId"
+              }
+            ]
+          },
+          "space": {
+            "$ref": "#/components/schemas/SpaceSpecification"
+          },
+          "inspectionResults": {
+            "type": "object",
+            "properties": {
+              "involvedViews": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ViewReference"
+                }
+              },
+              "involvedContainers": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ContainerReference"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ContainerInspectRequest": {
+        "type": "object",
+        "required": [
+          "inspectionOperations",
+          "items"
+        ],
+        "properties": {
+          "inspectionOperations": {
+            "type": "object",
+            "properties": {
+              "involvedViews": {
+                "type": "object",
+                "properties": {
+                  "allVersions": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              },
+              "totalInvolvedViewCount": {
+                "type": "object",
+                "properties": {
+                  "allVersions": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "includeUnavailableViews": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether or not to also count views which aren't available to the user. This is useful for understanding whether or not views/datamodels you don't have to access to will be affected by deleting/changing this container."
+                  }
+                }
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 10,
+            "items": {
+              "type": "object",
+              "required": [
+                "space",
+                "externalId"
+              ],
+              "properties": {
+                "space": {
+                  "$ref": "#/components/schemas/SpaceSpecification"
+                },
+                "externalId": {
+                  "description": "External id for the requested container",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/DMSExternalId"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "ContainerInspectResultItem": {
+        "type": "object",
+        "required": [
+          "externalId",
+          "space",
+          "inspectionResults"
+        ],
+        "properties": {
+          "externalId": {
+            "description": "External ids for the requested items",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DMSExternalId"
+              }
+            ]
+          },
+          "space": {
+            "$ref": "#/components/schemas/SpaceSpecification"
+          },
+          "inspectionResults": {
+            "type": "object",
+            "properties": {
+              "involvedViewCount": {
+                "description": "The total number of views mapping this container (including views you don't have access to)",
+                "type": "integer"
+              },
+              "involvedViews": {
+                "type": "array",
+                "description": "The views you have access to which map this container.",
+                "items": {
+                  "$ref": "#/components/schemas/ViewReference"
+                }
+              }
+            }
+          }
+        }
+      },
       "ListOfVersionReferences": {
         "type": "object",
         "required": [
@@ -26974,7 +29492,7 @@
         "type": "string"
       },
       "MultiNextCursorV3": {
-        "description": "Cursors to paginate to the next page of results.  The cursor applies to each result set expression.  We only  provide a cursor when more data is available.",
+        "description": "Cursors to paginate to the next page of results.  The cursor applies to each result set expression.  We only provide a cursor when more data is available.",
         "type": "object",
         "properties": {
           "additionalProperties": {
@@ -27014,7 +29532,7 @@
       "CountAggregateFunctionV3": {
         "title": "count",
         "type": "object",
-        "description": "Counts the number of items.  When you specify a property, it returns the number of non-null values for that  property.",
+        "description": "Counts the number of items.  When you specify a property, it returns the number of non-null values for that property.",
         "required": [
           "count"
         ],
@@ -27033,7 +29551,7 @@
       "AvgAggregateFunctionV3": {
         "type": "object",
         "title": "avg",
-        "description": "Calculates the average from the data stored by the specified property. This aggregation uses an average mean  calculation, and not an integral mean.",
+        "description": "Calculates the average from the data stored by the specified property. This aggregation uses an average mean calculation, and not an integral mean.",
         "required": [
           "avg"
         ],
@@ -27046,7 +29564,7 @@
             "properties": {
               "property": {
                 "type": "string",
-                "description": "The property who's data we use to calculate the average from.  This property needs to be a  defined-as-numerical property."
+                "description": "The property who's data we use to calculate the average from.  This property needs to be a defined-as-numerical property."
               }
             }
           }
@@ -27068,7 +29586,7 @@
             "properties": {
               "property": {
                 "type": "string",
-                "description": "The property who's data we use to generate the max value from.  This property needs to be a  defined-as-numerical property."
+                "description": "The property who's data we use to generate the max value from.  This property needs to be a defined-as-numerical property."
               }
             }
           }
@@ -27090,7 +29608,7 @@
             "properties": {
               "property": {
                 "type": "string",
-                "description": "The property who's data we use to generate the min value from.  This property needs to be a  defined-as-numerical property."
+                "description": "The property who's data we use to generate the min value from.  This property needs to be a defined-as-numerical property."
               }
             }
           }
@@ -27099,7 +29617,7 @@
       "HistogramAggregateFunctionV3": {
         "type": "object",
         "title": "histogram",
-        "description": "A histogram aggregator function.  This function will generate a histogram from the values of the specified  property.  It uses the specified interval as defined in your `interval` argument.",
+        "description": "A histogram aggregator function.  This function will generate a histogram from the values of the specified property.  It uses the specified interval as defined in your `interval` argument.",
         "required": [
           "histogram"
         ],
@@ -27113,7 +29631,7 @@
             "properties": {
               "property": {
                 "type": "string",
-                "description": "The property who's data we use to generate the histogram.  This property needs to be a  defined-as-numerical property."
+                "description": "The property who's data we use to generate the histogram.  This property needs to be a defined-as-numerical property."
               },
               "interval": {
                 "type": "number",
@@ -27139,7 +29657,7 @@
             "properties": {
               "property": {
                 "type": "string",
-                "description": "The property who's data we use to calculate the sum of.  This property needs to be a  defined-as-numerical property."
+                "description": "The property who's data we use to calculate the sum of.  This property needs to be a defined-as-numerical property."
               }
             }
           }
@@ -27160,7 +29678,7 @@
         "required": [
           "nodes"
         ],
-        "description": "The synchronization query to use when we listen for changes to nodes.  The nodes must also match the  specified filter.",
+        "description": "The synchronization query to use when we listen for changes to nodes.  The nodes must also match the specified filter.",
         "properties": {
           "limit": {
             "$ref": "#/components/schemas/TableExpressionSyncLimit"
@@ -27210,7 +29728,7 @@
         "required": [
           "edges"
         ],
-        "description": "The synchronization query to use when we listen for changes to edges.  The edges must also match the  specified filter.",
+        "description": "The synchronization query to use when we listen for changes to edges.  The edges must also match the specified filter.",
         "properties": {
           "limit": {
             "$ref": "#/components/schemas/TableExpressionSyncLimit"
@@ -27366,7 +29884,7 @@
               },
               "limitEach": {
                 "type": "integer",
-                "description": "Limit the number of returned edges for each of the source nodes in the result set.  The indicated  uniform limit applies to the result set from the referenced `from`.  `limitEach` only has meaning  when you also specify `maxDistance=1` and `from`.",
+                "description": "Limit the number of returned edges for each of the source nodes in the result set.  The indicated uniform limit applies to the result set from the referenced `from`.  `limitEach` only has meaning when you also specify `maxDistance=1` and `from`.",
                 "minimum": 1,
                 "maximum": 2000
               }
@@ -27390,7 +29908,7 @@
       },
       "QueryUnionAllTableExpressionV3": {
         "type": "object",
-        "description": "Return the union of the specified result sets.  We will remove the results that match the optional exception \nresult sets.  Note: The operation may return duplicate results since we do not perform deduplication.\n",
+        "description": "Return the union of the specified result sets.  We will remove the results that match the optional exception\nresult sets.  Note: The operation may return duplicate results since we do not perform deduplication.\n",
         "required": [
           "unionAll"
         ],
@@ -27420,7 +29938,7 @@
         }
       },
       "QueryUnionTableExpressionV3": {
-        "description": "Return the union of the specified result sets. We will remove the results that match the optional \nexception result sets.  But this operation does not result in duplicate results as it performs \ndeduplication. \n\nNote: You should use the `unionAll` operation whenever possible. Using it enables a built-in optimization. \nI.e. `A unionAll B` with `limit: n` will execute set operation B, if and only if, A returns less than \nn records.\n",
+        "description": "Return the union of the specified result sets. We will remove the results that match the optional\nexception result sets.  But this operation does not result in duplicate results as it performs\ndeduplication.\n\nNote: You should use the `unionAll` operation whenever possible. Using it enables a built-in optimization.\nI.e. `A unionAll B` with `limit: n` will execute set operation B, if and only if, A returns less than\nn records.\n",
         "type": "object",
         "required": [
           "union"
@@ -27452,7 +29970,7 @@
       },
       "QueryIntersectionTableExpressionV3": {
         "type": "object",
-        "description": "Find the common elements in the returned result set. Excludes the elements from the optional `except`  result set.",
+        "description": "Find the common elements in the returned result set. Excludes the elements from the optional `except` result set.",
         "required": [
           "intersection"
         ],
@@ -27658,7 +30176,7 @@
       },
       "SyncSelectV3": {
         "type": "object",
-        "description": "Specify the container or view to return properties for. Also specify the properties for those  containers/views to return. Up to 10 views can be specified.",
+        "description": "Specify the container or view to return properties for. Also specify the properties for those containers/views to return. Up to 10 views can be specified.",
         "properties": {
           "sources": {
             "$ref": "#/components/schemas/SourceSelectorV3"
@@ -27760,7 +30278,7 @@
               "scope",
               "filter"
             ],
-            "description": "Use `nested` to apply the properties of the direct relation as the filter.  `scope` specifies the direct \nrelation property you want use as the filtering property.\n\nExample:\n```\n  {\n    \"nested\": {\n      \"scope\": [\"some\", \"direct_relation\", \"property\"],\n      \"filter\": {\n        \"equals\": {\n          \"property\": [\"node\", \"name\"],\n          \"value\": \"ACME\"\n        }\n      }\n    }\n  }\n```\n",
+            "description": "Use `nested` to apply the properties of the direct relation as the filter.  `scope` specifies the direct\nrelation property you want use as the filtering property.\n\nExample:\n```\n  {\n    \"nested\": {\n      \"scope\": [\"some\", \"direct_relation\", \"property\"],\n      \"filter\": {\n        \"equals\": {\n          \"property\": [\"node\", \"name\"],\n          \"value\": \"ACME\"\n        }\n      }\n    }\n  }\n```\n",
             "type": "object",
             "properties": {
               "scope": {
@@ -27930,7 +30448,7 @@
               "property",
               "values"
             ],
-            "description": "Matches items where the property **exactly** matches one of the given values. You can only apply this  filter to properties containing a single value.",
+            "description": "Matches items where the property **exactly** matches one of the given values.",
             "type": "object",
             "properties": {
               "property": {
@@ -27955,7 +30473,7 @@
               "property",
               "values"
             ],
-            "description": "Matches items where the property **exactly** matches one of the given values. You can only apply this filter to properties containing a single value.",
+            "description": "Matches items where the property **exactly** matches one of the given values.",
             "type": "object",
             "properties": {
               "property": {
@@ -27979,7 +30497,7 @@
             "required": [
               "property"
             ],
-            "description": "Matches items that contain terms within the provided range. \n\nThe range must include both an upper and a lower bound. It is not permitted to specify both inclusive \nand exclusive bounds together.  E.g. `gte` and `gt`.\n\n  `gte`: Greater than or equal to.  \n  `gt`: Greater than.  \n  `lte`: Less than or equal to.  \n  `lt`: Less than.\n",
+            "description": "Matches items that contain terms within the provided range.\n\nThe range must include both an upper and a lower bound. It is not permitted to specify both inclusive\nand exclusive bounds together.  E.g. `gte` and `gt`.\n\n  `gte`: Greater than or equal to.\n  `gt`: Greater than.\n  `lte`: Less than or equal to.\n  `lt`: Less than.\n",
             "type": "object",
             "properties": {
               "property": {
@@ -28281,7 +30799,7 @@
       },
       "ReducedLimit": {
         "type": "object",
-        "description": "Limits the number of results returned. The greatest number of results returned by the server is 1000. This is  true even when you specify a higher limit.",
+        "description": "Limits the number of results returned. The greatest number of results returned by the server is 1000. This is true even when you specify a higher limit.",
         "properties": {
           "limit": {
             "type": "integer",
@@ -29134,7 +31652,7 @@
       },
       "PrimitiveProperty": {
         "type": "object",
-        "description": "Primitive types for the property.\n\nWe expect dates to be in the ISO-8601 format, while timestamps are expected to be an epoch value with \nmillisecond precision. JSON values have to be valid JSON fragments. The maximum allowed size for a JSON\nobject is 40960 bytes. For list of json values, the size of the entire list must be within this limit. \nThe maximum allowed length of a key is 128, while the maximum allowed size of a value is 10240 bytes \nand you can have up to 256 key-value pairs.\n",
+        "description": "Primitive types for the property.\n\nWe expect dates to be in the ISO-8601 format, while timestamps are expected to be an epoch value with\nmillisecond precision. JSON values have to be valid JSON fragments. The maximum allowed size for a JSON\nobject is 40960 bytes. For list of json values, the size of the entire list must be within this limit.\nThe maximum allowed length of a key is 128, while the maximum allowed size of a value is 10240 bytes\nand you can have up to 256 key-value pairs.\n",
         "required": [
           "type"
         ],
@@ -29154,7 +31672,7 @@
           },
           "unit": {
             "type": "object",
-            "description": "The unit of the data stored in this property, can only be assign to type float32 or float64. \nExternalId needs to match with a unit in the Cognite unit catalog.\n",
+            "description": "The unit of the data stored in this property, can only be assign to type float32 or float64.\nExternalId needs to match with a unit in the Cognite unit catalog.\n",
             "required": [
               "externalId"
             ],
@@ -29238,6 +31756,75 @@
                 "$ref": "#/components/schemas/ContainerReference"
               }
             ]
+          },
+          "list": {
+            "description": "Specifies that the data type is a list of values. The ordering of values is preserved.\n",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "EnumProperty": {
+        "type": "object",
+        "description": "An enum type property.\n\nAn enum property can only consist for predefined values.\n",
+        "required": [
+          "type",
+          "values"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "enum"
+            ]
+          },
+          "unknownValue": {
+            "type": "string",
+            "description": "The value to use when the enum value is unknown.\nThis can optionally be used to provide forward-compatibility, Specifying what value to use if the client does not recognize the returned value. It is not possible to ingest the unknown value, but it must be part of the allowed values."
+          },
+          "values": {
+            "type": "object",
+            "description": "A set of all possible values for the enum property.  The enum value identifier has to have a length of between 1 and 127 characters.  It must also match the pattern ```^[_A-Za-z][_0-9A-Za-z]{0,127}$```.\n\nExample: ```{ \"value1\": { \"name\": \"Value 1\", \"description\": \"This is value 1\" }, \"value2\": { } }```",
+            "additionalProperties": {
+              "x-additionalPropertiesName": "enumValueIdentifier",
+              "minProperties": 1,
+              "maxProperties": 32,
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/EnumValueProperties"
+                }
+              ]
+            }
+          }
+        },
+        "example": {
+          "unknownValue": "unknown",
+          "values": {
+            "value1": {
+              "name": "Value 1",
+              "description": "This is value 1"
+            },
+            "value2": {},
+            "unknown": {
+              "name": "Unknown",
+              "description": "Used if the client does not recognize the returned value."
+            }
+          }
+        }
+      },
+      "EnumValueProperties": {
+        "type": "object",
+        "description": "Metadata of the enum value.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the enum value.",
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the enum value.",
+            "maxLength": 1024
           }
         }
       },
@@ -29278,7 +31865,6 @@
         "description": "Property you want to filter. Use a list of strings to specify nested properties.\n\n<u>Example:</u>\n\nYou have the object\n```\n{\n  \"room\": {\n    \"id\": \"b53\"\n  },\n  \"roomId\": \"a23\"\n}\n```\n\nUse `[\"room\", \"id\"]` to return the value in the nested `id` property, which is a part of the `room` object.\n\nYou can also read the value(s) in the standalone property `roomId` with `[\"roomId\"]`.\n",
         "type": "array",
         "minItems": 1,
-        "maxItems": 3,
         "items": {
           "type": "string"
         }
@@ -29302,6 +31888,1668 @@
               }
             }
           }
+        }
+      },
+      "IngestLogsRequest": {
+        "type": "object",
+        "required": [
+          "stream",
+          "items"
+        ],
+        "properties": {
+          "stream": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Stream"
+              }
+            ]
+          },
+          "items": {
+            "type": "array",
+            "title": "logItems",
+            "description": "List of logs to ingest.\n",
+            "minItems": 1,
+            "maxItems": 2000,
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LogIngest"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "ListLogsRequest": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Defines a filter request. This will let you fetch logs with some necessary properties filtered by different criteria.\n",
+            "required": [
+              "stream"
+            ],
+            "properties": {
+              "stream": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Stream"
+                  }
+                ]
+              },
+              "sources": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SourceSelector"
+                  }
+                ]
+              },
+              "search": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SearchIla"
+                  }
+                ]
+              },
+              "filter": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/FilterDefinitionIla"
+                  }
+                ]
+              },
+              "createdTime": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatedTimeFilter"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/LimitWithDefault10"
+          },
+          {
+            "$ref": "#/components/schemas/Sort"
+          }
+        ]
+      },
+      "SyncLogRequest": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "stream"
+            ],
+            "properties": {
+              "stream": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Stream"
+                  }
+                ]
+              },
+              "sources": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SourceSelector"
+                  }
+                ]
+              },
+              "filter": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/FilterDefinitionIla"
+                  }
+                ]
+              },
+              "cursor": {
+                "type": "string",
+                "description": "A cursor returned from the previous sync request.\n",
+                "minLength": 1,
+                "maxLength": 100500,
+                "example": "c29tZSBjdXJzb3I="
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/LimitWithDefault10"
+          }
+        ]
+      },
+      "AggregateLogsRequest": {
+        "description": "Defines an aggregation request. This will let you aggregate supported data types. The request\nsupports filters, and allows optional search matching.\n",
+        "type": "object",
+        "required": [
+          "stream",
+          "aggregates"
+        ],
+        "properties": {
+          "stream": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Stream"
+              }
+            ]
+          },
+          "search": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SearchIla"
+              }
+            ]
+          },
+          "filter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FilterDefinitionIla"
+              }
+            ]
+          },
+          "createdTime": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedTimeFilter"
+              }
+            ]
+          },
+          "aggregates": {
+            "description": "A dictionary of requested aggregates with client defined names/identifiers.\n\n<u>Example:</u>\n\n```\n{\n  \"my_aggr_1\": {\n    \"min\": {\"property\": [\"room\", \"size\"]}\n  },\n  \"my_aggr_2\": {\n    \"uniqueValues\": {\n      \"property\": [\"room\", \"name\"],\n      \"aggregates\": {\n        \"my_sub_aggr\": {\n          \"avg\": {\"property\": [\"room\", \"size\"]}\n        }\n      }\n    }\n  },\n}\n```\n\nMax number of (sub-)aggregate trees on a level is 5, Max aggregate tree depth is 5. Max number of aggregates in the forest is 16.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AggregatesDefinitionIla"
+              }
+            ]
+          }
+        }
+      },
+      "Stream": {
+        "type": "string",
+        "title": "dataStream",
+        "description": "Name of the stream where the logs are located.\n\n<u>Currently, hardcoded names (per project) are supported:</u>\n\n```\ntest1, test2, test3, test4, test5\nlogs1, logs2, logs3, logs4, logs5\n```\n",
+        "pattern": "^[a-zA-Z][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$",
+        "minLength": 1,
+        "maxLength": 255,
+        "example": "test1"
+      },
+      "LogIngest": {
+        "type": "object",
+        "title": "logItem",
+        "description": "Log to ingest.\n",
+        "required": [
+          "space",
+          "sources"
+        ],
+        "properties": {
+          "space": {
+            "description": "Id of the space that the ```log``` belongs to.\n",
+            "example": "mySpace",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpaceSpecification"
+              }
+            ]
+          },
+          "sources": {
+            "type": "array",
+            "title": "propertiesPerContainer",
+            "description": "List of source properties to write. The properties are from the container(s) making up this ```log```.\n",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LogData"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "LogData": {
+        "type": "object",
+        "description": "Property values for the identified/specified container.\n",
+        "required": [
+          "source",
+          "properties"
+        ],
+        "properties": {
+          "source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContainerReferenceIla"
+              }
+            ]
+          },
+          "properties": {
+            "title": "containerProperties",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyValueGroupV3"
+              }
+            ]
+          }
+        }
+      },
+      "SourceSelector": {
+        "type": "array",
+        "title": "propertiesPerContainer",
+        "description": "List of containers and their properties which values should be selected for the response.\n",
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "type": "object",
+          "title": "propertiesForContainer",
+          "required": [
+            "source",
+            "properties"
+          ],
+          "properties": {
+            "source": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ContainerReferenceIla"
+                }
+              ]
+            },
+            "properties": {
+              "type": "array",
+              "title": "containerProperties",
+              "description": "Properties to return for the specified container. Use \"*\" to return all properties.\n",
+              "minItems": 1,
+              "maxItems": 1000,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 255,
+                "example": "someProperty"
+              }
+            }
+          }
+        }
+      },
+      "ContainerReferenceIla": {
+        "type": "object",
+        "title": "containerReference",
+        "description": "Reference to a container.\n",
+        "example": {
+          "type": "container,",
+          "space": "mySpace,",
+          "externalId": "myContainer"
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContainerReference"
+          }
+        ]
+      },
+      "SearchIla": {
+        "type": "object",
+        "title": "search",
+        "description": "Optional attribute to extend the ```filter``` with full text search capabilities for SINGLE query in the list of ```log``` properties with ```OR``` logic.\n\nTODO: use AQL approach.\n",
+        "required": [
+          "query",
+          "properties"
+        ],
+        "properties": {
+          "query": {
+            "type": "string",
+            "title": "query",
+            "description": "Query string that will be parsed and used for search.\n",
+            "minLength": 1,
+            "maxLength": 1000,
+            "example": "find me"
+          },
+          "properties": {
+            "type": "array",
+            "title": "properties",
+            "description": "Array of properties you want to search through (```OR``` logic is used).\n",
+            "minItems": 1,
+            "maxItems": 200,
+            "items": {
+              "example": [
+                "mySpace",
+                "myContainer",
+                "someProperty"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DMSFilterProperty"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "FilterDefinitionIla": {
+        "type": "object",
+        "title": "filter",
+        "description": "A filter Domain Specific Language (DSL) used to create advanced filter queries.\n",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BoolFilterIla"
+          },
+          {
+            "$ref": "#/components/schemas/LeafFilterIla"
+          }
+        ],
+        "example": {
+          "and": [
+            {
+              "containsAll": {
+                "property": [
+                  "mySpace",
+                  "myContainer",
+                  "myProperty"
+                ],
+                "values": [
+                  10011,
+                  10012
+                ]
+              }
+            },
+            {
+              "range": {
+                "property": [
+                  "my_space",
+                  "my_container",
+                  "my_weight"
+                ],
+                "gte": 0
+              }
+            }
+          ]
+        }
+      },
+      "BoolFilterIla": {
+        "type": "object",
+        "title": "boolFilter",
+        "description": "Build a new query by combining other queries, using boolean operators. We support the `and`, `or`, and\n`not` boolean operators.\n",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "and",
+            "required": [
+              "and"
+            ],
+            "properties": {
+              "and": {
+                "type": "array",
+                "description": "All the sub-clauses in the query must return a matching item.\n",
+                "minItems": 1,
+                "maxItems": 100,
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/FilterDefinitionIla"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "or",
+            "required": [
+              "or"
+            ],
+            "properties": {
+              "or": {
+                "type": "array",
+                "description": "One or more of the sub-clauses in the query must return a matching item.\n",
+                "minItems": 1,
+                "maxItems": 100,
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/FilterDefinitionIla"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "not",
+            "required": [
+              "not"
+            ],
+            "properties": {
+              "not": {
+                "type": "object",
+                "title": "not",
+                "description": "None of the sub-clauses in the query can return a matching item.\n",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/FilterDefinitionIla"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "LeafFilterIla": {
+        "type": "object",
+        "title": "leafFilter",
+        "description": "Leaf filter which is used in boolean filters to build advanced queries to filter out some logs.\n",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/MatchAllFilter"
+          },
+          {
+            "$ref": "#/components/schemas/DMSExistsFilter"
+          },
+          {
+            "$ref": "#/components/schemas/EqualsFilterIla"
+          },
+          {
+            "$ref": "#/components/schemas/HasDataFilterIla"
+          },
+          {
+            "$ref": "#/components/schemas/PrefixFilterIla"
+          },
+          {
+            "$ref": "#/components/schemas/RangeFilterIla"
+          },
+          {
+            "$ref": "#/components/schemas/InFilterIla"
+          },
+          {
+            "$ref": "#/components/schemas/ContainsAllFilterIla"
+          },
+          {
+            "$ref": "#/components/schemas/ContainsAnyFilterIla"
+          }
+        ]
+      },
+      "EqualsFilterIla": {
+        "type": "object",
+        "title": "equals",
+        "required": [
+          "equals"
+        ],
+        "properties": {
+          "equals": {
+            "type": "object",
+            "description": "Matches items that contain the exact value in the provided property.\n",
+            "required": [
+              "property",
+              "value"
+            ],
+            "properties": {
+              "property": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DMSFilterProperty"
+                  }
+                ]
+              },
+              "value": {
+                "title": "value",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RawPropertyValueV3"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "HasDataFilterIla": {
+        "type": "object",
+        "title": "hasData",
+        "required": [
+          "hasData"
+        ],
+        "properties": {
+          "hasData": {
+            "type": "array",
+            "title": "containerItems",
+            "minItems": 1,
+            "maxItems": 50,
+            "description": "Matches items where data is present in the referenced containers.\n",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ContainerReferenceIla"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "PrefixFilterIla": {
+        "type": "object",
+        "title": "prefix",
+        "required": [
+          "prefix"
+        ],
+        "properties": {
+          "prefix": {
+            "type": "object",
+            "description": "Matches items that have the prefix in the identified property. This filter is only supported for\nsingle value text properties.\n",
+            "required": [
+              "property",
+              "value"
+            ],
+            "properties": {
+              "property": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DMSFilterProperty"
+                  }
+                ]
+              },
+              "value": {
+                "type": "string",
+                "title": "prefixValue",
+                "minLength": 1,
+                "maxLength": 500
+              }
+            }
+          }
+        }
+      },
+      "RangeFilterIla": {
+        "type": "object",
+        "title": "range",
+        "required": [
+          "range"
+        ],
+        "properties": {
+          "range": {
+            "type": "object",
+            "description": "Matches items that contain terms within the provided range.\n\nThe range must include both an upper and a lower bound. It is not permitted to specify both inclusive\nand exclusive bounds together.  E.g. `gte` and `gt`.\n\n  `gte`: Greater than or equal to.\n  `gt`: Greater than.\n  `lte`: Less than or equal to.\n  `lt`: Less than.\n",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DMSFilterProperty"
+                  }
+                ]
+              },
+              "gte": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RangeValue"
+                  }
+                ]
+              },
+              "gt": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RangeValue"
+                  }
+                ]
+              },
+              "lte": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RangeValue"
+                  }
+                ]
+              },
+              "lt": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RangeValue"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "InFilterIla": {
+        "type": "object",
+        "title": "in",
+        "required": [
+          "in"
+        ],
+        "properties": {
+          "in": {
+            "type": "object",
+            "description": "Matches items where the property **exactly** matches one of the given values. You can only apply this\nfilter to properties containing a single value.\n",
+            "required": [
+              "property",
+              "values"
+            ],
+            "properties": {
+              "property": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DMSFilterProperty"
+                  }
+                ]
+              },
+              "values": {
+                "title": "values",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RawPropertyValueListV3"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "ContainsAllFilterIla": {
+        "type": "object",
+        "title": "containsAll",
+        "required": [
+          "containsAll"
+        ],
+        "properties": {
+          "containsAll": {
+            "type": "object",
+            "description": "Matches items where the property contains all the given values.\nOnly apply this filter to multivalued properties.\n",
+            "required": [
+              "property",
+              "values"
+            ],
+            "properties": {
+              "property": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DMSFilterProperty"
+                  }
+                ]
+              },
+              "values": {
+                "title": "values",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RawPropertyValueListV3"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "ContainsAnyFilterIla": {
+        "type": "object",
+        "title": "containsAny",
+        "required": [
+          "containsAny"
+        ],
+        "properties": {
+          "containsAny": {
+            "type": "object",
+            "description": "Matches items where the property contains one or more of the given values.\nOnly apply this filter to multivalued properties.\n",
+            "required": [
+              "property",
+              "values"
+            ],
+            "properties": {
+              "property": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DMSFilterProperty"
+                  }
+                ]
+              },
+              "values": {
+                "title": "values",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RawPropertyValueListV3"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "CreatedTimeFilter": {
+        "type": "object",
+        "title": "createdTime",
+        "description": "Matches logs with the created time within the provided range.\n\nThe range must include at least one an upper or a lower bound. It is not permitted to specify both inclusive\nand exclusive bounds together.  E.g. `gte` and `gt`.\n\n  `gte`: Greater than or equal to.\n  `gt`: Greater than.\n  `lte`: Less than or equal to.\n  `lt`: Less than.\n",
+        "properties": {
+          "gte": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedTimeRangeValue"
+              }
+            ]
+          },
+          "gt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedTimeRangeValue"
+              }
+            ]
+          },
+          "lte": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedTimeRangeValue"
+              }
+            ]
+          },
+          "lt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedTimeRangeValue"
+              }
+            ]
+          }
+        },
+        "example": {
+          "gt": 1705341600000,
+          "lt": "2030-05-15T18:00:00.00Z"
+        }
+      },
+      "CreatedTimeRangeValue": {
+        "oneOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          {
+            "type": "integer"
+          }
+        ],
+        "title": "createdTimeRangeBound",
+        "description": "Timestamp value you wish to find in the ```log``` created time using a range clause.\n"
+      },
+      "LimitWithDefault10": {
+        "type": "object",
+        "title": "limit",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "description": "Limits the number of results to return.\n",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 10000,
+            "example": 42
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "title": "sortsSpecification",
+        "properties": {
+          "sort": {
+            "type": "array",
+            "title": "orderedSortSpecList",
+            "description": "Ordered list of sorting specifications (property, direction, etc) to sort on.\n",
+            "minItems": 1,
+            "maxItems": 5,
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PropertySort"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "PropertySort": {
+        "type": "object",
+        "title": "sortSpecification",
+        "description": "Sorting spec for a property.\n",
+        "required": [
+          "property"
+        ],
+        "properties": {
+          "property": {
+            "example": [
+              "space"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DMSFilterProperty"
+              }
+            ]
+          },
+          "direction": {
+            "type": "string",
+            "default": "ascending",
+            "enum": [
+              "ascending",
+              "descending"
+            ],
+            "example": "descending"
+          }
+        }
+      },
+      "AggregatesDefinitionIla": {
+        "type": "object",
+        "title": "aggregatesDictionary",
+        "minProperties": 1,
+        "maxProperties": 5,
+        "uniqueItems": true,
+        "additionalProperties": {
+          "x-additionalPropertiesName": "aggregate-id",
+          "title": "aggregateDictionary",
+          "type": "object",
+          "description": "An aggregate. It's an aggregate identifier which map to an aggregator function, and some fields to use for the aggregator function.\nThe identifiers should match the next constraints:\n  pattern: \"^[A-Za-z_][A-Za-z0-9_]*$\"\n  maxLength: 255\n  minLength: 1\n",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/AvgAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/CountAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/MinAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/MaxAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/SumAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/UniqueValuesAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/NumberHistogramAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/TimeHistogramAggregateIla"
+            },
+            {
+              "$ref": "#/components/schemas/MovingFunctionAggregateIla"
+            }
+          ]
+        },
+        "propertyNames": {
+          "maxLength": 255,
+          "minLength": 1
+        },
+        "example": {
+          "my_avg_aggregate1": {
+            "avg": {
+              "property": [
+                "mySpace",
+                "myContainer",
+                "manufacturer"
+              ]
+            }
+          },
+          "my_terms_aggregate2": {
+            "uniqueValues": {
+              "property": [
+                "mySpace",
+                "myContainer",
+                "manufacturer"
+              ],
+              "aggregates": {
+                "my_sub_aggregate1": {
+                  "min": {
+                    "property": [
+                      "mySpace",
+                      "myContainer",
+                      "price"
+                    ]
+                  }
+                },
+                "my_sub_aggregate2": {
+                  "max": {
+                    "property": [
+                      "mySpace",
+                      "myContainer",
+                      "price"
+                    ]
+                  }
+                },
+                "my_sub_aggregate3": {
+                  "uniqueValues": {
+                    "property": [
+                      "mySpace",
+                      "myContainer",
+                      "region"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "MovingFunctionAggregateIla": {
+        "type": "object",
+        "title": "movingFunction",
+        "required": [
+          "movingFunction"
+        ],
+        "properties": {
+          "movingFunction": {
+            "type": "object",
+            "description": "Given an ordered series of data, the Moving Function aggregation will slide a window across the data and allow the user to specify a function that is executed on each window of data.\nA number of common functions are predefined such as min/max, moving averages, etc. Customer defined functions are not allowed now.\nThe aggregate must be embedded inside of a numberHistogram or timeHistogram aggregate. It can be embedded like any other metric aggregate.\n",
+            "required": [
+              "bucketsPath",
+              "window",
+              "function"
+            ],
+            "properties": {
+              "bucketsPath": {
+                "type": "string",
+                "description": "Path to the metric of interest from other aggregation.\n\n<u>`buckets_path` syntax:</u>\n\n```\nAGG_SEPARATOR       =  `>` ;\nAGG_NAME            =  <the name of the aggregation> ;\nMULTIBUCKET_KEY     =  `[<KEY_NAME>]`\nKEY_NAME            =  <the name of the bucket key in the multi-bucket aggregate result> ;\nPATH                =  <AGG_NAME><MULTIBUCKET_KEY>?(<AGG_SEPARATOR><AGG_NAME>)* ;\n```\n",
+                "maxLength": 1280,
+                "minLength": 1,
+                "example": "multi_bucket_aggr[\"top_bucket\"]>sub_aggr>sub_sub_aggr"
+              },
+              "window": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "The size of window to \"slide\" across the histogram.\n",
+                "example": 42
+              },
+              "function": {
+                "type": "string",
+                "enum": [
+                  "MovingFunctions.max",
+                  "MovingFunctions.min",
+                  "MovingFunctions.sum",
+                  "MovingFunctions.unweightedAvg",
+                  "MovingFunctions.linearWeightedAvg"
+                ],
+                "description": "The function that should be executed on each window of data.\n",
+                "example": "MovingFunctions.sum"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "AvgAggregateIla": {
+        "type": "object",
+        "title": "avg",
+        "required": [
+          "avg"
+        ],
+        "properties": {
+          "avg": {
+            "type": "object",
+            "description": "Calculates the average from the data stored by the specified property. This aggregation uses an average mean\ncalculation, and not an integral mean.\n",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "CountAggregateIla": {
+        "title": "count",
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "object",
+            "description": "Counts the number of items. When you specify a property, it returns the number of non-null values for that property.\n",
+            "properties": {
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "MinAggregateIla": {
+        "type": "object",
+        "title": "min",
+        "required": [
+          "min"
+        ],
+        "properties": {
+          "min": {
+            "type": "object",
+            "description": "The function will calculate, and return, the lowest - min - value for a property.\n",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "MaxAggregateIla": {
+        "type": "object",
+        "title": "max",
+        "required": [
+          "max"
+        ],
+        "properties": {
+          "max": {
+            "type": "object",
+            "description": "The function will calculate, and return, the highest - max - value for the property.\n",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SumAggregateIla": {
+        "type": "object",
+        "title": "sum",
+        "required": [
+          "sum"
+        ],
+        "properties": {
+          "sum": {
+            "type": "object",
+            "description": "Calculates the sum from the values of the specified property.\n",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "UniqueValuesAggregateIla": {
+        "type": "object",
+        "title": "uniqueValues",
+        "required": [
+          "uniqueValues"
+        ],
+        "properties": {
+          "uniqueValues": {
+            "type": "object",
+            "description": "Request unique value buckets aggregate on of the specified property.\nEach bucket is defined by `values` array and has the number of the `values` occurrences.\n",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              },
+              "aggregates": {
+                "description": "A dictionary of requested aggregates with client defined names/identifiers.\n",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatesDefinitionIla"
+                  }
+                ]
+              },
+              "size": {
+                "type": "integer",
+                "description": "The number of top buckets returned. The default limit is 10 items.\n",
+                "minimum": 1,
+                "maximum": 2000,
+                "default": 10
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "NumberHistogramAggregateIla": {
+        "type": "object",
+        "title": "numberHistogram",
+        "required": [
+          "numberHistogram"
+        ],
+        "properties": {
+          "numberHistogram": {
+            "type": "object",
+            "description": "A histogram aggregator function. This function will generate a histogram from the values of the specified\nproperty. It uses the specified interval as defined in your `interval` argument.\n",
+            "required": [
+              "property",
+              "interval"
+            ],
+            "properties": {
+              "interval": {
+                "type": "number",
+                "description": "The interval between each bucket.\n"
+              },
+              "hardBounds": {
+                "type": "object",
+                "description": "To limit the range of buckets in the histogram.\nIt is particularly useful in the case of open data ranges that can result in a very large number of buckets.\nOne or both bounds must be specified.\n",
+                "properties": {
+                  "min": {
+                    "type": "number",
+                    "description": "The lowest number for the histogram bucket should appear in the response.\n",
+                    "example": 42
+                  },
+                  "max": {
+                    "type": "number",
+                    "description": "The highest number for the histogram bucket should appear in the response.\n",
+                    "example": 777
+                  }
+                }
+              },
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              },
+              "aggregates": {
+                "description": "A dictionary of requested aggregates with client defined names/identifiers.\n",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatesDefinitionIla"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "TimeHistogramAggregateIla": {
+        "type": "object",
+        "title": "timeHistogram",
+        "required": [
+          "timeHistogram"
+        ],
+        "properties": {
+          "timeHistogram": {
+            "type": "object",
+            "description": "A time histogram aggregator function. This function will generate a histogram from the values of the specified\nproperty. It uses the specified calendar or fixed interval as defined in the request arguments.\nThe request attribute calendarInterval or fixedInterval must be specified but not both.\n",
+            "required": [
+              "property"
+            ],
+            "properties": {
+              "calendarInterval": {
+                "type": "string",
+                "enum": [
+                  "1s",
+                  "1m",
+                  "1h",
+                  "1d",
+                  "1w",
+                  "1M",
+                  "1q",
+                  "1y"
+                ],
+                "description": "The calendar interval between each bucket.\n",
+                "example": "1q"
+              },
+              "fixedInterval": {
+                "type": "string",
+                "description": "The interval between each bucket. It must be a correct duration representation: 3m, 400h, 25d, etc.\n",
+                "example": "42m",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "hardBounds": {
+                "type": "object",
+                "description": "To limit the range of buckets in the histogram.\nIt is particularly useful in the case of open data ranges that can result in a very large number of buckets.\nOne or both bounds must be specified.\n",
+                "properties": {
+                  "min": {
+                    "type": "string",
+                    "description": "The lowest time point for the histogram bucket should appear in the response. It must be correct instant time representation.\n",
+                    "example": "2024-05-15T20:00:00Z",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "max": {
+                    "type": "string",
+                    "description": "The highest time point for the histogram bucket should appear in the response. It must be correct instant time representation.\n",
+                    "example": "2024-05-16T20:00:00Z",
+                    "minLength": 1,
+                    "maxLength": 100
+                  }
+                }
+              },
+              "property": {
+                "title": "aggregateProperty",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatePropertyIla"
+                  }
+                ]
+              },
+              "aggregates": {
+                "description": "A dictionary of requested aggregates with client defined names/identifiers.\n",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AggregatesDefinitionIla"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "AggregatePropertyIla": {
+        "title": "property",
+        "description": "Property you want to aggregate. Use a list of strings to specify nested properties.\n\n<u>Example:</u>\n\nYou have the schema\n```\n{\n  \"mySpace\": {\n    \"myContainer\": {\n      \"myProperty\": \"b42\"\n    }\n  }\n}\n```\n\nUse `[\"mySpace\", \"myContainer\", \"myProperty\"]` to aggregate the values in the nested `myProperty` property.\n",
+        "type": "array",
+        "minItems": 3,
+        "maxItems": 3,
+        "items": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "example": [
+          "mySpace",
+          "myContainer",
+          "myProperty"
+        ]
+      },
+      "AggregatesResultDefinitionIla": {
+        "type": "object",
+        "title": "aggregatesResultDictionary",
+        "description": "A dictionary of the results for the requested aggregates mapped by the aggregates identifiers.\n\n<u>Example:</u>\n\n```\n{\n  \"my_aggr_1\": {\n    \"avg\": 42\n  },\n  \"my_aggr_2\": {\n    \"max\": 69\n  },\n}\n```\n",
+        "uniqueItems": true,
+        "additionalProperties": {
+          "x-additionalPropertiesName": "aggregate-id",
+          "type": "object",
+          "title": "aggregateResultDictionary",
+          "description": "Requested aggregate result. It's the aggregate identifier from the request and a set of fields to represent aggregated data.\n",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/AvgAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/CountAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/MinAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/MaxAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/SumAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/UniqueValuesAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/NumberHistogramAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/TimeHistogramAggregateResultIla"
+            },
+            {
+              "$ref": "#/components/schemas/MovingFunctionAggregateResultIla"
+            }
+          ]
+        },
+        "example": {
+          "my_avg_aggregate1": {
+            "avg": 42
+          },
+          "my_terms_aggregate2": {
+            "buckets": [
+              {
+                "value": "Cognite",
+                "count": 42,
+                "aggregates": {
+                  "my_sub_aggregate1": {
+                    "min": 13
+                  },
+                  "my_sub_aggregate2": {
+                    "max": 69
+                  },
+                  "my_sub_aggregate3": {
+                    "buckets": [
+                      {
+                        "value": "us1",
+                        "count": 42
+                      },
+                      {
+                        "value": "ie1",
+                        "count": 7
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "value": "AkerBP",
+                "count": 21,
+                "aggregates": {
+                  "my_sub_aggregate1": {
+                    "min": 99
+                  },
+                  "my_sub_aggregate2": {
+                    "max": 999
+                  },
+                  "my_sub_aggregate3": {
+                    "buckets": [
+                      {
+                        "value": "us1",
+                        "count": 11
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "MovingFunctionAggregateResultIla": {
+        "type": "object",
+        "title": "movingFunctionResult",
+        "required": [
+          "fnValue"
+        ],
+        "properties": {
+          "fnValue": {
+            "type": "number",
+            "description": "The moving function value from the parent histogram aggregate buckets data located by the specified in the request buckets path.\n",
+            "example": 42.7
+          }
+        }
+      },
+      "AvgAggregateResultIla": {
+        "type": "object",
+        "title": "avgResult",
+        "required": [
+          "avg"
+        ],
+        "properties": {
+          "avg": {
+            "type": "number",
+            "description": "The average value from the data stored by the specified in the request property.\n",
+            "example": 42.7
+          }
+        }
+      },
+      "CountAggregateResultIla": {
+        "type": "object",
+        "title": "countResult",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of non-null values for specified in the request property.\n",
+            "example": 42
+          }
+        }
+      },
+      "MinAggregateResultIla": {
+        "type": "object",
+        "title": "minResult",
+        "required": [
+          "min"
+        ],
+        "properties": {
+          "min": {
+            "type": "number",
+            "description": "The lowest - min - value for the specified in the request property.\n",
+            "example": 13.42
+          }
+        }
+      },
+      "MaxAggregateResultIla": {
+        "type": "object",
+        "title": "maxResult",
+        "required": [
+          "max"
+        ],
+        "properties": {
+          "max": {
+            "type": "number",
+            "description": "The highest - max - value for the specified in the request property.\n",
+            "example": 77.7
+          }
+        }
+      },
+      "SumAggregateResultIla": {
+        "type": "object",
+        "title": "sumResult",
+        "required": [
+          "sum"
+        ],
+        "properties": {
+          "sum": {
+            "type": "number",
+            "description": "The sum from the values of the specified in the request property.\n",
+            "example": 777
+          }
+        }
+      },
+      "UniqueValuesAggregateResultIla": {
+        "type": "object",
+        "title": "uniqueValuesResult",
+        "properties": {
+          "buckets": {
+            "type": "array",
+            "description": "Unique value buckets on of the specified in the request property.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "count",
+                "value"
+              ],
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "The count of items with the value in the property.\n",
+                  "example": 42
+                },
+                "value": {
+                  "title": "aggregateValue",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AggregateValue"
+                    }
+                  ]
+                },
+                "aggregates": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AggregatesResultDefinitionIla"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "NumberHistogramAggregateResultIla": {
+        "type": "object",
+        "title": "numberHistogramResult",
+        "properties": {
+          "buckets": {
+            "type": "array",
+            "description": "The histogram from the values of the specified in the request property.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "count",
+                "intervalStart"
+              ],
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "The count of items with the value from the bucket interval in the property.\n",
+                  "example": 100
+                },
+                "intervalStart": {
+                  "type": "number",
+                  "description": "The number which represents the start of the bucket interval (the next bucket start point is the end point for this bucket).\n",
+                  "example": 42.7
+                },
+                "aggregates": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AggregatesResultDefinitionIla"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "TimeHistogramAggregateResultIla": {
+        "type": "object",
+        "title": "timeHistogramResult",
+        "properties": {
+          "buckets": {
+            "type": "array",
+            "description": "The histogram from the values of the specified in the request property.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "count",
+                "intervalStart"
+              ],
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "The count of items with the value from the bucket interval in the property.\n",
+                  "example": 100
+                },
+                "intervalStart": {
+                  "type": "string",
+                  "description": "The time point which represent the start of the bucket interval (the next bucket start point is the end point for this bucket).\n",
+                  "example": "2024-05-16T00:00:00Z"
+                },
+                "aggregates": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AggregatesResultDefinitionIla"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "Log": {
+        "type": "object",
+        "title": "logItem",
+        "description": "Log item.\n",
+        "required": [
+          "space",
+          "createdTime",
+          "properties"
+        ],
+        "properties": {
+          "space": {
+            "description": "Id of the space that the ```log``` belongs to.\n",
+            "example": "mySpace",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpaceSpecification"
+              }
+            ]
+          },
+          "createdTime": {
+            "title": "createdTime",
+            "example": 1720616232,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EpochTimestamp"
+              }
+            ]
+          },
+          "properties": {
+            "type": "object",
+            "title": "spaceToContainers",
+            "description": "Spaces to containers to properties and their values for the requested containers.\n",
+            "uniqueItems": true,
+            "additionalProperties": {
+              "x-additionalPropertiesName": "space-name",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ContainerWithData"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "ContainerWithData": {
+        "type": "object",
+        "title": "containerToProperties",
+        "description": "Container holding properties.\n",
+        "uniqueItems": true,
+        "additionalProperties": {
+          "description": "Properties in the container of the ```log```.\n",
+          "x-additionalPropertiesName": "container-identifier",
+          "title": "propertyToValues",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/PropertyValueGroupV3"
+            }
+          ]
         }
       },
       "EventType": {
@@ -29885,7 +34133,7 @@
               "properties": {
                 "property": {
                   "type": "array",
-                  "description": "It's an array of strings to allow specifying nested properties.\n\nSupported properties:                  \n| Property                        | Type                         |\n|---------------------------------|------------------------------|\n| `[\"assetIds\"]`                  | array of [number]            |\n| `[\"dataSetId\"]`                 | number                       |\n| `[\"description\"]`               | string                       |\n| `[\"source\"]`                    | string                       |\n| `[\"subtype\"]`                   | string                       |\n| `[\"type\"]`                      | string                       |\n| `[\"metadata\"]`                  | string                       |\n| `[\"metadata\", <key>]`           | string                       |\n",
+                  "description": "It's an array of strings to allow specifying nested properties.\n\nSupported properties:\\\n| Property                        | Type                         |\n|---------------------------------|------------------------------|\n| `[\"assetIds\"]`                  | array of [number]            |\n| `[\"dataSetId\"]`                 | number                       |\n| `[\"description\"]`               | string                       |\n| `[\"source\"]`                    | string                       |\n| `[\"subtype\"]`                   | string                       |\n| `[\"type\"]`                      | string                       |\n| `[\"metadata\"]`                  | string                       |\n| `[\"metadata\", <key>]`           | string                       |\n",
                   "minItems": 1,
                   "maxItems": 2,
                   "items": {
@@ -29912,7 +34160,7 @@
         ],
         "properties": {
           "fields": {
-            "description": "This field is deprecated. Use the `properties` field instead.  \nThe field name(s) to apply the aggregation on. Currently limited to one field.\nAccepts the following field names: `type`, `subtype`, `dataSetId` and metadata fields, for example, `metadata.FooBar`.\n",
+            "description": "This field is deprecated. Use the `properties` field instead.\\\nThe field name(s) to apply the aggregation on. Currently limited to one field.\nAccepts the following field names: `type`, `subtype`, `dataSetId` and metadata fields, for example, `metadata.FooBar`.\n",
             "deprecated": true,
             "type": "array",
             "maxItems": 1,
@@ -30073,7 +34321,7 @@
         }
       },
       "EventLeafFilter": {
-        "description": "Leaf filter. ",
+        "description": "Leaf filter.",
         "title": "LeafFilter",
         "type": "object",
         "oneOf": [
@@ -30632,6 +34880,32 @@
           }
         ]
       },
+      "InstanceId": {
+        "type": "object",
+        "required": [
+          "space",
+          "externalId"
+        ],
+        "properties": {
+          "space": {
+            "$ref": "#/components/schemas/InstanceSpace"
+          },
+          "externalId": {
+            "$ref": "#/components/schemas/InstanceExternalId"
+          }
+        }
+      },
+      "FileInstanceId": {
+        "type": "object",
+        "required": [
+          "instanceId"
+        ],
+        "properties": {
+          "instanceId": {
+            "$ref": "#/components/schemas/InstanceId"
+          }
+        }
+      },
       "FileInternalId": {
         "type": "object",
         "properties": {
@@ -30648,7 +34922,30 @@
           }
         }
       },
+      "FileExternalIdEither": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FileExternalId"
+          },
+          {
+            "$ref": "#/components/schemas/FileInstanceId"
+          }
+        ]
+      },
       "FileIdEither": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FileInternalId"
+          },
+          {
+            "$ref": "#/components/schemas/FileExternalId"
+          },
+          {
+            "$ref": "#/components/schemas/FileInstanceId"
+          }
+        ]
+      },
+      "FileDeleteByIdEither": {
         "oneOf": [
           {
             "$ref": "#/components/schemas/FileInternalId"
@@ -30781,6 +35078,9 @@
               },
               "lastUpdatedTime": {
                 "$ref": "#/components/schemas/EpochTimestamp"
+              },
+              "instanceId": {
+                "$ref": "#/components/schemas/InstanceId"
               }
             }
           }
@@ -30900,6 +35200,9 @@
           },
           {
             "$ref": "#/components/schemas/FileChangeUpdateByExternalId"
+          },
+          {
+            "$ref": "#/components/schemas/FileChangeUpdateByInstanceId"
           }
         ]
       },
@@ -30939,6 +35242,16 @@
           }
         ]
       },
+      "FileChangeUpdateByInstanceId": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FileInstanceId"
+          },
+          {
+            "$ref": "#/components/schemas/DMSFileChange"
+          }
+        ]
+      },
       "DataFileMetadata": {
         "type": "object",
         "properties": {
@@ -30946,6 +35259,28 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FilesMetadata"
+            }
+          }
+        }
+      },
+      "DataFileUploadFileMetadata": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UploadFileMetadata"
+            }
+          }
+        }
+      },
+      "DataMultiPartUploadFileMetadata": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultiPartUploadFileMetadata"
             }
           }
         }
@@ -30968,6 +35303,30 @@
             }
           }
         }
+      },
+      "FileDeleteByIds": {
+        "type": "object",
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "items"
+            ],
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FileDeleteByIdEither"
+                },
+                "maxItems": 1000,
+                "minItems": 1
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/IgnoreUnknownIdsField"
+          }
+        ]
       },
       "FileDataIds": {
         "type": "object",
@@ -31000,6 +35359,15 @@
           }
         }
       },
+      "FileSelectByInstanceId": {
+        "type": "object",
+        "title": "Select by InstanceId",
+        "properties": {
+          "instanceId": {
+            "$ref": "#/components/schemas/InstanceId"
+          }
+        }
+      },
       "FileSelectEither": {
         "oneOf": [
           {
@@ -31007,6 +35375,9 @@
           },
           {
             "$ref": "#/components/schemas/FileSelectByExternalId"
+          },
+          {
+            "$ref": "#/components/schemas/FileSelectByInstanceId"
           }
         ]
       },
@@ -31033,6 +35404,22 @@
             "$ref": "#/components/schemas/IgnoreUnknownIdsField"
           }
         ]
+      },
+      "FileDataUploadIds": {
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileExternalIdEither"
+            },
+            "minItems": 1,
+            "maxItems": 1
+          }
+        }
       },
       "FileLinkIds": {
         "type": "object",
@@ -31107,6 +35494,52 @@
                     "$ref": "#/components/schemas/ArrayPatchLong"
                   }
                 ]
+              },
+              "labels": {
+                "$ref": "#/components/schemas/LabelsPatch"
+              },
+              "geoLocation": {
+                "$ref": "#/components/schemas/SinglePatchGeoLocation"
+              }
+            }
+          }
+        }
+      },
+      "DMSFileChange": {
+        "type": "object",
+        "description": "Changes will be applied to file.",
+        "required": [
+          "update"
+        ],
+        "properties": {
+          "update": {
+            "type": "object",
+            "properties": {
+              "externalId": {
+                "$ref": "#/components/schemas/SinglePatchString"
+              },
+              "metadata": {
+                "allOf": [
+                  {
+                    "description": "Custom, application specific metadata. String key -> String value. Limits: Maximum length of key is 128 bytes, value 10240 bytes, up to 256 key-value pairs, of total size at most 10240."
+                  },
+                  {
+                    "$ref": "#/components/schemas/ObjectPatch"
+                  }
+                ]
+              },
+              "assetIds": {
+                "allOf": [
+                  {
+                    "description": "Edit the set of assetIds for the file. Minimum 0, maximum 1000. See examples in the description for the updateFiles operation."
+                  },
+                  {
+                    "$ref": "#/components/schemas/ArrayPatchLong"
+                  }
+                ]
+              },
+              "dataSetId": {
+                "$ref": "#/components/schemas/SinglePatchLong"
               },
               "labels": {
                 "$ref": "#/components/schemas/LabelsPatch"
@@ -32087,7 +36520,7 @@
           },
           "secrets": {
             "type": "object",
-            "description": "Object with additional secrets as key/value pairs. These can e.g. password to simulators or other data sources. Keys must be lowercase characters, numbers or dashes (-) and at most 15 characters. You can create at most 30 secrets, all keys must be unique, and cannot be `token`, `indexUrl`, or `extraIndexUrls`. The secrets are returned scrambled if set.",
+            "description": "Object with additional secrets as key/value pairs. These can e.g. password to simulators or other data sources. Keys must be lowercase characters, numbers or dashes (-) and at most 15 characters. You can create at most 30 secrets, all keys must be unique, and cannot be `token`, `indexUrl`, or `extraIndexUrls`. For each secret, the combined size of the secret name and secret value is limited by 25 kB. The secrets are returned scrambled if set.",
             "maxProperties": 30,
             "additionalProperties": {
               "type": "string"
@@ -32130,16 +36563,15 @@
             "example": "py311",
             "default": "py311",
             "enum": [
-              "py38",
               "py39",
               "py310",
               "py311"
             ],
-            "description": "The runtime of the function. For exmple, runtime \"py38\" translates to the latest version of the Python 3.8 series."
+            "description": "The runtime of the function. For exmple, runtime \"py311\" translates to the latest version of the Python 3.11 series."
           },
           "runtimeVersion": {
             "type": "string",
-            "example": "Python 3.8.13",
+            "example": "Python 3.11.10",
             "readOnly": true,
             "description": "The complete specification of the function runtime with major, minor and patch version numbers."
           },
@@ -33309,14 +37741,14 @@
             "title": "DatapointsWithInternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/DatapointsInsertProperties"
-              },
-              {
                 "properties": {
                   "id": {
                     "$ref": "#/components/schemas/CogniteInternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsInsertProperties"
               }
             ]
           },
@@ -33327,14 +37759,32 @@
             "title": "DatapointsWithExternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/DatapointsInsertProperties"
-              },
-              {
                 "properties": {
                   "externalId": {
                     "$ref": "#/components/schemas/CogniteExternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsInsertProperties"
+              }
+            ]
+          },
+          {
+            "required": [
+              "instanceId"
+            ],
+            "title": "DatapointsWithInstanceId",
+            "allOf": [
+              {
+                "properties": {
+                  "instanceId": {
+                    "$ref": "#/components/schemas/CogniteInstanceId"
+                  }
+                }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsInsertProperties"
               }
             ]
           }
@@ -33394,13 +37844,19 @@
               },
               "granularity": {
                 "type": "string",
-                "description": "The time granularity size and unit to aggregate over. Valid entries are 'day, hour, minute, second', or short forms 'd, h, m, s', or a multiple of these indicated by a number as a prefix. For 'second' and 'minute', the multiple must be an integer between 1 and 120 inclusive; for 'hour' and 'day', the multiple must be an integer between 1 and 100000 inclusive. For example, a granularity '5m' means that aggregates are calculated over 5 minutes. This field is required if aggregates are specified.",
+                "description": "The time granularity size and unit to aggregate over. Valid entries are 'month, day, hour, minute, second', or short forms 'mo, d, h, m, s', or a multiple of these indicated by a number as a prefix. For 'second' and 'minute', the multiple must be an integer between 1 and 120 inclusive; for 'hour', 'day', and 'month', the multiple must be an integer between 1 and 100000 inclusive. For example, a granularity '5m' means that aggregates are calculated over 5 minutes. This field is required if aggregates are specified.",
                 "example": "1h"
               },
               "includeOutsidePoints": {
                 "type": "boolean",
-                "description": "Defines whether to include the last data point before the requested time period and the first one after. This option can be useful for interpolating data. It's not available for aggregates or cursors.\nNote: If there are more than `limit` data points in the time period, we will omit the excess data points and then append the first data point after the time period, thus causing a gap with omitted data points. When this is the case, we return up to `limit+2` data points.\nWhen doing manual paging (sequentially requesting smaller intervals instead of requesting a larger interval and using cursors to get all the data points) with this field set to true, the `start` of the each subsequent request should be one millisecond more than the `timestamp` of the _second-to-last_ data point from the previous response. This is because the last data point in most cases will be the extra point from outside the interval.\n",
+                "description": "Defines whether to include the last data point before the requested\ntime period and the first one after. This option can be\nuseful for interpolating data. It's not available for aggregates or cursors.\n\nNote: If there are more than `limit` data points in the time period, we will omit\nthe excess data points and then append the first data point after the time period,\nthus causing a gap with omitted data points. When this is the case, we return\nup to `limit+2` data points.\n\nWhen doing manual paging (sequentially requesting smaller intervals instead of\nrequesting a larger interval and using cursors to get all the data points) with this\nfield set to true, the `start` of the each subsequent request should be one\nmillisecond more than the `timestamp` of the _second-to-last_ data point from the\nprevious response. This is because the last data point in most cases will be the\nextra point from outside the interval.",
                 "default": false
+              },
+              "timeZone": {
+                "type": "string",
+                "description": "For aggregates of granularity 'hour' and longer, which [time zone](<https://developer.cognite.com/dev/concepts/aggregation/calendar>) should we align to.\nAlign to the start of the hour, start of the day or start of the month.\nFor time zones of type Region/Location, the aggregate duration can vary, typically due to daylight saving time.\nFor time zones of type UTC+/-HH:MM, use increments of 15 minutes.\n\nNote: Time zones with minute offsets (e.g. UTC+05:30 or Asia/Kolkata) may take longer to execute. Historical time zones, with offsets not multiples of 15 minutes, are not supported.",
+                "default": "UTC",
+                "example": "Europe/Oslo or UTC+05:30"
               }
             }
           },
@@ -33420,14 +37876,14 @@
             "title": "QueryWithInternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/DatapointsQueryProperties"
-              },
-              {
                 "properties": {
                   "id": {
                     "$ref": "#/components/schemas/CogniteInternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsQueryProperties"
               }
             ]
           },
@@ -33438,14 +37894,32 @@
             "title": "QueryWithExternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/DatapointsQueryProperties"
-              },
-              {
                 "properties": {
                   "externalId": {
                     "$ref": "#/components/schemas/CogniteExternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsQueryProperties"
+              }
+            ]
+          },
+          {
+            "required": [
+              "instanceId"
+            ],
+            "title": "QueryWithInstanceId",
+            "allOf": [
+              {
+                "properties": {
+                  "instanceId": {
+                    "$ref": "#/components/schemas/CogniteInstanceId"
+                  }
+                }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsQueryProperties"
               }
             ]
           }
@@ -33501,7 +37975,7 @@
           },
           "ignoreBadDataPoints": {
             "type": "boolean",
-            "description": "Treat data points with a _Bad_ status code as if they do not exist.\n\nIf set to false, raw queries will include bad data points in the response, and\naggregates will in general omit the time period between a bad data point and the next good data point.\nAlso, the period between a bad data point and the previous good data point will be considered constant.",
+            "description": "Treat data points with a _Bad_ status code as if they do not exist.\n\nIf set to false, raw queries will include bad data points in the response, and\naggregates will in general omit the time period between a bad data point and the next good data point.\nAlso, the period between a bad data point and the previous good data point will be considered constant.\n\nNote that bad data points may contain the string values 'NaN', 'Infinity', or '-Infinity', or be null (omitted).",
             "default": true
           },
           "treatUncertainAsBad": {
@@ -33512,6 +37986,12 @@
           "cursor": {
             "type": "string",
             "description": "To retrieve next page, insert the `nextCursor` from a previous response. Be sure to match with the corresponding time series. Not compatible with `includeOutsidePoints`.\n"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "Which time zone to align aggregates to. Omit to use top-level value.\n",
+            "default": "UTC",
+            "example": "Europe/Oslo or UTC+05:30"
           }
         }
       },
@@ -33551,14 +38031,14 @@
             "title": "QueryWithInternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/LatestDataPropertyFilter"
-              },
-              {
                 "properties": {
                   "id": {
                     "$ref": "#/components/schemas/CogniteInternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/LatestDataPropertyFilter"
               }
             ]
           },
@@ -33569,14 +38049,32 @@
             "title": "QueryWithExternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/LatestDataPropertyFilter"
-              },
-              {
                 "properties": {
                   "externalId": {
                     "$ref": "#/components/schemas/CogniteExternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/LatestDataPropertyFilter"
+              }
+            ]
+          },
+          {
+            "required": [
+              "instanceId"
+            ],
+            "title": "QueryWithInstanceId",
+            "allOf": [
+              {
+                "properties": {
+                  "instanceId": {
+                    "$ref": "#/components/schemas/CogniteInstanceId"
+                  }
+                }
+              },
+              {
+                "$ref": "#/components/schemas/LatestDataPropertyFilter"
               }
             ]
           }
@@ -33606,7 +38104,7 @@
           },
           "ignoreBadDataPoints": {
             "type": "boolean",
-            "description": "Treat data points with a _Bad_ status code as if they do not exist.\nSet to false to include all data points.",
+            "description": "Treat data points with a _Bad_ status code as if they do not exist.\nSet to false to include all data points.\n\nNote that bad data points may contain the string values 'NaN', 'Infinity', or '-Infinity', or be null (omitted).",
             "default": true
           },
           "treatUncertainAsBad": {
@@ -33644,14 +38142,14 @@
             "title": "QueryWithInternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/DatapointsDeleteRange"
-              },
-              {
                 "properties": {
                   "id": {
                     "$ref": "#/components/schemas/CogniteInternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsDeleteRange"
               }
             ]
           },
@@ -33662,14 +38160,32 @@
             "title": "QueryWithExternalId",
             "allOf": [
               {
-                "$ref": "#/components/schemas/DatapointsDeleteRange"
-              },
-              {
                 "properties": {
                   "externalId": {
                     "$ref": "#/components/schemas/CogniteExternalId"
                   }
                 }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsDeleteRange"
+              }
+            ]
+          },
+          {
+            "required": [
+              "instanceId"
+            ],
+            "title": "QueryWithInstanceId",
+            "allOf": [
+              {
+                "properties": {
+                  "instanceId": {
+                    "$ref": "#/components/schemas/CogniteInstanceId"
+                  }
+                }
+              },
+              {
+                "$ref": "#/components/schemas/DatapointsDeleteRange"
               }
             ]
           }
@@ -33687,6 +38203,51 @@
             "$ref": "#/components/schemas/TimeSeriesEpochTimestamp"
           }
         }
+      },
+      "TimeSeriesLookupByIdWithoutInstanceId": {
+        "type": "object",
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "items"
+            ],
+            "properties": {
+              "items": {
+                "uniqueItems": true,
+                "type": "array",
+                "description": "List of ID objects.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "title": "QueryWithInternalId",
+                      "properties": {
+                        "id": {
+                          "$ref": "#/components/schemas/CogniteInternalId"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "title": "QueryWithExternalId",
+                      "properties": {
+                        "externalId": {
+                          "$ref": "#/components/schemas/CogniteExternalId"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "maxItems": 1000,
+                "minItems": 1
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/IgnoreUnknownIdsField"
+          }
+        ]
       },
       "TimeSeriesLookupById": {
         "type": "object",
@@ -33718,6 +38279,15 @@
                       "properties": {
                         "externalId": {
                           "$ref": "#/components/schemas/CogniteExternalId"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "title": "QueryWithInstanceId",
+                      "properties": {
+                        "instanceId": {
+                          "$ref": "#/components/schemas/CogniteInstanceId"
                         }
                       }
                     }
@@ -33788,14 +38358,14 @@
           },
           {
             "$ref": "#/components/schemas/TimeSeriesUpdateByExternalId"
+          },
+          {
+            "$ref": "#/components/schemas/TimeSeriesUpdateByInstanceId"
           }
         ]
       },
       "TimeSeriesUpdateById": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/TimeSeriesPatch"
-          },
           {
             "type": "object",
             "required": [
@@ -33806,14 +38376,14 @@
                 "$ref": "#/components/schemas/CogniteInternalId"
               }
             }
+          },
+          {
+            "$ref": "#/components/schemas/TimeSeriesPatch"
           }
         ]
       },
       "TimeSeriesUpdateByExternalId": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/TimeSeriesPatch"
-          },
           {
             "type": "object",
             "required": [
@@ -33824,6 +38394,27 @@
                 "$ref": "#/components/schemas/CogniteExternalId"
               }
             }
+          },
+          {
+            "$ref": "#/components/schemas/TimeSeriesPatch"
+          }
+        ]
+      },
+      "TimeSeriesUpdateByInstanceId": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "instanceId"
+            ],
+            "properties": {
+              "instanceId": {
+                "$ref": "#/components/schemas/CogniteInstanceId"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/TimeSeriesPatchDM"
           }
         ]
       },
@@ -33863,6 +38454,32 @@
               },
               "securityCategories": {
                 "$ref": "#/components/schemas/ArrayPatchLong"
+              },
+              "dataSetId": {
+                "$ref": "#/components/schemas/NullableSinglePatchLong"
+              }
+            }
+          }
+        }
+      },
+      "TimeSeriesPatchDM": {
+        "type": "object",
+        "description": "Changes will be applied to time series. Note that these changes will not be visible in data modeling.",
+        "required": [
+          "update"
+        ],
+        "properties": {
+          "update": {
+            "type": "object",
+            "properties": {
+              "externalId": {
+                "$ref": "#/components/schemas/NullableSinglePatchString"
+              },
+              "metadata": {
+                "$ref": "#/components/schemas/ObjectPatch"
+              },
+              "assetId": {
+                "$ref": "#/components/schemas/NullableSinglePatchLong"
               },
               "dataSetId": {
                 "$ref": "#/components/schemas/NullableSinglePatchLong"
@@ -33942,7 +38559,7 @@
               },
               "value": {
                 "type": "number",
-                "description": "The numerical data value of a numerical metric. Numerical data values can be in the range (-1e100, 1e100) The value is required unless the status is bad.\n"
+                "description": "The numerical data value of a numerical metric.\nNumerical data values can be in the range (-1e100, 1e100)\n\nThe value is required unless the status is bad. Bad data points may also have one\nof the three special string values: 'NaN', 'Infinity' or '-Infinity'."
               },
               "status": {
                 "$ref": "#/components/schemas/DatapointStatus"
@@ -34261,7 +38878,7 @@
             "properties": {
               "value": {
                 "type": "string",
-                "description": "The data value. The value is required unless the status is bad.\n"
+                "description": "The data value. The value is required unless the status is bad.\nIf the status is bad, the value may also be null (omitted).\n"
               },
               "status": {
                 "$ref": "#/components/schemas/DatapointStatus"
@@ -34280,7 +38897,7 @@
             "properties": {
               "value": {
                 "type": "number",
-                "description": "The data value. The value is required unless the status is bad.\n",
+                "description": "The data value.\nThe value is required unless the status is bad.\n\nIf the status is bad, the value may also be one of the 3 special string values:\n'NaN', 'Infinity' or '-Infinity'.",
                 "format": "double"
               },
               "status": {
@@ -34407,6 +39024,9 @@
             "type": "string",
             "description": "The externally supplied ID for the time series."
           },
+          "instanceId": {
+            "$ref": "#/components/schemas/CogniteInstanceId"
+          },
           "name": {
             "maxLength": 255,
             "type": "string",
@@ -34478,6 +39098,9 @@
             "maxLength": 255,
             "type": "string",
             "description": "The external ID of the time series the data points belong to."
+          },
+          "instanceId": {
+            "$ref": "#/components/schemas/CogniteInstanceId"
           }
         }
       },
@@ -35107,7 +39730,7 @@
             "type": "array",
             "minItems": 1,
             "maxItems": 1,
-            "description": "<details>\n<summary>\nSubscription definitions. A subscription may be configured explicitly with a list\nof time series, or it may be a configured dynamically through a filter. The\nsubscription cannot change type later.\n\nAn explicit list must be manually updated by the user, while a filter will be updated\nautomatically whenever a time series is added/deleted/updated (eventually consistent).\n\nThe filter subscriptions uses the same syntax as advanced filters in the _Filter time series_\nendpoint, with two exceptions: The field is named &#x60;filter&#x60; instead of &#x60;advancedFilter&#x60;,\nand we do not support the &#x60;search&#x60; LeafFilter.\n</summary>\n\n### Advanced filtering\n\nThe `filter`\nfield lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, and `exists`, by using the Boolean operators `and`, `or`, and `not`.\nFiltering applies to basic fields as well as metadata. See the `advancedFilter` syntax in the request example.\n\n\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields       | Description and example                                                                                                                                                            |\n|----------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                         |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                   |\n| `exists`       | All fields             | Only includes results where the specified property exists (has a value). <br /> `{\"exists\": {\"property\": [\"property\"]}}`                                                           |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                              |\n| `prefix`       | String type fields     | Only includes results which start with the specified text. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                     |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n\n#### Supported properties\n\n| Property                          | Type               |\n|-----------------------------------|--------------------|\n| `[\"description\"]`                 | string             |\n| `[\"externalId\"]`                  | string             |\n| `[\"metadata\", \"<someCustomKey>\"]` | string             |\n| `[\"name\"]`                        | string             |\n| `[\"unit\"]`                        | string              |\n| `[\"unitExternalId\"]`              | string              |\n| `[\"unitQuantity\"]`                | string              |\n| `[\"assetId\"]`                     | number              |\n| `[\"assetRootId\"]`                 | number              |\n| `[\"createdTime\"]`                 | number              |\n| `[\"dataSetId\"]`                   | number              |\n| `[\"id\"]`                          | number              |\n| `[\"lastUpdatedTime\"]`             | number              |\n| `[\"isStep\"]`                      | Boolean             |\n| `[\"isString\"]`                    | Boolean             |\n\n#### Limits\n\n- Filter query max depth: 10.\n- Filter query max number of clauses: 100.\n- `and` and `or` clauses must have at least one element (and at most 99, since each element counts\n  towards the total clause limit, and so does the `and`/`or` clause itself).\n- The `property` array of each leaf filter has the following limitations:\n  - Number of elements in the array is 1 or 2.\n  - Elements must not be null or blank.\n  - Each element max length is 256 characters.\n  - The `property` array must match one of the existing properties (static top-level property or dynamic metadata property).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100].\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of number or string type (matching the type of the given property).\n- `range` filter must have at lest one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be of number or string type (matching the type of the given property).\n- The maximum length of the `value` of a leaf filter that is applied to a string property is 256.\n\n</details>",
+            "description": "<details>\n<summary>\nSubscription definitions. A subscription may be configured explicitly with a list\nof time series, or it may be a configured dynamically through a filter. The\nsubscription cannot change type later.\n\nAn explicit list must be manually updated by the user, while a filter will be updated\nautomatically whenever a time series is added/deleted/updated (eventually consistent).\n\nThe filter subscriptions uses the same syntax as advanced filters in the _Filter time series_\nendpoint, with two exceptions: The field is named &#x60;filter&#x60; instead of &#x60;advancedFilter&#x60;,\nand we do not support the &#x60;search&#x60; LeafFilter.\n</summary>\n\n### Advanced filtering\n\nThe `filter`\nfield lets you create complex filtering expressions that combine simple operations,\nsuch as `equals`, `prefix`, and `exists`, by using the Boolean operators `and`, `or`, and `not`.\nFiltering applies to basic fields as well as metadata. See the `advancedFilter` syntax in the request example.\n\n\n\n#### Supported leaf filters\n\n| Leaf filter    | Supported fields       | Description and example                                                                                                                                                            |\n|----------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| `containsAll`  | Array type fields      | Only includes results which contain all of the specified values. <br /> `{\"containsAll\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                         |\n| `containsAny`  | Array type fields      | Only includes results which contain at least one of the specified values. <br /> `{\"containsAny\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                |\n| `equals`       | Non-array type fields  | Only includes results that are equal to the specified value. <br /> `{\"equals\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                   |\n| `exists`       | All fields             | Only includes results where the specified property exists (has a value). <br /> `{\"exists\": {\"property\": [\"property\"]}}`                                                           |\n| `in`           | Non-array type fields  | Only includes results that are equal to one of the specified values. <br /> `{\"in\": {\"property\": [\"property\"], \"values\": [1, 2, 3]}}`                                              |\n| `prefix`       | String type fields     | Only includes results which start with the specified text. <br /> `{\"prefix\": {\"property\": [\"property\"], \"value\": \"example\"}}`                                                     |\n| `range`        | Non-array type fields  | Only includes results that fall within the specified range. <br /> `{\"range\": {\"property\": [\"property\"], \"gt\": 1, \"lte\": 5}}` <br /> Supported operators: `gt`, `lt`, `gte`, `lte` |\n\n#### Supported properties\n\n| Property                          | Type               |\n|-----------------------------------|--------------------|\n| `[\"description\"]`                 | string             |\n| `[\"externalId\"]`                  | string             |\n| `[\"metadata\", \"<someCustomKey>\"]` | string             |\n| `[\"name\"]`                        | string             |\n| `[\"unit\"]`                         | string              |\n| `[\"unitExternalId\"]`               | string              |\n| `[\"unitQuantity\"]`                 | string              |\n| `[\"instanceId\", \"space\"]`          | string              |\n| `[\"instanceId\", \"externalId\"]`     | string              |\n| `[\"assetId\"]`                      | number              |\n| `[\"assetRootId\"]`                  | number              |\n| `[\"createdTime\"]`                  | number              |\n| `[\"dataSetId\"]`                    | number              |\n| `[\"id\"]`                           | number              |\n| `[\"lastUpdatedTime\"]`              | number              |\n| `[\"isStep\"]`                       | Boolean             |\n| `[\"isString\"]`                     | Boolean             |\n\n#### Limits\n\n- Filter query max depth: 10.\n- Filter query max number of clauses: 100.\n- `and` and `or` clauses must have at least one element (and at most 99, since each element counts\n  towards the total clause limit, and so does the `and`/`or` clause itself).\n- The `property` array of each leaf filter has the following limitations:\n  - Number of elements in the array is 1 or 2.\n  - Elements must not be null or blank.\n  - Each element max length is 256 characters.\n  - The `property` array must match one of the existing properties (static top-level property or dynamic metadata property).\n- `containsAll`, `containsAny`, and `in` filter `values` array size must be in the range [1, 100].\n- `containsAll`, `containsAny`, and `in` filter `values` array must contain elements of number or string type (matching the type of the given property).\n- `range` filter must have at lest one of `gt`, `gte`, `lt`, `lte` attributes.\n  But `gt` is mutually exclusive to `gte`, while `lt` is mutually exclusive to `lte`.\n- `gt`, `gte`, `lt`, `lte` in the `range` filter must be of number or string type (matching the type of the given property).\n- The maximum length of the `value` of a leaf filter that is applied to a string property is 256.\n\n</details>",
             "items": {
               "type": "object",
               "required": [
@@ -35146,6 +39769,15 @@
                   "maxItems": 100,
                   "items": {
                     "$ref": "#/components/schemas/CogniteExternalId"
+                  }
+                },
+                "instanceIds": {
+                  "type": "array",
+                  "description": "List of instance ids of time series that this subscription will listen to. Not compatible with filter.",
+                  "minItems": 1,
+                  "maxItems": 100,
+                  "items": {
+                    "$ref": "#/components/schemas/CogniteInstanceId"
                   }
                 },
                 "filter": {
@@ -35221,6 +39853,9 @@
           },
           "id": {
             "$ref": "#/components/schemas/CogniteInternalId"
+          },
+          "instanceId": {
+            "$ref": "#/components/schemas/CogniteInstanceId"
           }
         }
       },
@@ -35360,6 +39995,47 @@
                               "maxItems": 100,
                               "items": {
                                 "$ref": "#/components/schemas/CogniteExternalId"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "instanceIds": {
+                      "description": "Update subscription definition (not applicable for filter subscriptions).",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "add": {
+                              "type": "array",
+                              "description": "List of instance ids of time series to add to the subscription.",
+                              "minItems": 1,
+                              "maxItems": 100,
+                              "items": {
+                                "$ref": "#/components/schemas/CogniteInstanceId"
+                              }
+                            },
+                            "remove": {
+                              "type": "array",
+                              "description": "List of instance ids of time series to remove from the subscription.",
+                              "minItems": 1,
+                              "maxItems": 100,
+                              "items": {
+                                "$ref": "#/components/schemas/CogniteInstanceId"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "set": {
+                              "type": "array",
+                              "description": "Replace the subscription's current list of time series with this list of instance ids.",
+                              "minItems": 1,
+                              "maxItems": 100,
+                              "items": {
+                                "$ref": "#/components/schemas/CogniteInstanceId"
                               }
                             }
                           }
@@ -35672,6 +40348,67 @@
           }
         }
       },
+      "NotFoundResponseWithoutInstanceId": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "description": "Error details.",
+            "required": [
+              "code",
+              "message",
+              "missing"
+            ],
+            "properties": {
+              "code": {
+                "type": "integer",
+                "description": "HTTP status code",
+                "format": "int32",
+                "example": 400
+              },
+              "message": {
+                "type": "string",
+                "description": "Error message."
+              },
+              "missing": {
+                "uniqueItems": true,
+                "type": "array",
+                "description": "Items that are not found.",
+                "items": {
+                  "description": "Ids, ExternalIds or InstanceIds that are not found.",
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "$ref": "#/components/schemas/CogniteInternalId"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "externalId"
+                      ],
+                      "properties": {
+                        "externalId": {
+                          "$ref": "#/components/schemas/CogniteExternalId"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
       "NotFoundResponse": {
         "type": "object",
         "required": [
@@ -35702,10 +40439,11 @@
                 "type": "array",
                 "description": "Items that are not found.",
                 "items": {
-                  "description": "Ids or ExternalIds that are not found.",
+                  "description": "Ids, ExternalIds or InstanceIds that are not found.",
                   "oneOf": [
                     {
                       "type": "object",
+                      "title": "id",
                       "required": [
                         "id"
                       ],
@@ -35717,12 +40455,25 @@
                     },
                     {
                       "type": "object",
+                      "title": "externalId",
                       "required": [
                         "externalId"
                       ],
                       "properties": {
                         "externalId": {
                           "$ref": "#/components/schemas/CogniteExternalId"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "title": "instanceId",
+                      "required": [
+                        "instanceId"
+                      ],
+                      "properties": {
+                        "instanceId": {
+                          "$ref": "#/components/schemas/CogniteInstanceId"
                         }
                       }
                     }
@@ -36208,7 +40959,7 @@
         }
       },
       "TimeSeriesFilterProperty": {
-        "description": "The property on which you want to filter. May be either:\n- A single-element list that contains the name of one of the predefined top-level\n  properties, in which case the filter will be applied to that top-level property.\n- A single-element list that contains `'metadata'`, in which case the filter will be applied\n  to _all_ metadata properties.\n- A two-element list where the first element is `'metadata'` and the second one is any\n  string, in which case the filter will be applied to metadata properties with that name.\n",
+        "description": "The property on which you want to filter. May be either:\n- A single-element list that contains the name of one of the predefined top-level\n  properties, in which case the filter will be applied to that top-level property.\n- A single-element list that contains `'metadata'`, in which case the filter will be applied\n  to _all_ metadata properties.\n- A two-element list where the first element is `'metadata'` and the second one is any\n  string, in which case the filter will be applied to metadata properties with that name.\n- A two-element list where the first element is `'instanceId'` and the second element is\n  either `'space'` or `'externalId'`.\n",
         "type": "array",
         "minItems": 1,
         "maxItems": 2,
@@ -36497,7 +41248,7 @@
         "properties": {
           "property": {
             "type": "array",
-            "description": "Property to sort on.\nSorting can be done on the following properties:\n  | Property                          |\n  |-----------------------------------|\n  | `['assetId']`                     |\n  | `['createdTime']`                 |\n  | `['dataSetId']`                   |\n  | `['description']`                 |\n  | `['externalId']`                  |\n  | `['lastUpdatedTime']`             |\n  | `['metadata', '<someCustomKey>']` |\n  | `['name']`                        |\n  | `['_score_']`                     |",
+            "description": "Property to sort on.\nSorting can be done on the following properties:\n  | Property                          |\n  |-----------------------------------|\n  | `['assetId']`                     |\n  | `['createdTime']`                 |\n  | `['dataSetId']`                   |\n  | `['description']`                 |\n  | `['externalId']`                  |\n  | `['lastUpdatedTime']`             |\n  | `['metadata', '<someCustomKey>']` |\n  | `['name']`                        |\n  | `['_score_']`                     |\n  | `['instanceId', 'space']`         |\n  | `['instanceId', 'externalId']`    |",
             "minItems": 1,
             "maxItems": 2,
             "items": {
@@ -36551,7 +41302,7 @@
           "expression": {
             "type": "string",
             "description": "query definition. For limits, see the [guide to synthetic time series](https://developer.cognite.com/dev/concepts/resource_types/synthetic_timeseries.html#limits).",
-            "example": "(5 + TS{externalId='hello'}) / TS{id=123, aggregate='average', granularity='1h'}"
+            "example": "(5 + TS{externalId='hello'}) / TS{id=123, aggregate='average', granularity='1h'} * TS{space='dm space', externalId='dm id'}"
           },
           "start": {
             "$ref": "#/components/schemas/TimestampOrStringStart"
@@ -36566,6 +41317,12 @@
             "example": 100,
             "minimum": 1,
             "maximum": 10000
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "For aggregates of granularity 'hour' and longer, which [time zone](<https://developer.cognite.com/dev/concepts/aggregation/calendar>) should we align to. Align to the start of the hour, start of the day or start of the month. For time zones of type Region/Location, the aggregate duration can vary, typically due to daylight saving time. For time zones of type UTC+/-HH:MM, use increments of 15 minutes.\n",
+            "default": "UTC",
+            "example": "Europe/Oslo or UTC+05:30"
           }
         }
       },
@@ -37041,331 +41798,372 @@
       "CogniteCapability": {
         "type": "array",
         "items": {
-          "type": "object",
-          "oneOf": [
+          "allOf": [
             {
-              "title": "analyticsAcl",
-              "required": [
-                "analyticsAcl"
-              ],
-              "properties": {
-                "analyticsAcl": {
-                  "$ref": "#/components/schemas/cogniteanalytics_aclAcl"
+              "oneOf": [
+                {
+                  "title": "analyticsAcl",
+                  "required": [
+                    "analyticsAcl"
+                  ],
+                  "properties": {
+                    "analyticsAcl": {
+                      "$ref": "#/components/schemas/cogniteanalytics_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "annotationsAcl",
+                  "properties": {
+                    "annotationsAcl": {
+                      "$ref": "#/components/schemas/annotations_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "assetsAcl",
+                  "required": [
+                    "assetsAcl"
+                  ],
+                  "properties": {
+                    "assetsAcl": {
+                      "$ref": "#/components/schemas/cogniteassets_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "dataModelInstancesAcl",
+                  "required": [
+                    "dataModelInstancesAcl"
+                  ],
+                  "properties": {
+                    "dataModelInstancesAcl": {
+                      "$ref": "#/components/schemas/cognitedatamodelinstances_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "dataModelsAcl",
+                  "required": [
+                    "dataModelsAcl"
+                  ],
+                  "properties": {
+                    "dataModelsAcl": {
+                      "$ref": "#/components/schemas/cognitedatamodels_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "datasetsAcl",
+                  "required": [
+                    "datasetsAcl"
+                  ],
+                  "properties": {
+                    "datasetsAcl": {
+                      "$ref": "#/components/schemas/cognitedatasets_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "digitalTwinAcl",
+                  "required": [
+                    "digitalTwinAcl"
+                  ],
+                  "properties": {
+                    "digitalTwinAcl": {
+                      "$ref": "#/components/schemas/cognitedigitaltwin_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "entityMatchingAcl",
+                  "properties": {
+                    "entityMatchingAcl": {
+                      "$ref": "#/components/schemas/entitymatching_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "eventsAcl",
+                  "required": [
+                    "eventsAcl"
+                  ],
+                  "properties": {
+                    "eventsAcl": {
+                      "$ref": "#/components/schemas/cogniteevents_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "extractionPipelinesAcl",
+                  "properties": {
+                    "extractionpipelinesAcl": {
+                      "$ref": "#/components/schemas/extractionpipelines_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "extractionRunsAcl",
+                  "properties": {
+                    "extractionrunsAcl": {
+                      "$ref": "#/components/schemas/extractionruns_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "ilainstancesAcl",
+                  "required": [
+                    "ilainstancesAcl"
+                  ],
+                  "properties": {
+                    "ilainstancesAcl": {
+                      "$ref": "#/components/schemas/cogniteilainstances_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "filesAcl",
+                  "required": [
+                    "filesAcl"
+                  ],
+                  "properties": {
+                    "filesAcl": {
+                      "$ref": "#/components/schemas/cognitefiles_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "functionsAcl",
+                  "required": [
+                    "functionsAcl"
+                  ],
+                  "properties": {
+                    "functionsAcl": {
+                      "$ref": "#/components/schemas/functions_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "geospatialAcl",
+                  "required": [
+                    "geospatialAcl"
+                  ],
+                  "properties": {
+                    "geospatialAcl": {
+                      "$ref": "#/components/schemas/cognitegeospatial_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "geospatialCrsAcl",
+                  "required": [
+                    "geospatialCrsAcl"
+                  ],
+                  "properties": {
+                    "geospatialCrsAcl": {
+                      "$ref": "#/components/schemas/cognitegeospatialcrs_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "groupsAcl",
+                  "required": [
+                    "groupsAcl"
+                  ],
+                  "properties": {
+                    "groupsAcl": {
+                      "$ref": "#/components/schemas/cognitegroups_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "labelsAcl",
+                  "required": [
+                    "labelsAcl"
+                  ],
+                  "properties": {
+                    "labelsAcl": {
+                      "$ref": "#/components/schemas/cognitelabels_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "locationFiltersAcl",
+                  "properties": {
+                    "locationFiltersAcl": {
+                      "$ref": "#/components/schemas/locationfilters_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "projectsAcl",
+                  "required": [
+                    "projectsAcl"
+                  ],
+                  "properties": {
+                    "projectsAcl": {
+                      "$ref": "#/components/schemas/cogniteprojects_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "rawAcl",
+                  "required": [
+                    "rawAcl"
+                  ],
+                  "properties": {
+                    "rawAcl": {
+                      "$ref": "#/components/schemas/cogniteraw_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "relationshipsAcl",
+                  "required": [
+                    "relationshipsAcl"
+                  ],
+                  "properties": {
+                    "relationshipsAcl": {
+                      "$ref": "#/components/schemas/cogniterelationships_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "roboticsAcl",
+                  "required": [
+                    "roboticsAcl"
+                  ],
+                  "properties": {
+                    "groupsAcl": {
+                      "$ref": "#/components/schemas/cogniterobotics_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "securityCategoriesAcl",
+                  "required": [
+                    "securityCategoriesAcl"
+                  ],
+                  "properties": {
+                    "securityCategoriesAcl": {
+                      "$ref": "#/components/schemas/cognitesecuritycategories_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "seismicAcl",
+                  "required": [
+                    "seismicAcl"
+                  ],
+                  "properties": {
+                    "seismicAcl": {
+                      "$ref": "#/components/schemas/cogniteseismic_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "sequencesAcl",
+                  "required": [
+                    "sequencesAcl"
+                  ],
+                  "properties": {
+                    "sequencesAcl": {
+                      "$ref": "#/components/schemas/cognitesequences_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "sessionsAcl",
+                  "properties": {
+                    "sessionsAcl": {
+                      "$ref": "#/components/schemas/sessions_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "threedAcl",
+                  "required": [
+                    "threedAcl"
+                  ],
+                  "properties": {
+                    "threedAcl": {
+                      "$ref": "#/components/schemas/cognitethreed_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "timeSeriesAcl",
+                  "required": [
+                    "timeSeriesAcl"
+                  ],
+                  "properties": {
+                    "timeSeriesAcl": {
+                      "$ref": "#/components/schemas/cognitetimeseries_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "timeSeriesSubscriptionsAcl",
+                  "required": [
+                    "timeSeriesSubscriptionsAcl"
+                  ],
+                  "properties": {
+                    "timeSeriesSubscriptionsAcl": {
+                      "$ref": "#/components/schemas/cognitetimeseriessubscriptions_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "transformationsAcl",
+                  "required": [
+                    "transformationsAcl"
+                  ],
+                  "properties": {
+                    "transformationsAcl": {
+                      "$ref": "#/components/schemas/cognitetransformations_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "typesAcl",
+                  "required": [
+                    "typesAcl"
+                  ],
+                  "properties": {
+                    "typesAcl": {
+                      "$ref": "#/components/schemas/cognitetypes_aclAcl"
+                    }
+                  }
+                },
+                {
+                  "title": "workflowOrchestrationAcl",
+                  "required": [
+                    "workflowOrchestrationAcl"
+                  ],
+                  "properties": {
+                    "workflowOrchestrationAcl": {
+                      "$ref": "#/components/schemas/cogniteWorkflowOrchestration_aclAcl"
+                    }
+                  }
                 }
-              }
+              ]
             },
             {
-              "title": "annotationsAcl",
+              "type": "object",
+              "title": "Project URL names",
               "properties": {
-                "annotationsAcl": {
-                  "$ref": "#/components/schemas/annotations_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "assetsAcl",
-              "required": [
-                "assetsAcl"
-              ],
-              "properties": {
-                "assetsAcl": {
-                  "$ref": "#/components/schemas/cogniteassets_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "datamodelinstancesAcl",
-              "required": [
-                "datamodelinstancesAcl"
-              ],
-              "properties": {
-                "datamodelinstancesAcl": {
-                  "$ref": "#/components/schemas/cognitedatamodelinstances_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "datamodelsAcl",
-              "required": [
-                "datamodelsAcl"
-              ],
-              "properties": {
-                "datamodelsAcl": {
-                  "$ref": "#/components/schemas/cognitedatamodels_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "datasetsAcl",
-              "required": [
-                "datasetsAcl"
-              ],
-              "properties": {
-                "datasetsAcl": {
-                  "$ref": "#/components/schemas/cognitedatasets_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "digitalTwinAcl",
-              "required": [
-                "digitalTwinAcl"
-              ],
-              "properties": {
-                "digitalTwinAcl": {
-                  "$ref": "#/components/schemas/cognitedigitaltwin_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "entityMatchingAcl",
-              "properties": {
-                "entityMatchingAcl": {
-                  "$ref": "#/components/schemas/entitymatching_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "eventsAcl",
-              "required": [
-                "eventsAcl"
-              ],
-              "properties": {
-                "eventsAcl": {
-                  "$ref": "#/components/schemas/cogniteevents_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "extractionPipelinesAcl",
-              "properties": {
-                "extractionpipelinesAcl": {
-                  "$ref": "#/components/schemas/extractionpipelines_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "extractionRunsAcl",
-              "properties": {
-                "extractionrunsAcl": {
-                  "$ref": "#/components/schemas/extractionruns_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "filesAcl",
-              "required": [
-                "filesAcl"
-              ],
-              "properties": {
-                "filesAcl": {
-                  "$ref": "#/components/schemas/cognitefiles_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "functionsAcl",
-              "required": [
-                "functionsAcl"
-              ],
-              "properties": {
-                "functionsAcl": {
-                  "$ref": "#/components/schemas/functions_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "geospatialAcl",
-              "required": [
-                "geospatialAcl"
-              ],
-              "properties": {
-                "geospatialAcl": {
-                  "$ref": "#/components/schemas/cognitegeospatial_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "geospatialCrsAcl",
-              "required": [
-                "geospatialCrsAcl"
-              ],
-              "properties": {
-                "geospatialCrsAcl": {
-                  "$ref": "#/components/schemas/cognitegeospatialcrs_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "groupsAcl",
-              "required": [
-                "groupsAcl"
-              ],
-              "properties": {
-                "groupsAcl": {
-                  "$ref": "#/components/schemas/cognitegroups_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "labelsAcl",
-              "required": [
-                "labelsAcl"
-              ],
-              "properties": {
-                "labelsAcl": {
-                  "$ref": "#/components/schemas/cognitelabels_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "projectsAcl",
-              "required": [
-                "projectsAcl"
-              ],
-              "properties": {
-                "projectsAcl": {
-                  "$ref": "#/components/schemas/cogniteprojects_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "rawAcl",
-              "required": [
-                "rawAcl"
-              ],
-              "properties": {
-                "rawAcl": {
-                  "$ref": "#/components/schemas/cogniteraw_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "relationshipsAcl",
-              "required": [
-                "relationshipsAcl"
-              ],
-              "properties": {
-                "relationshipsAcl": {
-                  "$ref": "#/components/schemas/cogniterelationships_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "roboticsAcl",
-              "required": [
-                "roboticsAcl"
-              ],
-              "properties": {
-                "groupsAcl": {
-                  "$ref": "#/components/schemas/cogniterobotics_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "securityCategoriesAcl",
-              "required": [
-                "securityCategoriesAcl"
-              ],
-              "properties": {
-                "securityCategoriesAcl": {
-                  "$ref": "#/components/schemas/cognitesecuritycategories_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "seismicAcl",
-              "required": [
-                "seismicAcl"
-              ],
-              "properties": {
-                "seismicAcl": {
-                  "$ref": "#/components/schemas/cogniteseismic_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "sequencesAcl",
-              "required": [
-                "sequencesAcl"
-              ],
-              "properties": {
-                "sequencesAcl": {
-                  "$ref": "#/components/schemas/cognitesequences_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "sessionsAcl",
-              "properties": {
-                "sessionsAcl": {
-                  "$ref": "#/components/schemas/sessions_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "threedAcl",
-              "required": [
-                "threedAcl"
-              ],
-              "properties": {
-                "threedAcl": {
-                  "$ref": "#/components/schemas/cognitethreed_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "timeSeriesAcl",
-              "required": [
-                "timeSeriesAcl"
-              ],
-              "properties": {
-                "timeSeriesAcl": {
-                  "$ref": "#/components/schemas/cognitetimeseries_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "timeSeriesSubscriptionsAcl",
-              "required": [
-                "timeSeriesSubscriptionsAcl"
-              ],
-              "properties": {
-                "timeSeriesSubscriptionsAcl": {
-                  "$ref": "#/components/schemas/cognitetimeseriessubscriptions_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "transformationsAcl",
-              "required": [
-                "transformationsAcl"
-              ],
-              "properties": {
-                "transformationsAcl": {
-                  "$ref": "#/components/schemas/cognitetransformations_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "typesAcl",
-              "required": [
-                "typesAcl"
-              ],
-              "properties": {
-                "typesAcl": {
-                  "$ref": "#/components/schemas/cognitetypes_aclAcl"
-                }
-              }
-            },
-            {
-              "title": "workflowOrchestrationAcl",
-              "required": [
-                "workflowOrchestrationAcl"
-              ],
-              "properties": {
-                "workflowOrchestrationAcl": {
-                  "$ref": "#/components/schemas/cogniteWorkflowOrchestration_aclAcl"
+                "projectUrlNames": {
+                  "required": [
+                    "urlNames"
+                  ],
+                  "properties": {
+                    "urlNames": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ProjectUrlName"
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -37471,14 +42269,14 @@
           "actions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/cognitedatamodelInstancess_aclAction"
+              "$ref": "#/components/schemas/cognitedatamodelInstances_aclAction"
             }
           },
           "scope": {
             "$ref": "#/components/schemas/cognitedatamodels_aclScope"
           }
         },
-        "title": "Acl:DatamodelInstances"
+        "title": "Acl:DataModelInstances"
       },
       "cognitedatamodels_aclAcl": {
         "type": "object",
@@ -37497,9 +42295,9 @@
             "$ref": "#/components/schemas/cognitedatamodels_aclScope"
           }
         },
-        "title": "Acl:Datamodels"
+        "title": "Acl:DataModels"
       },
-      "cognitedatamodelInstancess_aclAction": {
+      "cognitedatamodelInstances_aclAction": {
         "type": "string",
         "enum": [
           "READ",
@@ -37507,7 +42305,7 @@
           "WRITE_PROPERTIES"
         ],
         "default": "READ",
-        "title": "Datamodels:Action"
+        "title": "DataModelInstances:Action"
       },
       "cognitedatamodels_aclAction": {
         "type": "string",
@@ -37516,7 +42314,7 @@
           "WRITE"
         ],
         "default": "READ",
-        "title": "Datamodels:Action"
+        "title": "DataModels:Action"
       },
       "cognitedatamodels_aclScope": {
         "type": "object",
@@ -37538,7 +42336,7 @@
             }
           }
         ],
-        "title": "Datasets:Scope"
+        "title": "DataModels:Scope"
       },
       "cognitedatamodels_aclSpaceIdScope": {
         "type": "object",
@@ -37551,7 +42349,7 @@
             "title": "Space IDs"
           }
         },
-        "title": "Scope:SpaceScope"
+        "title": "Scope:SpaceIdScope"
       },
       "cognitedatasets_aclAcl": {
         "type": "object",
@@ -37704,6 +42502,34 @@
           }
         ],
         "title": "Event:Scope"
+      },
+      "cogniteilainstances_aclAcl": {
+        "type": "object",
+        "required": [
+          "actions",
+          "scope"
+        ],
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cogniteilainstances_aclAction"
+            }
+          },
+          "scope": {
+            "$ref": "#/components/schemas/cognitedatamodels_aclScope"
+          }
+        },
+        "title": "Acl:IndustrialLogAnalyticsInstances"
+      },
+      "cogniteilainstances_aclAction": {
+        "type": "string",
+        "enum": [
+          "READ",
+          "WRITE"
+        ],
+        "default": "READ",
+        "title": "IndustrialLogAnalytics:Action"
       },
       "cognitefiles_aclAcl": {
         "type": "object",
@@ -38871,6 +43697,70 @@
         ],
         "title": "Extraction Pipelines Configs:Scope"
       },
+      "locationfilters_aclAcl": {
+        "type": "object",
+        "required": [
+          "actions",
+          "scope"
+        ],
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/locationfilters_aclAction"
+            }
+          },
+          "scope": {
+            "$ref": "#/components/schemas/locationfilters_aclScope"
+          }
+        },
+        "title": "Acl:Location Filters"
+      },
+      "locationfilters_aclAction": {
+        "type": "string",
+        "enum": [
+          "READ",
+          "WRITE"
+        ],
+        "default": "READ",
+        "title": "Location Filters:Action"
+      },
+      "locationfilters_aclScope": {
+        "type": "object",
+        "oneOf": [
+          {
+            "title": "all",
+            "properties": {
+              "all": {
+                "$ref": "#/components/schemas/generic_aclAllScope"
+              }
+            }
+          },
+          {
+            "title": "idScope",
+            "properties": {
+              "idScope": {
+                "$ref": "#/components/schemas/locationfilters_aclIdScope"
+              }
+            }
+          }
+        ],
+        "title": "Location Filters:Scope"
+      },
+      "locationfilters_aclIdScope": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64"
+            },
+            "title": "location filter IDs"
+          }
+        },
+        "title": "Scope:LocationFiltersIdScope"
+      },
       "entitymatching_aclAcl": {
         "type": "object",
         "required": [
@@ -39137,6 +44027,18 @@
           }
         },
         "description": "Sets if the project should be a leaf project or not. Currently only permitted to be updated by cluster administrators.\n\nCluster administrators should exercise caution when updating the `leafProject` status of a project, as it has the potential\nto break the invariants that only leaf projects can contain industrial data (assets, timeseries, etc.), or that leaf projects\nshould not have child projects.\n\nTypically the `leafProject` state should only be updated if a project has been mistakenly created with the wrong status.\n"
+      },
+      "SinglePatchDataModelingStatus": {
+        "type": "object",
+        "required": [
+          "set"
+        ],
+        "properties": {
+          "set": {
+            "$ref": "#/components/schemas/DataModelingStatus"
+          }
+        },
+        "description": "Sets the data modeling status of the project. Only permitted to be updated by cluster administrators."
       },
       "SinglePatchReservedPrefix": {
         "type": "object",
@@ -39760,7 +44662,7 @@
           "writeProtected": {
             "default": false,
             "type": "boolean",
-            "description": "To write data to a write-protected data set, you need to be a member of a group that has the \"datasets:owner\" action for the data set.  To learn more about write-protected data sets, follow this [guide](/cdf/data_governance/concepts/datasets/#write-protection)"
+            "description": "To write data to a write-protected data set, you need to be a member of a group that has the \"datasets:owner\" action for the data set. To learn more about write-protected data sets, follow this [guide](https://docs.cognite.com/cdf/data_governance/concepts/datasets/#write-protection)."
           }
         }
       },
@@ -41168,7 +46070,7 @@
                 "$ref": "#/components/schemas/SequenceFilter"
               },
               "advancedFilter": {
-                "$ref": "#/components/schemas/TimeSeriesFilterLanguage"
+                "$ref": "#/components/schemas/SequencesFilterLanguage"
               },
               "limit": {
                 "description": "Returns up to this many results per page.",
@@ -41187,17 +46089,9 @@
             "$ref": "#/components/schemas/PartitionObject"
           },
           {
-            "$ref": "#/components/schemas/TimeSeriesSort"
+            "$ref": "#/components/schemas/SequencesSort"
           }
         ]
-      },
-      "SequencesAggregateDTO": {
-        "type": "object",
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/SequenceFilter"
-          }
-        }
       },
       "SequencesAdvancedAggregateDTO": {
         "type": "object",
@@ -41205,10 +46099,10 @@
           {
             "properties": {
               "advancedFilter": {
-                "$ref": "#/components/schemas/TimeSeriesFilterLanguage"
+                "$ref": "#/components/schemas/SequencesFilterLanguage"
               },
               "aggregateFilter": {
-                "$ref": "#/components/schemas/TimeSeriesAggregateFilter"
+                "$ref": "#/components/schemas/SequencesAggregateFilter"
               },
               "filter": {
                 "$ref": "#/components/schemas/SequenceFilter"
@@ -41402,6 +46296,692 @@
           "DOUBLE",
           "LONG"
         ]
+      },
+      "SequencesFilterLanguage": {
+        "type": "object",
+        "description": "A filter DSL (Domain Specific Language) to define advanced filter queries.\n\nAt the top level, an `advancedFilter` expression is either a single Boolean filter or a\nsingle leaf filter. Boolean filters contain other Boolean filters and/or leaf filters. The\ntotal number of filters may be at most 100, and the depth (the greatest number of times\nfilters have been nested inside each other) may be at most 10. The `search` leaf filter may\nat most be used twice within a single `advancedFilter`, but all other filters can be used\nas many times as you like as long as the other limits are respected.\n",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SequencesBoolFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesLeafFilter"
+          }
+        ],
+        "example": {
+          "or": [
+            {
+              "not": {
+                "and": [
+                  {
+                    "equals": {
+                      "property": [
+                        "metadata",
+                        "manufacturer"
+                      ],
+                      "value": "acme"
+                    }
+                  },
+                  {
+                    "in": {
+                      "property": [
+                        "name"
+                      ],
+                      "values": [
+                        "pump-1-temperature",
+                        "motor-9-temperature"
+                      ]
+                    }
+                  },
+                  {
+                    "range": {
+                      "property": [
+                        "dataSetId"
+                      ],
+                      "gte": 1,
+                      "lt": 10
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "and": [
+                {
+                  "equals": {
+                    "property": [
+                      "assetId"
+                    ],
+                    "value": 1234
+                  }
+                },
+                {
+                  "equals": {
+                    "property": [
+                      "description"
+                    ],
+                    "value": "Temperature in Celsius"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "SequencesLeafFilter": {
+        "description": "Leaf filter.\n",
+        "title": "Leaf filter",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SequencesEqualsFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesInFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesRangeFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesPrefixFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesExistsFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesContainsAnyFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesContainsAllFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesSearchFilter"
+          }
+        ]
+      },
+      "SequencesBoolFilter": {
+        "description": "A query that matches items matching boolean combinations of other queries.\nIt is built by nesting one or more Boolean clauses, each of which is one of `and`, `or`, and `not`.\nEach such clause contains one or more child clauses (though `not` can only have one).\nEach child clause can be either another Boolean clause or a leaf filter.\n",
+        "title": "Boolean filter",
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "and",
+            "required": [
+              "and"
+            ],
+            "properties": {
+              "and": {
+                "description": "All of the sub-clauses in the query must appear in matching items.",
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 99,
+                "items": {
+                  "$ref": "#/components/schemas/SequencesFilterLanguage"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "or",
+            "required": [
+              "or"
+            ],
+            "properties": {
+              "or": {
+                "description": "At least one of the sub-clauses in the query must appear in matching items.",
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 99,
+                "items": {
+                  "$ref": "#/components/schemas/SequencesFilterLanguage"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "not",
+            "required": [
+              "not"
+            ],
+            "properties": {
+              "not": {
+                "title": "Filter DSL",
+                "description": "Sub-clauses in the query must not appear in matching items.",
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SequencesFilterLanguage"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "SequencesEqualsFilter": {
+        "type": "object",
+        "title": "equals",
+        "required": [
+          "equals"
+        ],
+        "properties": {
+          "equals": {
+            "required": [
+              "property",
+              "value"
+            ],
+            "description": "Matches items where the given property is **exactly** equal to the given value.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              },
+              "value": {
+                "$ref": "#/components/schemas/SequencesValue"
+              }
+            }
+          }
+        }
+      },
+      "SequencesInFilter": {
+        "type": "object",
+        "title": "in",
+        "required": [
+          "in"
+        ],
+        "properties": {
+          "in": {
+            "required": [
+              "property",
+              "values"
+            ],
+            "description": "Matches items where the given property is **exactly** equal to one of the given values.\nThis filter can only be applied to single-valued properties.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              },
+              "values": {
+                "$ref": "#/components/schemas/SequencesValues"
+              }
+            }
+          }
+        }
+      },
+      "SequencesRangeFilter": {
+        "type": "object",
+        "title": "range",
+        "required": [
+          "range"
+        ],
+        "properties": {
+          "range": {
+            "required": [
+              "property"
+            ],
+            "description": "Matches items that contain terms within the provided range.\n\nOne upper bound and/or one lower bound must be specified. It's not allowed to specify both inclusive and exclusive\nbounds \"on the same side\" together (at most one of `lte` and `lt` may be specified, and at most one of `gte` and `gt`).\n- `gte`: Greater than or equal to.\n- `gt`: Greater than.\n- `lte`: Less than or equal to.\n- `lt`: Less than.\n\nMay only be applied to string properties and number properties.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              },
+              "gte": {
+                "$ref": "#/components/schemas/SequencesRangeValue"
+              },
+              "gt": {
+                "$ref": "#/components/schemas/SequencesRangeValue"
+              },
+              "lte": {
+                "$ref": "#/components/schemas/SequencesRangeValue"
+              },
+              "lt": {
+                "$ref": "#/components/schemas/SequencesRangeValue"
+              }
+            }
+          }
+        }
+      },
+      "SequencesPrefixFilter": {
+        "type": "object",
+        "title": "prefix",
+        "required": [
+          "prefix"
+        ],
+        "properties": {
+          "prefix": {
+            "required": [
+              "property",
+              "value"
+            ],
+            "description": "Matches items where the provided property begins with the given text.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              },
+              "value": {
+                "$ref": "#/components/schemas/SequencesStringValue"
+              }
+            }
+          }
+        }
+      },
+      "SequencesExistsFilter": {
+        "type": "object",
+        "title": "exists",
+        "required": [
+          "exists"
+        ],
+        "properties": {
+          "exists": {
+            "required": [
+              "property"
+            ],
+            "description": "Matches items that have a value for the specified property.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              }
+            }
+          }
+        }
+      },
+      "SequencesContainsAnyFilter": {
+        "type": "object",
+        "title": "containsAny",
+        "required": [
+          "containsAny"
+        ],
+        "properties": {
+          "containsAny": {
+            "required": [
+              "property",
+              "values"
+            ],
+            "description": "Matches items where the property contains one or more of the given values.\nThis filter can only be applied to multivalued properties.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              },
+              "values": {
+                "$ref": "#/components/schemas/SequencesValues"
+              }
+            }
+          }
+        }
+      },
+      "SequencesContainsAllFilter": {
+        "type": "object",
+        "title": "containsAll",
+        "required": [
+          "containsAll"
+        ],
+        "properties": {
+          "containsAll": {
+            "required": [
+              "property",
+              "values"
+            ],
+            "description": "Matches items where the property contains all the given values.\nThis filter can only be applied to multivalued properties.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              },
+              "values": {
+                "$ref": "#/components/schemas/SequencesValues"
+              }
+            }
+          }
+        }
+      },
+      "SequencesSearchFilter": {
+        "type": "object",
+        "title": "search",
+        "required": [
+          "search"
+        ],
+        "properties": {
+          "search": {
+            "required": [
+              "property",
+              "value"
+            ],
+            "description": "Matches items where the provided string property contains the given value according to a fuzzy search.\nThe value may exist anywhere in the string, even as a part of a word or with some grammatical\nvariations (e.g., searching for \"run\" will also find \"ran\").\n\nThe supported properties are `name` and `description`. It's also possible to set `property`\nto `[\"query\"]`, in which case both `name` and `description` will be searched.\n\nWhen the `search` filter is being used, and it's not nested inside a `not` filter (directly or indirectly),\nand no `sort` is specified, the results will be ranked according to how good the match is.\nWhen the `query` 'property' is specified, matches in `name` will rank higher than matches in `description`.\nThe `search` filter may be used at most twice within the same `advancedFilter` expression.\n",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/SequencesFilterProperty"
+              },
+              "value": {
+                "$ref": "#/components/schemas/SequencesStringValue"
+              }
+            }
+          }
+        }
+      },
+      "SequencesFilterProperty": {
+        "description": "The property on which you want to filter. May be either:\n- A single-element list that contains the name of one of the predefined top-level\n  properties, in which case the filter will be applied to that top-level property.\n- A single-element list that contains `'metadata'`, in which case the filter will be applied\n  to _all_ metadata properties.\n- A two-element list where the first element is `'metadata'` and the second one is any\n  string, in which case the filter will be applied to metadata properties with that name.\n",
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 2,
+        "items": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      "SequencesValue": {
+        "description": "A value that you wish to find in the provided property.\n",
+        "oneOf": [
+          {
+            "type": "string",
+            "maxLength": 256
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "SequencesValues": {
+        "description": "One or more values that you wish to find in the provided properties.\n",
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 100,
+        "items": {
+          "$ref": "#/components/schemas/SequencesValue"
+        }
+      },
+      "SequencesStringValue": {
+        "title": "String",
+        "description": "A value that you wish to find in the provided property.\n",
+        "type": "string",
+        "maxLength": 256
+      },
+      "SequencesRangeValue": {
+        "description": "An upper or lower bound in a `range` filter.",
+        "oneOf": [
+          {
+            "type": "string",
+            "maxLength": 256
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "SequencesAggregateFilter": {
+        "type": "object",
+        "description": "A filter DSL (Domain Specific Language) to define aggregate filters.\n",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SequencesBoolAggregateFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesLeafAggregateFilter"
+          }
+        ]
+      },
+      "SequencesLeafAggregateFilter": {
+        "description": "Leaf filter.\n",
+        "title": "Leaf filter",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SequencesInAggregateFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesRangeAggregateFilter"
+          },
+          {
+            "$ref": "#/components/schemas/SequencesPrefixAggregateFilter"
+          }
+        ]
+      },
+      "SequencesBoolAggregateFilter": {
+        "description": "A query that matches items matching boolean combinations of other queries.\nIt's built by nesting one or more Boolean clauses, each of which is one of `and`, `or`, and `not`.\nEach such clause contains one or more child clauses (though `not` can only have one).\nEach child clause can be either another Boolean clause or a leaf filter.\n",
+        "title": "Boolean filter",
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "and",
+            "required": [
+              "and"
+            ],
+            "properties": {
+              "and": {
+                "title": "Aggregate filter DSL",
+                "description": "The aggregation result will only contain items that match _all_ of the given\nsub-clauses.\n",
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 19,
+                "items": {
+                  "$ref": "#/components/schemas/SequencesAggregateFilter"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "or",
+            "required": [
+              "or"
+            ],
+            "properties": {
+              "or": {
+                "title": "Aggregate filter DSL",
+                "description": "The aggregation result will only contain items that match _at least one_\n(but potentially many or even all) of the given sub-clauses.\n",
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 19,
+                "items": {
+                  "$ref": "#/components/schemas/SequencesAggregateFilter"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "not",
+            "required": [
+              "not"
+            ],
+            "properties": {
+              "not": {
+                "title": "Aggregate filter DSL",
+                "description": "The aggregation result will only contain items that do _not_ match the given\nsub-clause.\n",
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SequencesAggregateFilter"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "SequencesInAggregateFilter": {
+        "type": "object",
+        "title": "in",
+        "required": [
+          "in"
+        ],
+        "properties": {
+          "in": {
+            "required": [
+              "values"
+            ],
+            "description": "Matches intermediate aggregation results where the property key or the property value is _exactly_\nequal to one of the given values. When the `aggregate` operation is `uniqueProperties` or\n`cardinalityProperties`, property _keys_ will be targeted; when it is `uniqueValues` or\n`cardinalityValues`, property _values_ will be targeted.\n",
+            "type": "object",
+            "properties": {
+              "values": {
+                "$ref": "#/components/schemas/SequencesInAggregateValues"
+              }
+            }
+          }
+        }
+      },
+      "SequencesPrefixAggregateFilter": {
+        "type": "object",
+        "title": "prefix",
+        "required": [
+          "prefix"
+        ],
+        "properties": {
+          "prefix": {
+            "required": [
+              "value"
+            ],
+            "description": "Matches intermediate aggregation results where the property key or the property value begins with\nthe given text. When the `aggregate` operation is `uniqueProperties` or `cardinalityProperties`,\nproperty _keys_ will be targeted; when it is `uniqueValues` or `cardinalityValues`, property\n_values_ will be targeted.\n",
+            "type": "object",
+            "properties": {
+              "value": {
+                "$ref": "#/components/schemas/SequencesPrefixAggregateValue"
+              }
+            }
+          }
+        }
+      },
+      "SequencesRangeAggregateFilter": {
+        "type": "object",
+        "title": "range",
+        "required": [
+          "range"
+        ],
+        "properties": {
+          "range": {
+            "description": "Matches intermediate aggregation results where the property key or the property value is within the\nprovided range. When the `aggregate` operation is `uniqueProperties` or `cardinalityProperties`,\nproperty _keys_ will be targeted; when it is `uniqueValues` or `cardinalityValues`, property \n_values_ will be targeted.\n\nAt least one of the following bounds must be specified:\n- `gte`: Greater than or equal to.\n- `gt`: Greater than.\n- `lte`: Less than or equal to.\n- `lt`: Less than.\n\nIt is not valid to specify both inclusive and exclusive bounds \"on the same side\" together:\nat most one of `lte` and `lt` may be specified, and at most one of `gte` and `gt`.\n\nIn the case of `aggregate` being `uniqueProperties` or `cardinalityProperties`,\n`gte`/`gt`/`lte`/`lt` must be set to a string. In the case of `aggregate` being `uniqueValues` or\n`cardinalityValues`, this filter may only be applied to string properties or number properties,\nwith `gte`/`gt`/`lte`/`lt` containing values of the corresponding type.\n",
+            "type": "object",
+            "properties": {
+              "gte": {
+                "$ref": "#/components/schemas/SequencesRangeAggregateValue"
+              },
+              "gt": {
+                "$ref": "#/components/schemas/SequencesRangeAggregateValue"
+              },
+              "lte": {
+                "$ref": "#/components/schemas/SequencesRangeAggregateValue"
+              },
+              "lt": {
+                "$ref": "#/components/schemas/SequencesRangeAggregateValue"
+              }
+            }
+          }
+        }
+      },
+      "SequencesInAggregateValues": {
+        "description": "The property keys or property values (depending on the `aggregate` operation) on which you want to\nfilter the intermediate aggregate results.\n",
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 100,
+        "items": {
+          "$ref": "#/components/schemas/SequencesInAggregateValue"
+        }
+      },
+      "SequencesInAggregateValue": {
+        "description": "The property key or property value (depending on the `aggregate` operation) on which you want to\nfilter the intermediate aggregate results.\n",
+        "oneOf": [
+          {
+            "type": "string",
+            "maxLength": 256
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "SequencesPrefixAggregateValue": {
+        "title": "String",
+        "description": "A string value that represents either a property key or a property value, depending on the\n`aggregate` operation.\n",
+        "type": "string",
+        "maxLength": 256
+      },
+      "SequencesRangeAggregateValue": {
+        "description": "An upper or lower bound for a property key or property value (depending on which `aggregate` was\nspecified at the top level of the aggregation request).\n",
+        "oneOf": [
+          {
+            "type": "string",
+            "maxLength": 256
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "SequencesSort": {
+        "type": "object",
+        "properties": {
+          "sort": {
+            "description": "Sort by array of selected properties.\n",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 2,
+            "items": {
+              "$ref": "#/components/schemas/SequencesSortItem"
+            }
+          }
+        }
+      },
+      "SequencesSortItem": {
+        "type": "object",
+        "required": [
+          "property"
+        ],
+        "properties": {
+          "property": {
+            "type": "array",
+            "description": "Property to sort on.\nSorting can be done on the following properties:\n  | Property                          |\n  |-----------------------------------|\n  | `['assetId']`                     |\n  | `['createdTime']`                 |\n  | `['dataSetId']`                   |\n  | `['description']`                 |\n  | `['externalId']`                  |\n  | `['lastUpdatedTime']`             |\n  | `['metadata', '<someCustomKey>']` |\n  | `['name']`                        |\n  | `['_score_']`                     |",
+            "minItems": 1,
+            "maxItems": 2,
+            "items": {
+              "type": "string",
+              "maxLength": 128
+            }
+          },
+          "order": {
+            "type": "string",
+            "description": "The `order` attribute is optional and defaults to `desc` for `_score_` and `asc` for all\nother properties.",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "nulls": {
+            "type": "string",
+            "description": "The `nulls` attribute is optional and defaults to `auto`. `auto` is translated to `last`\nfor the `asc` order and to `first` for the `desc` order.",
+            "enum": [
+              "first",
+              "last",
+              "auto"
+            ],
+            "default": "auto"
+          }
+        }
       },
       "LabelDefinitionCreateList": {
         "type": "object",
@@ -43026,13 +48606,34 @@
         "example": "1234",
         "description": "The external ID of a file in CDF. The file must have mime_type application/pdf, image/jpeg, image/png or image/tiff."
       },
+      "DiagramInstanceId": {
+        "type": "object",
+        "required": [
+          "space",
+          "externalId"
+        ],
+        "example": {
+          "space": "space",
+          "externalId": "externalId"
+        },
+        "description": "The instance id of a file in CDF. The file must have mime_type application/pdf, image/jpeg, image/png or image/tiff.",
+        "properties": {
+          "space": {
+            "$ref": "#/components/schemas/InstanceSpace"
+          },
+          "externalId": {
+            "$ref": "#/components/schemas/InstanceExternalId"
+          }
+        }
+      },
       "OneOfFileId": {
         "type": "object",
         "required": [
           "fileId",
-          "fileExternalId"
+          "fileExternalId",
+          "fileInstanceId"
         ],
-        "description": "An object containing file (external) id. The file can have at most 50 pages.",
+        "description": "An object containing file (external/instance) id. The file can have at most 50 pages.",
         "oneOf": [
           {
             "properties": {
@@ -43045,6 +48646,13 @@
             "properties": {
               "fileExternalId": {
                 "$ref": "#/components/schemas/DiagramFileExternalId"
+              }
+            }
+          },
+          {
+            "properties": {
+              "fileInstanceId": {
+                "$ref": "#/components/schemas/DiagramInstanceId"
               }
             }
           }
@@ -43076,9 +48684,10 @@
         "type": "object",
         "required": [
           "fileId",
-          "fileExternalId"
+          "fileExternalId",
+          "fileInstanceId"
         ],
-        "description": "Either file id or file external id, and optionally a page range. At most 50 pages can be given",
+        "description": "Either file id, external id or instance id, and optionally a page range. At most 50 pages can be queried.",
         "oneOf": [
           {
             "properties": {
@@ -43091,6 +48700,13 @@
             "properties": {
               "fileExternalId": {
                 "$ref": "#/components/schemas/DiagramFileExternalId"
+              }
+            }
+          },
+          {
+            "properties": {
+              "fileInstanceId": {
+                "$ref": "#/components/schemas/DiagramInstanceId"
               }
             }
           }
@@ -43112,6 +48728,9 @@
           },
           "fileExternalId": {
             "$ref": "#/components/schemas/DiagramFileExternalId"
+          },
+          "fileInstanceId": {
+            "$ref": "#/components/schemas/DiagramInstanceId"
           }
         }
       },
@@ -43126,6 +48745,9 @@
           },
           "fileExternalId": {
             "$ref": "#/components/schemas/DiagramFileExternalId"
+          },
+          "fileInstanceId": {
+            "$ref": "#/components/schemas/DiagramInstanceId"
           },
           "pageRange": {
             "$ref": "#/components/schemas/PageRange"
@@ -44730,13 +50352,34 @@
         "example": "1234",
         "description": "The external ID of a file in CDF."
       },
+      "VisionInstanceId": {
+        "type": "object",
+        "required": [
+          "space",
+          "externalId"
+        ],
+        "example": {
+          "space": "space",
+          "externalId": "externalId"
+        },
+        "description": "The instance id of a file in CDF.",
+        "properties": {
+          "space": {
+            "$ref": "#/components/schemas/InstanceSpace"
+          },
+          "externalId": {
+            "$ref": "#/components/schemas/InstanceExternalId"
+          }
+        }
+      },
       "FileReference": {
         "type": "object",
         "required": [
           "fileId",
-          "fileExternalId"
+          "fileExternalId",
+          "fileInstanceId"
         ],
-        "description": "An object containing file (external) id.",
+        "description": "An external-id or instance-id reference to the referenced file.",
         "oneOf": [
           {
             "type": "object",
@@ -44759,6 +50402,17 @@
                 "$ref": "#/components/schemas/VisionFileExternalId"
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "fileInstanceId"
+            ],
+            "properties": {
+              "fileInstanceId": {
+                "$ref": "#/components/schemas/VisionInstanceId"
+              }
+            }
           }
         ]
       },
@@ -44773,6 +50427,9 @@
           },
           "fileExternalId": {
             "$ref": "#/components/schemas/VisionFileExternalId"
+          },
+          "fileInstanceId": {
+            "$ref": "#/components/schemas/VisionInstanceId"
           }
         }
       },
@@ -44795,7 +50452,7 @@
       },
       "ThresholdParameter": {
         "title": "Threshold",
-        "description": "The confidence threshold returns predictions as positive if their confidence score is the selected value or higher. \nA higher confidence threshold increases precision but lowers recall, and vice versa.\n",
+        "description": "The confidence threshold returns predictions as positive if their confidence score is the selected value or higher.\nA higher confidence threshold increases precision but lowers recall, and vice versa.\n",
         "type": "number",
         "example": 0.8,
         "minimum": 0,
@@ -44956,7 +50613,7 @@
             "$ref": "#/components/schemas/ThresholdParameter"
           },
           "partialMatch": {
-            "description": "Allow partial (fuzzy) matching of detected external IDs in the file. \nWill only match when it is possible to do so unambiguously.\n",
+            "description": "Allow partial (fuzzy) matching of detected external IDs in the file.\nWill only match when it is possible to do so unambiguously.\n",
             "type": "boolean",
             "default": false,
             "example": true
@@ -44966,7 +50623,7 @@
             "items": {
               "type": "integer"
             },
-            "description": "Search for external ID or name of assets that are in a subtree rooted at one of \nthe assetSubtreeIds (including the roots given).\n",
+            "description": "Search for external ID or name of assets that are in a subtree rooted at one of\nthe assetSubtreeIds (including the roots given).\n",
             "example": [
               1,
               2
@@ -45127,7 +50784,7 @@
           "assetTagPredictions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Annotations.cognite__annotation_types__images__AssetLink"
+              "$ref": "#/components/schemas/Annotations.cogmono__annotation_types__images__AssetLink"
             }
           },
           "peoplePredictions": {
@@ -45394,6 +51051,24 @@
           }
         }
       },
+      "DocumentQAAnswer": {
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentQAAnswerContent"
+            },
+            "type": "array",
+            "title": "Content",
+            "description": "The content of an answer consists of one or more parts. Each part can have a different set of document locations connected to it."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "Answer"
+      },
       "ChatCompletionRequest": {
         "properties": {
           "n": {
@@ -45403,56 +51078,60 @@
             "default": 1
           },
           "presencePenalty": {
+            "title": "Presencepenalty",
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
             "type": "number",
             "maximum": 2,
-            "minimum": -2,
-            "title": "Presencepenalty",
-            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics."
+            "minimum": -2
           },
           "frequencyPenalty": {
+            "title": "Frequencypenalty",
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.",
             "type": "number",
             "maximum": 2,
-            "minimum": -2,
-            "title": "Frequencypenalty",
-            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim."
+            "minimum": -2
           },
           "stop": {
+            "title": "Stop",
+            "description": "Up to 4 sequences where the API will stop generating further tokens.",
             "items": {
               "type": "string"
             },
             "type": "array",
             "maxItems": 4,
-            "minItems": 1,
-            "title": "Stop",
-            "description": "Up to 4 sequences where the API will stop generating further tokens."
+            "minItems": 1
           },
           "logitBias": {
+            "title": "Logitbias",
+            "description": "Modify the likelihood of specified tokens appearing in the completion. Accepts a json object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.",
             "additionalProperties": {
               "type": "number"
             },
-            "type": "object",
-            "title": "Logitbias",
-            "description": "Modify the likelihood of specified tokens appearing in the completion. Accepts a json object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token."
+            "type": "object"
           },
           "user": {
+            "title": "User",
+            "description": "A unique identifier representing your end-user, which can help Azure GPT to monitor and detect abuse.",
             "type": "string",
             "maxLength": 128,
-            "minLength": 1,
-            "title": "User",
-            "description": "A unique identifier representing your end-user, which can help Azure GPT to monitor and detect abuse."
+            "minLength": 1
           },
           "functions": {
+            "title": "Functions",
+            "description": "A list of functions the model may generate JSON inputs for.",
+            "deprecated": true,
             "items": {
               "$ref": "#/components/schemas/GPTFunctions"
             },
             "type": "array",
             "maxItems": 10,
-            "minItems": 1,
-            "title": "Functions",
-            "description": "A list of functions the model may generate JSON inputs for."
+            "minItems": 1
           },
           "functionCall": {
-            "anyOf": [
+            "title": "Functioncall",
+            "description": "Controls how the model responds to function calls. \"none\" means the model does not call a function,\nand responds to the end-user. \"auto\" means the model can pick between an end-user or calling a function.\n Specifying a particular function via `{\"name\": \"my_function\"}` forces the model to call that function.\n \"none\" is the default when no functions are present. \"auto\" is the default if functions are present.",
+            "deprecated": true,
+            "oneOf": [
               {
                 "$ref": "#/components/schemas/GPTFunctionName"
               },
@@ -45463,16 +51142,40 @@
                   "auto"
                 ]
               }
-            ],
-            "title": "Functioncall",
-            "description": "Controls how the model responds to function calls. \"none\" means the model does not call a function,\nand responds to the end-user. \"auto\" means the model can pick between an end-user or calling a function.\n Specifying a particular function via `{\"name\": \"my_function\"}` forces the model to call that function.\n \"none\" is the default when no functions are present. \"auto\" is the default if functions are present."
+            ]
           },
-          "messages": {
+          "tools": {
+            "title": "Tools",
+            "description": "A list of tools the model may use",
             "items": {
-              "$ref": "#/components/schemas/ChatMessage"
+              "$ref": "#/components/schemas/GPTTool"
             },
             "type": "array",
             "maxItems": 10,
+            "minItems": 1
+          },
+          "toolChoice": {
+            "title": "Toolchoice",
+            "description": "Controls which (if any) tool is called by the model. `none` means the model will not call any tool and instead generates a message. `auto` means the model can pick between generating a message or calling one or more tools. Specifying a particular tool via `{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}` forces the model to call that tool.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/GPTFunctionName"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "auto"
+                ]
+              }
+            ]
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage-Input"
+            },
+            "type": "array",
+            "maxItems": 100,
             "minItems": 1,
             "title": "Messages",
             "description": "The messages to generate chat completions for, in the chat format."
@@ -45480,11 +51183,10 @@
           "model": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/LLMModel"
+                "$ref": "#/components/schemas/LanguageModelKind"
               }
             ],
-            "description": "Name of the model to use.",
-            "default": "gpt-35-turbo"
+            "description": "Name of the model to use."
           },
           "temperature": {
             "type": "number",
@@ -45496,6 +51198,7 @@
           },
           "maxTokens": {
             "type": "integer",
+            "exclusiveMinimum": 0,
             "title": "Maxtokens",
             "description": "The maximum number of tokens to generate in the completion. The token count of your prompt plus maxTokens can't exceed the model's context length",
             "default": 2000
@@ -45519,7 +51222,7 @@
           "model": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/LLMModel"
+                "$ref": "#/components/schemas/LanguageModelKind"
               }
             ],
             "description": "The model used"
@@ -45561,7 +51264,7 @@
           "model": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/LLMModel"
+                "$ref": "#/components/schemas/LanguageModelKind"
               }
             ],
             "description": "The model used"
@@ -45580,8 +51283,8 @@
             "description": "The list of completion choices"
           },
           "usage": {
-            "$ref": "#/components/schemas/Usage",
-            "description": "The token usage related to the completion chunk"
+            "description": "The token usage related to the completion chunk",
+            "$ref": "#/components/schemas/Usage"
           }
         },
         "additionalProperties": false,
@@ -45593,12 +51296,22 @@
         ],
         "title": "ChatCompletionsStreamResponse"
       },
-      "ChatMessage": {
+      "ChatMessage-Input": {
         "properties": {
           "content": {
-            "type": "string",
             "title": "Content",
-            "description": "The contents of the message."
+            "description": "The contents of the message.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/GPTContent"
+                },
+                "type": "array"
+              }
+            ]
           },
           "role": {
             "allOf": [
@@ -45609,13 +51322,81 @@
             "description": "The role of the author of this message."
           },
           "name": {
-            "type": "string",
             "title": "Name",
-            "description": "The name of a function in a function call."
+            "description": "The name of a function in a function call.",
+            "type": "string"
           },
           "functionCall": {
-            "$ref": "#/components/schemas/GPTFunctionCall",
-            "description": "The name and arguments of a function that should be called, as generated by the model."
+            "description": "The name and arguments of a function that should be called, as generated by the model.",
+            "$ref": "#/components/schemas/GPTFunctionCall"
+          },
+          "toolCalls": {
+            "title": "Toolcalls",
+            "description": "The tools to be called",
+            "items": {
+              "$ref": "#/components/schemas/GPTToolCall"
+            },
+            "type": "array"
+          },
+          "toolCallId": {
+            "title": "Toolcallid",
+            "description": "The ID of the tool to be called",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "title": "ChatMessage"
+      },
+      "ChatMessage-Output": {
+        "properties": {
+          "content": {
+            "title": "Content",
+            "description": "The contents of the message.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/GPTContent"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "role": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChatMessageRole"
+              }
+            ],
+            "description": "The role of the author of this message."
+          },
+          "name": {
+            "title": "Name",
+            "description": "The name of a function in a function call.",
+            "type": "string"
+          },
+          "functionCall": {
+            "description": "The name and arguments of a function that should be called, as generated by the model.",
+            "$ref": "#/components/schemas/GPTFunctionCall"
+          },
+          "toolCalls": {
+            "title": "Toolcalls",
+            "description": "The tools to be called",
+            "items": {
+              "$ref": "#/components/schemas/GPTToolCall"
+            },
+            "type": "array"
+          },
+          "toolCallId": {
+            "title": "Toolcallid",
+            "description": "The ID of the tool to be called",
+            "type": "string"
           }
         },
         "additionalProperties": false,
@@ -45631,7 +51412,8 @@
           "user",
           "system",
           "assistant",
-          "function"
+          "function",
+          "tool"
         ],
         "title": "ChatMessageRole"
       },
@@ -45640,7 +51422,7 @@
           "message": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ChatMessage"
+                "$ref": "#/components/schemas/ChatMessage-Output"
               }
             ],
             "description": "The generated completion in the chat format"
@@ -45659,6 +51441,36 @@
         ],
         "title": "Choice"
       },
+      "CodeEditRequest": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 10,
+            "title": "Prompt",
+            "description": "The query to be completed."
+          },
+          "previousCodeContext": {
+            "title": "Previouscodecontext",
+            "description": "Previously executed code.",
+            "type": "string",
+            "maxLength": 16384
+          },
+          "currentCode": {
+            "type": "string",
+            "maxLength": 4096,
+            "title": "Currentcode",
+            "description": "Code to edit."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "prompt",
+          "currentCode"
+        ],
+        "title": "CodeEditRequest"
+      },
       "CodeGenerationRequest": {
         "properties": {
           "prompt": {
@@ -45668,17 +51480,11 @@
             "title": "Prompt",
             "description": "The query to be completed."
           },
-          "currentCode": {
-            "type": "string",
-            "maxLength": 4096,
-            "title": "Currentcode",
-            "description": "Code to edit."
-          },
           "previousCodeContext": {
-            "type": "string",
-            "maxLength": 16384,
             "title": "Previouscodecontext",
-            "description": "Previously executed code."
+            "description": "Previously executed code.",
+            "type": "string",
+            "maxLength": 16384
           }
         },
         "additionalProperties": false,
@@ -45688,19 +51494,485 @@
         ],
         "title": "CodeGenerationRequest"
       },
+      "Completion": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "Generated content",
+            "title": "Content",
+            "type": "string"
+          },
+          "previous_context": {
+            "description": "Previous context",
+            "items": {
+              "type": "object"
+            },
+            "title": "Previous Context",
+            "type": "array"
+          }
+        },
+        "required": [
+          "content",
+          "previous_context"
+        ],
+        "title": "Completion",
+        "type": "object"
+      },
+      "DocumentQAAnswerContent": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "description": "A part of the answer from the LLM."
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentQAAnswerReference"
+            },
+            "type": "array",
+            "title": "References",
+            "description": "The document locations that this part of the answer is sourced from"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "Content"
+      },
+      "CogAIDataModel": {
+        "properties": {
+          "space": {
+            "type": "string",
+            "maxLength": 43,
+            "minLength": 1,
+            "title": "Space",
+            "description": "The space the data model is in"
+          },
+          "externalId": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Externalid",
+            "description": "The external ID of the data model"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version",
+            "description": "The version of the data model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "space",
+          "externalId",
+          "version"
+        ],
+        "title": "DataModel"
+      },
+      "DataModelType": {
+        "properties": {
+          "space": {
+            "type": "string",
+            "maxLength": 43,
+            "minLength": 1,
+            "title": "Space",
+            "description": "The space the data model is in"
+          },
+          "externalId": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Externalid",
+            "description": "The external ID of the data model"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version",
+            "description": "The version of the data model"
+          },
+          "type": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Type",
+            "description": "Relevant data model type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "space",
+          "externalId",
+          "version",
+          "type"
+        ],
+        "title": "DataModelType"
+      },
+      "DocumentQARequest": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 10,
+            "title": "Question",
+            "description": "Question to ask about the documents"
+          },
+          "additionalContext": {
+            "title": "Additionalcontext",
+            "description": "Optional additional context that the model can use to improve its answer",
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 10
+          },
+          "fileIds": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FileId"
+                },
+                {
+                  "$ref": "#/components/schemas/CogAIFileExternalId"
+                }
+              ]
+            },
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Fileids",
+            "description": "List of file ids or external ids"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "question",
+          "fileIds"
+        ],
+        "title": "DocumentQARequest"
+      },
+      "DocumentSummarizationRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "description": "List of documents to summarize",
+            "items": {
+              "$ref": "#/components/schemas/DocumentSummarizationRequestItem"
+            },
+            "maxItems": 1,
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          },
+          "ignoreMissing": {
+            "default": false,
+            "description": "If True, the API will not fail if any documents are missing, but summaries for the missing documents will be excluded from the response.",
+            "title": "IgnoreMissing",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "DocumentSummarizationRequest",
+        "type": "object"
+      },
+      "DocumentSummarizationRequestItem": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "The file ID for the document. Either id or externalId must be provided.",
+            "title": "Id",
+            "type": "integer",
+            "example": 123,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CogniteInternalId"
+              }
+            ]
+          },
+          "externalId": {
+            "description": "The external ID for the document. This value matches the externalId set in the Files API.",
+            "title": "ExternalId",
+            "type": "string",
+            "example": "file-external-id",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CogniteExternalId"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "DocumentSummarizationRequestItem",
+        "type": "object"
+      },
+      "DocumentSummarizationResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "description": "List of documents with summaries",
+            "items": {
+              "$ref": "#/components/schemas/DocumentSummarizationResponseItem"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "DocumentSummarizationResponse",
+        "type": "object"
+      },
+      "DocumentSummarizationResponseItem": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "The file ID for the document. Either id or externalId must be provided.",
+            "title": "Id",
+            "type": "integer",
+            "example": 123,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CogniteInternalId"
+              }
+            ]
+          },
+          "externalId": {
+            "description": "The external ID for the document. This value matches the externalId set in the Files API.",
+            "title": "ExternalId",
+            "type": "string",
+            "example": "file-external-id",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CogniteExternalId"
+              }
+            ]
+          },
+          "summary": {
+            "description": "Summary of the document",
+            "title": "Summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "summary"
+        ],
+        "title": "DocumentSummarizationResponseItem",
+        "type": "object"
+      },
+      "EmbeddingAPIRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "dimensions": {
+            "description": "The number of dimensions the resulting output embeddings should have. Only supported for certain models.",
+            "title": "Dimensions",
+            "type": "integer"
+          },
+          "encodingFormat": {
+            "$ref": "#/components/schemas/EncodingFormat",
+            "default": "float",
+            "description": "The encoding for the document. Currently, we only support float."
+          },
+          "items": {
+            "description": "List of items to create Embeddings for.",
+            "items": {
+              "$ref": "#/components/schemas/EmbeddingsAPIRequestItem"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          },
+          "model": {
+            "$ref": "#/components/schemas/EmbeddingModelKind",
+            "description": "The model to use for vectorization."
+          }
+        },
+        "required": [
+          "model",
+          "items"
+        ],
+        "title": "EmbeddingAPIRequest",
+        "type": "object"
+      },
+      "EmbeddingAPIResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "dimensions": {
+            "description": "The number of dimensions the resulting output embeddings should have. Only supported for certain models.",
+            "title": "Dimensions",
+            "type": "integer"
+          },
+          "encodingFormat": {
+            "$ref": "#/components/schemas/EncodingFormat",
+            "default": "float",
+            "description": "The encoding for the document. Currently, we only support float."
+          },
+          "items": {
+            "description": "List of Items that we created embeddings for.",
+            "items": {
+              "$ref": "#/components/schemas/EmbeddingAPIResponseItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "model": {
+            "$ref": "#/components/schemas/EmbeddingModelKind",
+            "description": "The model to use for vectorization."
+          }
+        },
+        "required": [
+          "model",
+          "items"
+        ],
+        "title": "EmbeddingAPIResponse",
+        "type": "object"
+      },
+      "EmbeddingAPIResponseItem": {
+        "additionalProperties": false,
+        "properties": {
+          "embedding": {
+            "description": "The Embedding results for the text requested.",
+            "items": {
+              "type": "number"
+            },
+            "title": "Embedding",
+            "type": "array"
+          },
+          "text": {
+            "description": "The text data that will be vectorized.",
+            "maxLength": 1000000,
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "EmbeddingAPIResponseItem",
+        "type": "object"
+      },
+      "EmbeddingModelKind": {
+        "enum": [
+          "text-embedding-ada-002",
+          "text-embedding-3-small",
+          "text-embedding-3-large"
+        ],
+        "title": "EmbeddingModelKind",
+        "type": "string"
+      },
+      "EmbeddingsAPIRequestItem": {
+        "additionalProperties": false,
+        "properties": {
+          "text": {
+            "description": "The text data that will be vectorized.",
+            "maxLength": 1000000,
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "EmbeddingsAPIRequestItem",
+        "type": "object"
+      },
+      "EncodingFormat": {
+        "const": "float",
+        "enum": [
+          "float"
+        ],
+        "title": "EncodingFormat",
+        "type": "string"
+      },
+      "CogAIFileExternalId": {
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "title": "Externalid"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "externalId"
+        ],
+        "title": "FileExternalId"
+      },
+      "FileId": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "FileId"
+      },
+      "GPTContent": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text",
+              "image_url"
+            ],
+            "title": "Type",
+            "description": "The type of content"
+          },
+          "text": {
+            "title": "Text",
+            "description": "The text content",
+            "type": "string"
+          },
+          "imageUrl": {
+            "description": "The URL of the image",
+            "$ref": "#/components/schemas/GPTContentImageURL"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "GPTContent"
+      },
+      "GPTContentImageURL": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "description": "The URL of the image"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "GPTContentImageURL"
+      },
       "GPTFunctionCall": {
         "properties": {
           "name": {
+            "title": "Name",
+            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.",
             "type": "string",
             "maxLength": 64,
-            "minLength": 1,
-            "title": "Name",
-            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
+            "minLength": 1
           },
           "arguments": {
-            "type": "string",
             "title": "Arguments",
-            "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may fabricate parameters not defined by your function schema. Validate the arguments in your code before calling your function."
+            "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may fabricate parameters not defined by your function schema. Validate the arguments in your code before calling your function.",
+            "type": "string"
           }
         },
         "additionalProperties": false,
@@ -45710,11 +51982,11 @@
       "GPTFunctionName": {
         "properties": {
           "name": {
+            "title": "Name",
+            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.",
             "type": "string",
             "maxLength": 64,
-            "minLength": 1,
-            "title": "Name",
-            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
+            "minLength": 1
           }
         },
         "additionalProperties": false,
@@ -45727,16 +51999,16 @@
       "GPTFunctions": {
         "properties": {
           "name": {
+            "title": "Name",
+            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.",
             "type": "string",
             "maxLength": 64,
-            "minLength": 1,
-            "title": "Name",
-            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
+            "minLength": 1
           },
           "description": {
-            "type": "string",
             "title": "Description",
-            "description": "A description of what the function does. The model will use this description when selecting the function and interpreting its parameters."
+            "description": "A description of what the function does. The model will use this description when selecting the function and interpreting its parameters.",
+            "type": "string"
           },
           "parameters": {
             "type": "object",
@@ -45775,16 +52047,274 @@
           }
         }
       },
-      "LLMModel": {
+      "GPTTool": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "function"
+            ],
+            "const": "function",
+            "title": "Type",
+            "description": "The type of tool",
+            "default": "function"
+          },
+          "function": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GPTFunctions"
+              }
+            ],
+            "description": "The function the model may call"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "function"
+        ],
+        "title": "GPTTool",
+        "example": {
+          "function": {
+            "description": "Get the current weather in a given location",
+            "name": "get_current_weather",
+            "parameters": {
+              "properties": {
+                "location": {
+                  "description": "The city and state, e.g. San Francisco, CA",
+                  "type": "string"
+                },
+                "unit": {
+                  "enum": [
+                    "celsius",
+                    "fahrenheit"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "location"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "function"
+        }
+      },
+      "GPTToolCall": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "function": {
+            "$ref": "#/components/schemas/GPTFunctionCall"
+          },
+          "type": {
+            "title": "Type",
+            "description": "The type of tool",
+            "default": "function",
+            "type": "string",
+            "enum": [
+              "function"
+            ],
+            "const": "function"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "function"
+        ],
+        "title": "GPTToolCall"
+      },
+      "GraphQLCompletionsRequest": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Prompt",
+            "description": "The query to generate GraphQL completions for"
+          },
+          "dataModels": {
+            "title": "Datamodels",
+            "description": "List of relevant Data models",
+            "items": {
+              "$ref": "#/components/schemas/CogAIDataModel"
+            },
+            "type": "array",
+            "maxItems": 80,
+            "minItems": 1
+          },
+          "dataModelType": {
+            "description": "Relevant data model type from a given data model",
+            "$ref": "#/components/schemas/DataModelType"
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "description": "Whether to stream back partial progress.",
+            "default": true
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "title": "GraphQLCompletionsRequest"
+      },
+      "LanguageModelKind": {
         "type": "string",
         "enum": [
           "gpt-35-turbo",
           "gpt-35-turbo-16k",
           "gpt-4",
           "gpt-4-turbo",
-          "gpt-4-32k"
+          "gpt-4-32k",
+          "gpt-4-vision",
+          "gpt-4o-2024-05-13",
+          "gpt-4o-mini",
+          "gemini-1.0-pro",
+          "gemini-1.5-pro",
+          "gemini-1.5-flash",
+          "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+          "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+          "bedrock/anthropic.claude-instant-v1",
+          "bedrock/meta.llama3-8b-instruct-v1:0",
+          "bedrock/meta.llama3-70b-instruct-v1:0",
+          "bedrock/mistral.mixtral-8x7b-instruct-v0:1",
+          "bedrock/mistral.mistral-large-2402-v1:0",
+          "ollama/llama2",
+          "ollama/llama2:13b",
+          "ollama/llama2:70b",
+          "ollama/llama3",
+          "ollama/llama3:70b",
+          "ollama/codellama",
+          "ollama/codellama:13b",
+          "ollama/codellama:34b",
+          "ollama/codellama:70b",
+          "ollama/mixtral"
         ],
-        "title": "LLMModel"
+        "title": "LanguageModelKind"
+      },
+      "DocumentQAAnswerLocation": {
+        "properties": {
+          "pageNumber": {
+            "type": "integer",
+            "title": "Pagenumber",
+            "description": "The page number within the file. Page numbers start at 1."
+          },
+          "left": {
+            "type": "number",
+            "title": "Left"
+          },
+          "right": {
+            "type": "number",
+            "title": "Right"
+          },
+          "top": {
+            "type": "number",
+            "title": "Top"
+          },
+          "bottom": {
+            "type": "number",
+            "title": "Bottom"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "pageNumber",
+          "left",
+          "right",
+          "top",
+          "bottom"
+        ],
+        "title": "Location"
+      },
+      "DocumentQAAnswerReference": {
+        "properties": {
+          "fileId": {
+            "type": "integer",
+            "title": "Fileid",
+            "description": "The id of the file"
+          },
+          "locations": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentQAAnswerLocation"
+            },
+            "type": "array",
+            "title": "Locations",
+            "description": "The locations in the document that contain the relevant text"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "fileId",
+          "locations"
+        ],
+        "title": "Reference"
+      },
+      "ServiceInfo": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Service name."
+          },
+          "path": {
+            "type": "string",
+            "title": "Path",
+            "description": "Service path."
+          },
+          "available": {
+            "type": "boolean",
+            "title": "Available",
+            "description": "Whether service is available."
+          },
+          "supportedLanguageModels": {
+            "items": {
+              "$ref": "#/components/schemas/LanguageModelKind"
+            },
+            "type": "array",
+            "title": "Supportedlanguagemodels",
+            "description": "Available language models",
+            "default": [
+              "default"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "name",
+          "path",
+          "available"
+        ],
+        "title": "ServiceInfo"
+      },
+      "ServiceInfoResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ServiceInfo"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "Service availability information."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "ServiceInfoResponse"
       },
       "StreamChoice": {
         "properties": {
@@ -45797,9 +52327,9 @@
             "description": "The incremental changes to the conversation"
           },
           "finishReason": {
-            "type": "string",
             "title": "Finishreason",
-            "description": "The reason the conversation ended"
+            "description": "The reason the conversation ended",
+            "type": "string"
           }
         },
         "additionalProperties": false,
@@ -45813,22 +52343,35 @@
       "StreamDelta": {
         "properties": {
           "content": {
-            "type": "string",
             "title": "Content",
-            "description": "The contents of the message."
+            "description": "The contents of the message.",
+            "type": "string"
           },
           "role": {
-            "$ref": "#/components/schemas/ChatMessageRole",
-            "description": "The role of the author of this message."
+            "description": "The role of the author of this message.",
+            "$ref": "#/components/schemas/ChatMessageRole"
           },
           "name": {
-            "type": "string",
             "title": "Name",
-            "description": "The name of a function in a function call."
+            "description": "The name of a function in a function call.",
+            "type": "string"
           },
           "functionCall": {
-            "$ref": "#/components/schemas/GPTFunctionCall",
-            "description": "The name and arguments of a function that should be called, as generated by the model."
+            "description": "The name and arguments of a function that should be called, as generated by the model.",
+            "$ref": "#/components/schemas/GPTFunctionCall"
+          },
+          "toolCalls": {
+            "title": "Toolcalls",
+            "description": "The tools to be called",
+            "items": {
+              "$ref": "#/components/schemas/GPTToolCall"
+            },
+            "type": "array"
+          },
+          "toolCallId": {
+            "title": "Toolcallid",
+            "description": "The ID of the tool to be called",
+            "type": "string"
           }
         },
         "additionalProperties": false,
@@ -45888,6 +52431,45 @@
           }
         ]
       },
+      "DocumentSemanticSearchRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DocumentSemanticSearchFilter"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentSemanticSearchPassageExpansion"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentSemanticSearchLimit"
+          }
+        ]
+      },
+      "DocumentStatusRequest": {
+        "required": [
+          "items"
+        ],
+        "description": "List of document ids to check the status for.",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/CogniteInternalId"
+                }
+              }
+            }
+          },
+          "includeStatistics": {
+            "type": "boolean",
+            "description": "Whether or not to include statistics about the document. This gives additional insight such as the number of pages, number of vectors, etc.",
+            "default": false
+          }
+        }
+      },
       "DocumentListRequest": {
         "allOf": [
           {
@@ -45913,6 +52495,30 @@
           }
         }
       },
+      "DocumentSemanticSearchFilter": {
+        "description": "Narrow down search results. You must specify exactly one `semanticSearch` filter.",
+        "type": "object",
+        "required": [
+          "filter"
+        ],
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/DocumentSemanticFilter"
+          }
+        }
+      },
+      "DocumentSemanticSearchVectorspace": {
+        "description": "Limit search to namespace",
+        "type": "object",
+        "required": [
+          "namespace"
+        ],
+        "properties": {
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
       "DocumentListFilter": {
         "description": "Filter with exact match",
         "type": "object",
@@ -45932,6 +52538,58 @@
             "minimum": 0,
             "maximum": 1000,
             "default": 100
+          }
+        }
+      },
+      "DocumentSemanticSearchPassageExpansionSymmetric": {
+        "type": "object",
+        "required": [
+          "strategy",
+          "chunk_count"
+        ],
+        "properties": {
+          "strategy": {
+            "description": "Expand the passage with adjacent passages that exists before and after a passage.",
+            "type": "string",
+            "enum": [
+              "symmetric"
+            ],
+            "default": "symmetric"
+          },
+          "chunk_count": {
+            "description": "Number of passages to expand a given passage by",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4
+          }
+        }
+      },
+      "DocumentSemanticSearchPassageExpansion": {
+        "type": "object",
+        "required": [
+          "expansionStrategy"
+        ],
+        "properties": {
+          "expansionStrategy": {
+            "description": "A expansion strategy to to increase the text view for each passage returned. Helpful to increase context for an LLM.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DocumentSemanticSearchPassageExpansionSymmetric"
+              }
+            ]
+          }
+        }
+      },
+      "DocumentSemanticSearchLimit": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "description": "Maximum number of items.",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 10
           }
         }
       },
@@ -46054,6 +52712,98 @@
           },
           "item": {
             "$ref": "#/components/schemas/Document"
+          }
+        }
+      },
+      "DocumentSemanticSearchItem": {
+        "type": "object",
+        "required": [
+          "item",
+          "match"
+        ],
+        "description": "Each item contains the semantic match and the relevant document it belongs to.",
+        "properties": {
+          "match": {
+            "$ref": "#/components/schemas/DocumentSemanticMatch"
+          },
+          "item": {
+            "$ref": "#/components/schemas/Document"
+          }
+        }
+      },
+      "DocumentStatusItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "semanticSearch",
+          "elements"
+        ],
+        "description": "Each item contains the semantic match and the relevant document it belongs to.",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/CogniteInternalId"
+          },
+          "semanticSearch": {
+            "type": "object",
+            "required": [
+              "status"
+            ],
+            "description": "Status of the document in the semantic search system.",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "waiting",
+                  "ignored",
+                  "error",
+                  "indexed",
+                  "progress"
+                ],
+                "description": "The status of the document in the semantic search index. File is searchable when the status is `indexed`."
+              },
+              "reason": {
+                "type": "string",
+                "description": "Provides additional insight for an error status."
+              }
+            }
+          },
+          "elements": {
+            "type": "object",
+            "required": [
+              "status"
+            ],
+            "description": "Status of the document layout analysis.",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "waiting",
+                  "ignored",
+                  "error",
+                  "indexed",
+                  "progress"
+                ],
+                "description": "The status of the document for layout analysis. Document elements is retrievable when the status is `indexed`."
+              },
+              "reason": {
+                "type": "string",
+                "description": "Provides additional insight for an error status."
+              }
+            }
+          },
+          "statistics": {
+            "type": "object",
+            "description": "Statistics about the document. This is only available when setting `includeStatistics` to `true` in the request.",
+            "properties": {
+              "numberOfPages": {
+                "type": "integer",
+                "description": "The number of pages in the document. This is only available for documents that have been indexed."
+              },
+              "numberOfVectors": {
+                "type": "integer",
+                "description": "The number of vectors (passages) in the document. This is only available for documents that have been indexed."
+              }
+            }
           }
         }
       },
@@ -46471,6 +53221,58 @@
           ]
         }
       },
+      "DocumentSemanticMatch": {
+        "type": "object",
+        "description": "Semantic insight about a search result",
+        "required": [
+          "text"
+        ],
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "locations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "pageNumber": {
+                  "type": "number",
+                  "format": "int32"
+                },
+                "left": {
+                  "type": "number",
+                  "format": "float"
+                },
+                "right": {
+                  "type": "number",
+                  "format": "float"
+                },
+                "up": {
+                  "type": "number",
+                  "format": "float"
+                },
+                "bottom": {
+                  "type": "number",
+                  "format": "float"
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "text": "Pump installation\nFollow these 15 steps:\n ...",
+          "location": [
+            {
+              "page": 7,
+              "left": 68.78,
+              "right": 478.56,
+              "top": 75.04,
+              "bottom": 386.1
+            }
+          ]
+        }
+      },
       "DocumentGeoJsonGeometry": {
         "description": "GeoJSON Geometry.",
         "type": "object",
@@ -46547,6 +53349,18 @@
           },
           {
             "$ref": "#/components/schemas/DocumentFilterLeaf"
+          }
+        ]
+      },
+      "DocumentSemanticFilter": {
+        "description": "A JSON based filtering language. See detailed documentation above.\n",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DocumentSemanticFilterBool"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentSemanticFilterLeaf"
           }
         ]
       },
@@ -46656,6 +53470,48 @@
           }
         ]
       },
+      "DocumentSemanticFilterBool": {
+        "title": "bool filters",
+        "description": "A query that matches items matching boolean combinations of other queries.\nCurrently only supports `and` clause.\n",
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "and",
+            "required": [
+              "and"
+            ],
+            "properties": {
+              "and": {
+                "description": "All of the sub-clauses in the query must appear in matching items.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/components/schemas/DocumentSemanticFilter"
+                },
+                "example": [
+                  {
+                    "prefix": {
+                      "property": [
+                        "name"
+                      ],
+                      "value": "Report"
+                    }
+                  },
+                  {
+                    "equals": {
+                      "property": [
+                        "type"
+                      ],
+                      "value": "PDF"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
       "DocumentFilterLeaf": {
         "title": "leaf filters",
         "description": "Leaf filter",
@@ -46696,6 +53552,25 @@
           },
           {
             "$ref": "#/components/schemas/DocumentFilterInAssetSubtree"
+          }
+        ]
+      },
+      "DocumentSemanticFilterLeaf": {
+        "title": "leaf filters",
+        "description": "Leaf filter",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DocumentPassagesFilterEquals"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentPassagesFilterIn"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentFilterSemanticSearch"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentFilterLexicalSearch"
           }
         ]
       },
@@ -46916,6 +53791,153 @@
               "value"
             ],
             "description": "Matches items that contains the search query.",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/DocumentFilterProperty"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "property": [
+                "content"
+              ],
+              "value": "Report"
+            }
+          }
+        }
+      },
+      "DocumentPassagesFilterValue": {
+        "description": "Value you wish to find in the provided property.",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      },
+      "DocumentPassagesFilterValueList": {
+        "description": "One or more values you wish to find in the provided property.",
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 100,
+        "items": {
+          "$ref": "#/components/schemas/DocumentPassagesFilterValue"
+        }
+      },
+      "DocumentPassagesFilterEquals": {
+        "type": "object",
+        "title": "equals",
+        "required": [
+          "equals"
+        ],
+        "properties": {
+          "equals": {
+            "required": [
+              "property",
+              "value"
+            ],
+            "description": "Matches items that contain the exact value in the provided property.",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/DocumentFilterProperty"
+              },
+              "value": {
+                "$ref": "#/components/schemas/DocumentPassagesFilterValue"
+              }
+            },
+            "example": {
+              "property": [
+                "type"
+              ],
+              "value": "PDF"
+            }
+          }
+        }
+      },
+      "DocumentPassagesFilterIn": {
+        "type": "object",
+        "title": "in",
+        "required": [
+          "in"
+        ],
+        "properties": {
+          "in": {
+            "required": [
+              "property",
+              "values"
+            ],
+            "description": "Matches items where the property matches one of the given values",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/DocumentFilterProperty"
+              },
+              "values": {
+                "$ref": "#/components/schemas/DocumentPassagesFilterValueList"
+              }
+            },
+            "example": {
+              "property": [
+                "id"
+              ],
+              "values": [
+                6546,
+                45756456
+              ]
+            }
+          }
+        }
+      },
+      "DocumentFilterSemanticSearch": {
+        "type": "object",
+        "title": "semanticSearch",
+        "required": [
+          "semanticSearch"
+        ],
+        "properties": {
+          "semanticSearch": {
+            "required": [
+              "property",
+              "value"
+            ],
+            "description": "Matches passages that have similar semantic meaning as the search query.",
+            "type": "object",
+            "properties": {
+              "property": {
+                "$ref": "#/components/schemas/DocumentFilterProperty"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "property": [
+                "content"
+              ],
+              "value": "Report"
+            }
+          }
+        }
+      },
+      "DocumentFilterLexicalSearch": {
+        "type": "object",
+        "title": "lexicalSearch",
+        "required": [
+          "lexicalSearch"
+        ],
+        "properties": {
+          "lexicalSearch": {
+            "required": [
+              "property",
+              "value"
+            ],
+            "description": "Matches passages that contains specified keywords.",
             "type": "object",
             "properties": {
               "property": {
@@ -47994,6 +55016,250 @@
           }
         }
       },
+      "DocumentElement": {
+        "type": "object",
+        "description": "A single document layout element. Can be a title, a paragraph or a table.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DocumentTitleElement"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentParagraphElement"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentListElement"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentTableOfContentsElement"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentTableElement"
+          }
+        ]
+      },
+      "DocumentTitleElement": {
+        "type": "object",
+        "description": "A title in a document. A title can consist of one or more lines of text.",
+        "required": [
+          "type",
+          "lines"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "title"
+            ]
+          },
+          "level": {
+            "type": "number",
+            "description": "The level of this header, from 1 to 3, where smaller numbers mean larger headers.",
+            "minimum": 1,
+            "maximum": 3
+          },
+          "lines": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/DocumentLineElement"
+            }
+          }
+        }
+      },
+      "DocumentParagraphElement": {
+        "type": "object",
+        "description": "A paragraph in a document. A paragraph can consist of one or more lines of text.",
+        "required": [
+          "type",
+          "lines"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "paragraph"
+            ]
+          },
+          "lines": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/DocumentLineElement"
+            }
+          }
+        }
+      },
+      "DocumentListElement": {
+        "type": "object",
+        "description": "An ordered or unordered list.",
+        "required": [
+          "type",
+          "lines"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "list"
+            ]
+          },
+          "lines": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/DocumentLineElement"
+            }
+          }
+        }
+      },
+      "DocumentTableOfContentsElement": {
+        "type": "object",
+        "description": "A table of contents.",
+        "required": [
+          "type",
+          "lines"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toc"
+            ]
+          },
+          "lines": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/DocumentLineElement"
+            }
+          }
+        }
+      },
+      "DocumentTableElement": {
+        "type": "object",
+        "description": "A table in a document. A table consists of a list of rows where each row is a list of\ncells.",
+        "required": [
+          "type",
+          "rows"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "table"
+            ]
+          },
+          "columnHeaderCount": {
+            "type": "number",
+            "description": "Number of header rows (column headers) at the top of the table."
+          },
+          "rowHeaderCount": {
+            "type": "number",
+            "description": "Number of header columns (row headers) at the left of the table."
+          },
+          "rows": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/components/schemas/DocumentCellElement"
+              }
+            }
+          }
+        }
+      },
+      "DocumentCellElement": {
+        "type": "object",
+        "description": "A cell in a table. A cell contains zero or more lines of text.",
+        "required": [
+          "lines"
+        ],
+        "properties": {
+          "lines": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/components/schemas/DocumentLineElement"
+            }
+          }
+        }
+      },
+      "DocumentLineElement": {
+        "type": "object",
+        "description": "A single line containing a list of words",
+        "required": [
+          "words"
+        ],
+        "properties": {
+          "words": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/DocumentWordElement"
+            }
+          }
+        }
+      },
+      "DocumentWordElement": {
+        "type": "object",
+        "description": "A single word containing a list of characters",
+        "required": [
+          "characters"
+        ],
+        "properties": {
+          "characters": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/DocumentCharacterElement"
+            }
+          }
+        }
+      },
+      "DocumentCharacterElement": {
+        "type": "object",
+        "description": "A character. Contains a reference to the relevant page, and a bounding box.",
+        "required": [
+          "text",
+          "page",
+          "left",
+          "right",
+          "top",
+          "bottom"
+        ],
+        "properties": {
+          "text": {
+            "description": "The text representing the character. This is usually one character long, but may be more\nin some cases, for instance where there are ligatures in the document.",
+            "type": "string"
+          },
+          "page": {
+            "description": "The page number where the character can be found. Pages start at 1.",
+            "type": "integer"
+          },
+          "left": {
+            "type": "number"
+          },
+          "right": {
+            "type": "number"
+          },
+          "top": {
+            "type": "number"
+          },
+          "bottom": {
+            "type": "number"
+          }
+        },
+        "example": {
+          "title": "Pump installation",
+          "page": 7,
+          "left": 68.78,
+          "right": 178.56,
+          "top": 75.04,
+          "bottom": 96.1
+        }
+      },
       "GeospatialError": {
         "type": "object",
         "required": [
@@ -48170,7 +55436,7 @@
           },
           "properties": {
             "type": "object",
-            "description": "Each property name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.   The number of properties is limited to 200 per feature type.",
+            "description": "Each property name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.\\ The number of properties is limited to 200 per feature type.",
             "additionalProperties": {
               "$ref": "#/components/schemas/GeospatialFeatureTypeProperty"
             },
@@ -48178,7 +55444,7 @@
           },
           "searchSpec": {
             "type": "object",
-            "description": "Each index name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.   The number of indexes is limited to 10 per feature type.",
+            "description": "Each index name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.\\ The number of indexes is limited to 10 per feature type.",
             "additionalProperties": {
               "$ref": "#/components/schemas/GeospatialIndexSpec"
             },
@@ -48226,7 +55492,7 @@
               },
               "properties": {
                 "type": "object",
-                "description": "List of properties to be added, deleted or modified in an existing feature type. Each property name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.   The total number of properties is limited to 100 per feature type. There must not be any property name overlap in `add`, `remove` and `modify` fields.",
+                "description": "List of properties to be added, deleted or modified in an existing feature type. Each property name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.\\ The total number of properties is limited to 100 per feature type. There must not be any property name overlap in `add`, `remove` and `modify` fields.",
                 "properties": {
                   "add": {
                     "type": "object",
@@ -48245,7 +55511,7 @@
               },
               "searchSpec": {
                 "type": "object",
-                "description": "Each index name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.   The total number of indexes is limited to 5 per feature type.",
+                "description": "Each index name has to match the following regexp pattern `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`.\\ The total number of indexes is limited to 5 per feature type.",
                 "properties": {
                   "add": {
                     "type": "object",
@@ -49089,7 +56355,7 @@
           },
           "sort": {
             "type": "array",
-            "description": "Sort result by selected fields. Syntax: sort:[\"field_1\",\"field_2:ASC\",\"field_3:DESC\"]. Default sort order is ascending if not specified. Available sort direction: ASC, DESC, ASC_NULLS_FIRST,  DESC_NULLS_FIRST, ASC_NULLS_LAST, DESC_NULLS_LAST.\n",
+            "description": "Sort result by selected fields. Syntax: sort:[\"field_1\",\"field_2:ASC\",\"field_3:DESC\"]. Default sort order is ascending if not specified. Available sort direction: ASC, DESC, ASC_NULLS_FIRST, DESC_NULLS_FIRST, ASC_NULLS_LAST, DESC_NULLS_LAST.\n",
             "items": {
               "type": "string"
             }
@@ -53777,16 +61043,16 @@
             "$ref": "#/components/schemas/Annotations.UnhandledTextObject"
           },
           {
-            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__diagrams__AssetLink"
+            "$ref": "#/components/schemas/Annotations.cogmono__annotation_types__diagrams__AssetLink"
           },
           {
-            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__diagrams__InstanceLink"
+            "$ref": "#/components/schemas/Annotations.cogmono__annotation_types__diagrams__InstanceLink"
           },
           {
-            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__images__AssetLink"
+            "$ref": "#/components/schemas/Annotations.cogmono__annotation_types__images__AssetLink"
           },
           {
-            "$ref": "#/components/schemas/Annotations.cognite__annotation_types__images__InstanceLink"
+            "$ref": "#/components/schemas/Annotations.cogmono__annotation_types__images__InstanceLink"
           }
         ],
         "example": {
@@ -54517,7 +61783,7 @@
         "title": "primitives.references.View",
         "type": "object"
       },
-      "Annotations.cognite__annotation_types__primitives__geometry2d__Geometry": {
+      "Annotations.cogmono__annotation_types__primitives__geometry2d__Geometry": {
         "additionalProperties": false,
         "description": "A geometry represented by exactly *one of* ` bounding_box`, `polygon` and\n`polyline` which, respectively, represents a BoundingBox, Polygon and\nPolyLine.",
         "properties": {
@@ -54549,7 +61815,7 @@
         "title": "primitives.geometry2d.Geometry",
         "type": "object"
       },
-      "Annotations.cognite__annotation_types__primitives__geometry3d__Geometry": {
+      "Annotations.cogmono__annotation_types__primitives__geometry3d__Geometry": {
         "additionalProperties": false,
         "description": "A 3D geometry model represented by exactly *one of* `cylinder` and `box`.",
         "properties": {
@@ -54603,7 +61869,7 @@
           "region": {
             "description": "The region of the annotation defined by a list of geometry primitives (cylinder and box).",
             "items": {
-              "$ref": "#/components/schemas/Annotations.cognite__annotation_types__primitives__geometry3d__Geometry"
+              "$ref": "#/components/schemas/Annotations.cogmono__annotation_types__primitives__geometry3d__Geometry"
             },
             "maxItems": 1000,
             "minItems": 1,
@@ -54828,11 +62094,11 @@
               }
             ],
             "default": null,
-            "description": "Contains a link to a file in CDF. This is used to navigate between files."
+            "description": "The asset this annotation is pointing at. Store the id of the file assets to generate downloadable URL."
           },
           "text": {
             "default": null,
-            "description": "Text found in the area, might be a FLOC, valve detail, pipe or diagram name.",
+            "description": "The pattern identified by the detection API results.",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
@@ -54848,7 +62114,7 @@
           },
           "indirectRelation": {
             "default": null,
-            "description": "Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'upstreams of'. This references the 'indirectExternalId'.",
+            "description": "Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'second valve upstreams of'. This references the 'indirectExternalId'.",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
@@ -54860,7 +62126,7 @@
               }
             ],
             "default": null,
-            "description": "The indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. E.g. first valve upstreams of <indirectExternalId>."
+            "description": "The indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. Exa. this is the <indirectRelation> of <indirectExternalId>."
           },
           "lineExternalId": {
             "allOf": [
@@ -54880,14 +62146,14 @@
           },
           "subDetail": {
             "default": null,
-            "description": "Additional details, the fluid code for pipes e.g. LO for Lube oil etc.",
+            "description": "Use to save the fluid code of pipes Exa. LO for Lube oil and etc.",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
           },
           "sourceType": {
             "default": null,
-            "description": "Marks the hotspot as user created or detected via pipeline.",
+            "description": "Use to identify whether the annotation is user created one or ditected via pipeline.",
             "enum": [
               "pipeline",
               "user"
@@ -54896,19 +62162,19 @@
           },
           "linkedResourceInternalId": {
             "default": null,
-            "description": "Stores the Functional Location (FLOC) ID represented by the hotspot.",
+            "description": "Stores Functional Locations' (FLOC) ID linked to the annotation.",
             "type": "integer"
           },
           "linkedResourceExternalId": {
             "default": null,
-            "description": "Stores Functional Location (FLOC) external ID represented by the hotspot.",
+            "description": "Stores Functional Locations (FLOC) external ID linked to the annotation.",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
           },
           "linkedResourceType": {
             "default": null,
-            "description": "Whether the hotspot represents an asset (FLOC) or file.",
+            "description": "Stores Functional Location (FLOC) type the annotation linked to.",
             "enum": [
               "asset",
               "file"
@@ -54924,14 +62190,14 @@
           },
           "relativePosition": {
             "default": null,
-            "description": "Relative position of the relation connecting the hotspot to a tag. E.g. '2nd'. This references the 'indirectExternalId'.",
+            "description": "Indicate the relative position of an annotation.",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
           },
           "revision": {
             "default": null,
-            "description": "Revision number of the P&ID file that the hotspot is valid for.",
+            "description": "Keeps track of the modification to an annotation.",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
@@ -54947,7 +62213,7 @@
           },
           "oldAnnotationId": {
             "default": null,
-            "description": "Temporary field for migration purposes. Id of corresponding legacy annotation.",
+            "description": "Keep track of data link with old annotations.",
             "maxLength": 128,
             "minLength": 1,
             "type": "string"
@@ -55259,7 +62525,7 @@
         "title": "diagrams.UnhandledTextObject",
         "type": "object"
       },
-      "Annotations.cognite__annotation_types__diagrams__AssetLink": {
+      "Annotations.cogmono__annotation_types__diagrams__AssetLink": {
         "additionalProperties": false,
         "description": "Models a link to a CDF Asset referenced in an engineering diagram",
         "properties": {
@@ -55323,7 +62589,7 @@
         "title": "diagrams.AssetLink",
         "type": "object"
       },
-      "Annotations.cognite__annotation_types__diagrams__InstanceLink": {
+      "Annotations.cogmono__annotation_types__diagrams__InstanceLink": {
         "additionalProperties": false,
         "description": "Models a link to an FDM instance referenced in an engineering diagram",
         "properties": {
@@ -55387,7 +62653,7 @@
         "title": "diagrams.InstanceLink",
         "type": "object"
       },
-      "Annotations.cognite__annotation_types__images__AssetLink": {
+      "Annotations.cogmono__annotation_types__images__AssetLink": {
         "additionalProperties": false,
         "description": "Models a link to a CDF Asset referenced in an image",
         "properties": {
@@ -55423,7 +62689,7 @@
           "objectRegion": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/Annotations.cognite__annotation_types__primitives__geometry2d__Geometry"
+                "$ref": "#/components/schemas/Annotations.cogmono__annotation_types__primitives__geometry2d__Geometry"
               }
             ],
             "default": null,
@@ -55438,7 +62704,7 @@
         "title": "images.AssetLink",
         "type": "object"
       },
-      "Annotations.cognite__annotation_types__images__InstanceLink": {
+      "Annotations.cogmono__annotation_types__images__InstanceLink": {
         "additionalProperties": false,
         "description": "Models a link to an FDM instance referenced in an image",
         "properties": {
@@ -55560,7 +62826,7 @@
           },
           "email": {
             "type": "string",
-            "description": "The user's email address (if any). The email address is is returned directly from \nthe identity provider and not guaranteed to be verified. \nNote that the email is mutable and can be updated in the identity provider. It should \n_not_ be used to uniquely identify as a user. Use the `userIdentifier` property instead.\n",
+            "description": "The user's email address (if any). The email address is is returned directly from\nthe identity provider and not guaranteed to be verified.\nNote that the email is mutable and can be updated in the identity provider. It should\n_not_ be used to uniquely identify as a user. Use the `userIdentifier` property instead.\n",
             "nullable": true,
             "example": "jane.doe@example.com"
           },
@@ -55741,7 +63007,79 @@
           "INTERNAL_SERVICE"
         ]
       },
-      "Workflow": {
+      "UserListResponse": {
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "maxItems": 1000,
+            "items": {
+              "$ref": "#/components/schemas/OrgUser"
+            }
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "description": {
+                  "$ref": "#/components/schemas/Cursor/description"
+                }
+              },
+              {
+                "$ref": "#/components/schemas/Cursor/properties/cursor"
+              }
+            ]
+          }
+        }
+      },
+      "OrgUser": {
+        "type": "object",
+        "required": [
+          "id",
+          "pictureUrl"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/UserId"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "name": {
+            "type": "string",
+            "example": "John N. Doe"
+          },
+          "givenName": {
+            "type": "string",
+            "example": "John"
+          },
+          "middleName": {
+            "type": "string",
+            "example": "N."
+          },
+          "familyName": {
+            "type": "string",
+            "example": "Doe"
+          },
+          "pictureUrl": {
+            "type": "string",
+            "format": "url",
+            "example": "https://example.com/picture.png"
+          }
+        }
+      },
+      "UserId": {
+        "type": "string",
+        "description": "The ID of an organization user",
+        "minLength": 22,
+        "maxLength": 22,
+        "example": "-user-string-id-aBc123",
+        "pattern": "^[-_a-zA-Z0-9]{22}$"
+      },
+      "WorkflowView": {
         "title": "Workflow",
         "type": "object",
         "properties": {
@@ -55754,11 +63092,15 @@
           },
           "createdTime": {
             "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
           }
         },
         "required": [
           "externalId",
-          "createdTime"
+          "createdTime",
+          "lastUpdatedTime"
         ]
       },
       "WorkflowDefinition": {
@@ -55793,11 +63135,13 @@
           },
           "name": {
             "type": "string",
-            "maxLength": 32
+            "maxLength": 255,
+            "description": "Readable name meant for use in UIs"
           },
           "description": {
             "type": "string",
-            "maxLength": 500
+            "maxLength": 500,
+            "description": "Description of the intention of the task"
           },
           "parameters": {
             "oneOf": [
@@ -55830,7 +63174,7 @@
             "default": 3600,
             "minimum": 100,
             "maximum": 43200,
-            "description": "Timeout in seconds.  After this time, the task will be marked as `TIMED_OUT`. By default, the task won't be retried upon timeout. Use the `onFailure` parameter to change this behavior."
+            "description": "Timeout in seconds. After this time, the task will be marked as `TIMED_OUT`. By default, the task won't be retried upon timeout. Use the `onFailure` parameter to change this behavior."
           },
           "onFailure": {
             "type": "string",
@@ -55839,7 +63183,7 @@
               "skipTask"
             ],
             "default": "abortWorkflow",
-            "description": "Defines the policy to handle failures and timeouts. \n- `skipTask`: For both failures and timeouts, it will retry until the retries are exhausted. After that, the Task is marked as COMPLETED_WITH_ERRORS and the subsequent tasks are executed.\n- `abortWorkflow`: \n  - In case of failures, retries will be performed until exhausted, after which the task is marked as FAILED and the Workflow is marked the same. \n  - In the event of a timeout, no retries are undertaken; the task is marked as TIMED_OUT and the Workflow is marked as FAILED.\n"
+            "description": "Defines the policy to handle failures and timeouts.\n- `skipTask`: For both failures and timeouts, it will retry until the retries are exhausted. After that, the Task is marked as COMPLETED_WITH_ERRORS and the subsequent tasks are executed.\n- `abortWorkflow`:\n  - In case of failures, retries will be performed until exhausted, after which the task is marked as FAILED and the Workflow is marked the same.\n  - In the event of a timeout, no retries are undertaken; the task is marked as TIMED_OUT and the Workflow is marked as FAILED.\n"
           },
           "dependsOn": {
             "type": "array",
@@ -55872,7 +63216,8 @@
           "transformation",
           "cdf",
           "dynamic",
-          "subworkflow"
+          "subworkflow",
+          "simulator"
         ]
       },
       "WorkflowExecution": {
@@ -56000,7 +63345,7 @@
           "isAsyncComplete": {
             "type": "boolean",
             "default": false,
-            "description": "Defines if the execution of the task should be completed asynchronously.\n\n  - If `false`, the status of the task will be set to `COMPLETED` when the Cognite Function call completes successfully.  \n  - If `true`, the task status will remain `IN_PROGRESS` even when the Cognite Function call completes successfully. \n  It will then wait for an external process to update the task status directly using the task update endpoint. \n  The task id required for the callback to update the task status is included in the input data of the Function with key \"cogniteOrchestrationTaskId\"."
+            "description": "Defines if the execution of the task should be completed asynchronously.\n\n  - If `false`, the status of the task will be set to `COMPLETED` when the Cognite Function call completes successfully.\\\n  - If `true`, the task status will remain `IN_PROGRESS` even when the Cognite Function call completes successfully.\\\n  It will then wait for an external process to update the task status directly using the task update endpoint.\\\n  The task id required for the callback to update the task status is included in the input data of the Function with key \"cogniteOrchestrationTaskId\"."
           }
         }
       },
@@ -56013,7 +63358,7 @@
             "type": "object",
             "properties": {
               "resourcePath": {
-                "description": "The path of the request. The path should be prefixed by `{cluster}.cognitedata.com/api/v1/project/{project}` based on the relevant cluster and project. \n\nExample: to list TimeSeries, the resourcePath would be `{cluster}.cognitedata.com/api/v1/project/{project}/timeseries/list`.\n",
+                "description": "The path of the request. The path should be prefixed by `{cluster}.cognitedata.com/api/v1/project/{project}` based on the relevant cluster and project.\n\nExample: to list TimeSeries, the resourcePath would be `{cluster}.cognitedata.com/api/v1/project/{project}/timeseries/list`.\n",
                 "oneOf": [
                   {
                     "type": "string",
@@ -56107,20 +63452,42 @@
         "type": "object",
         "properties": {
           "subworkflow": {
-            "type": "object",
-            "properties": {
-              "tasks": {
-                "description": "A list of tasks with their inputs and interdependencies. Similar to the way tasks are defined in a workflow definition.\n",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/TaskDefinition"
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "tasks": {
+                    "description": "A list of tasks with their inputs and interdependencies. Similar to the way tasks are defined in a workflow definition.\n",
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/TaskDefinition"
+                    },
+                    "maxItems": 100,
+                    "minItems": 1
+                  }
                 },
-                "maxItems": 100,
-                "minItems": 1
+                "required": [
+                  "tasks"
+                ]
+              },
+              {
+                "type": "object",
+                "description": "Run another workflow embedded as a subworkflow. The tasks within the subworkflow will count towards the limit on total number of tasks in a workflow.\n",
+                "properties": {
+                  "workflowExternalId": {
+                    "type": "string",
+                    "description": "External ID of the referenced workflow"
+                  },
+                  "version": {
+                    "type": "string",
+                    "description": "Version of the referenced workflow"
+                  }
+                },
+                "required": [
+                  "workflowExternalId",
+                  "version"
+                ]
               }
-            },
-            "required": [
-              "tasks"
             ]
           }
         }
@@ -56234,6 +63601,12 @@
           },
           "workflowDefinition": {
             "$ref": "#/components/schemas/WorkflowDefinitionResponse"
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
           }
         }
       },
@@ -56350,7 +63723,7 @@
       },
       "Reference": {
         "type": "string",
-        "description": "A Reference is an expression that allows dynamically injecting input to a task during execution. References can be used to reference the input of the Workflow, the output of a previous task in the Workflow, or the input of a previous task in the Workflow.  Note that the injected value must be valid in the context of the property it is injected into.\nExample Task reference: ${myTaskExternalId.output.someKey} Example Workflow input reference: ${workflow.input.myKey}"
+        "description": "A Reference is an expression that allows dynamically injecting input to a task during execution. References can be used to reference the input of the Workflow, the output of a previous task in the Workflow, or the input of a previous task in the Workflow. Note that the injected value must be valid in the context of the property it is injected into.\nExample Task reference: ${myTaskExternalId.output.someKey} Example Workflow input reference: ${workflow.input.myKey}"
       },
       "WorkflowStatus": {
         "type": "string",
@@ -56359,8 +63732,7 @@
           "COMPLETED",
           "FAILED",
           "TIMED_OUT",
-          "TERMINATED",
-          "PAUSED"
+          "TERMINATED"
         ]
       },
       "WorkflowExecutionResponse": {
@@ -56515,7 +63887,7 @@
           "type": "string",
           "maxLength": 255
         },
-        "description": "Custom, application-specific metadata. String key -> String value.\nKeys have a maximum length of 32 characters, values a maximum of 255, \nand there can be a maximum of 10 key-value pairs.\n"
+        "description": "Custom, application-specific metadata. String key -> String value.\nKeys have a maximum length of 32 characters, values a maximum of 255,\nand there can be a maximum of 10 key-value pairs.\n"
       },
       "ReasonForIncompletion": {
         "type": "string",
@@ -56527,7 +63899,7 @@
           "key1": "value1",
           "key2": "value2"
         },
-        "description": "Input data to the workflow. The content of the input data can be used as input to the workflow tasks using references.   The input data should be in JSON format, and is limited to 100KB in size."
+        "description": "Input data to the workflow. The content of the input data can be used as input to the workflow tasks using references. The input data should be in JSON format, and is limited to 100KB in size."
       },
       "CancelExecution": {
         "title": "Workflow cancellation request",
@@ -56553,18 +63925,188 @@
           "authentication"
         ]
       },
+      "SimulationLogs": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "message": {
+            "type": "string",
+            "description": "Message of the log"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "Debug",
+              "Information",
+              "Warning",
+              "Error"
+            ],
+            "description": "Severity of the log"
+          }
+        }
+      },
+      "SimulatorRunResultOutput": {
+        "type": "object",
+        "properties": {
+          "referenceId": {
+            "type": "string",
+            "description": "Reference id of the value"
+          },
+          "value": {
+            "type": "object",
+            "description": "Value used for simulation"
+          },
+          "valueType": {
+            "type": "string",
+            "enum": [
+              "STRING",
+              "DOUBLE",
+              "STRING_ARRAY",
+              "DOUBLE_ARRAY"
+            ],
+            "description": "Type of the value"
+          }
+        }
+      },
+      "SimulatorRunResultData": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The runId of the simulation run instance."
+          },
+          "outputs": {
+            "type": "array",
+            "$ref": "#/components/schemas/SimulatorRunResultOutput"
+          }
+        }
+      },
+      "SimulatorInputsUnit": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the unit."
+          }
+        }
+      },
+      "SimulatorInput": {
+        "type": "object",
+        "properties": {
+          "referenceId": {
+            "type": "string",
+            "description": "Reference id of the value to override"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 1024,
+                "minLength": 1
+              },
+              {
+                "type": "number"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "maxItems": 100,
+                "minItems": 1
+              },
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array",
+                "maxItems": 100,
+                "minItems": 1
+              }
+            ],
+            "title": "Value",
+            "description": "Override the value used for a simulation run"
+          },
+          "unit": {
+            "description": "Override the unit of the value",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SimulatorInputsUnit"
+            },
+            "minItems": 0,
+            "maxItems": 100
+          }
+        }
+      },
       "Authentication": {
         "type": "object",
         "properties": {
           "nonce": {
             "type": "string",
-            "description": "The nonce of a sessions token, which can be obtained using client credentials authentication flow. The nonce's session must be a root session, i.e. it must not be a child of another session.  See [Sessions API](https://api-docs.cognite.com/20230101/tag/Sessions) documentation for more information.",
+            "description": "The nonce of a sessions token, which can be obtained using client credentials authentication flow. The nonce's session must be a root session, i.e. it must not be a child of another session. See [Sessions API](https://api-docs.cognite.com/20230101/tag/Sessions) documentation for more information.",
             "example": "hOfy4Zop4N2SPRfl"
           }
         },
         "required": [
           "nonce"
         ]
+      },
+      "TriggerExternalId": {
+        "type": "string",
+        "description": "Identifier for a trigger. Must be unique for the project. No trailing or leading whitespace and no null characters allowed.",
+        "maxLength": 255
+      },
+      "TriggerView": {
+        "title": "Trigger response",
+        "type": "object",
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/TriggerExternalId"
+          },
+          "triggerRule": {
+            "$ref": "#/components/schemas/TriggerRule"
+          },
+          "input": {
+            "$ref": "#/components/schemas/ExecutionInput"
+          },
+          "workflowExternalId": {
+            "$ref": "#/components/schemas/WorkflowExternalId"
+          },
+          "workflowVersion": {
+            "$ref": "#/components/schemas/Version"
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        }
+      },
+      "TriggerRule": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CronTrigger"
+          }
+        ]
+      },
+      "CronTrigger": {
+        "type": "object",
+        "properties": {
+          "triggerType": {
+            "type": "string",
+            "enum": [
+              "schedule"
+            ]
+          },
+          "cronExpression": {
+            "type": "string",
+            "description": "A cron expression (UNIX format) specifying when the trigger should be executed. Use https://crontab.guru/ to create a cron expression. The API may adjust the exact timing of cron job executions to distribute the backend load more evenly. However, it will aim to maintain the overall frequency of executions as specified in the cron expression."
+          }
+        }
       },
       "CertificateDetails": {
         "additionalProperties": false,
@@ -56665,8 +64207,11 @@
             "type": "string",
             "description": "Format type."
           },
-          "preProcessingLayers": {
-            "$ref": "#/components/schemas/PreProcessingLayers"
+          "encoding": {
+            "$ref": "#/components/schemas/EncodingType"
+          },
+          "compression": {
+            "$ref": "#/components/schemas/CompressionType"
           },
           "prefix": {
             "$ref": "#/components/schemas/PrefixConfig"
@@ -56689,7 +64234,7 @@
           "credentials": {
             "$ref": "#/components/schemas/SessionCredentials"
           },
-          "datasetId": {
+          "targetDataSetId": {
             "type": "integer",
             "title": "Data Set ID",
             "minimum": 1,
@@ -56798,6 +64343,7 @@
             "type": "integer",
             "minimum": 1,
             "maximum": 10,
+            "default": 1,
             "description": "Number of partitions on the topic."
           }
         }
@@ -56883,6 +64429,29 @@
           }
         }
       },
+      "BodyPaginationConfig": {
+        "additionalProperties": false,
+        "type": "object",
+        "title": "BodyPaginationConfig",
+        "required": [
+          "type",
+          "value"
+        ],
+        "properties": {
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "enum": [
+              "body"
+            ]
+          },
+          "value": {
+            "title": "Value",
+            "type": "string",
+            "description": "Expression yielding next message body. Note that body-based pagination is not allowed to be used if `method` is not set to `post`.\n"
+          }
+        }
+      },
       "RestJobConfig": {
         "additionalProperties": false,
         "type": "object",
@@ -56894,15 +64463,53 @@
           "path": {
             "type": "string",
             "title": "Path",
-            "description": "Path of resource to access on the server",
+            "description": "Path of resource to access on the server, without query.",
             "minLength": 1,
             "maxLength": 2048
           },
+          "method": {
+            "type": "string",
+            "title": "Method",
+            "description": "HTTP method to use for each request.",
+            "enum": [
+              "get",
+              "post"
+            ],
+            "default": "get"
+          },
+          "body": {
+            "title": "Body",
+            "description": "Initial JSON body to send with request. Only applicable if method is `post`. Maximum of 10000 bytes total.\n"
+          },
+          "query": {
+            "type": "object",
+            "title": "Query",
+            "description": "Query parameters to include in request. String key -> String value. Limits: Maximum 255 characters per key, 2048 per value, and at most 32 pairs.\n",
+            "x-maxKeyLength": 255,
+            "maxProperties": 32,
+            "additionalProperties": {
+              "type": "string",
+              "maxLength": 2048
+            }
+          },
+          "headers": {
+            "type": "object",
+            "title": "Query",
+            "description": "Headers to include in request. String key -> String value. Limits: Maximum 255 characters per key, 2048 per value, and at most 32 pairs.\n",
+            "x-maxKeyLength": 255,
+            "maxProperties": 32,
+            "additionalProperties": {
+              "type": "string",
+              "maxLength": 2048
+            }
+          },
           "incrementalLoad": {
+            "type": "object",
             "discriminator": {
               "mapping": {
                 "queryParam": "#/components/schemas/QueryParameterConfig",
-                "headerValue": "#/components/schemas/HeaderValueConfig"
+                "headerValue": "#/components/schemas/HeaderValueConfig",
+                "body": "#/components/schemas/BodyPaginationConfig"
               },
               "propertyName": "type"
             },
@@ -56912,17 +64519,22 @@
               },
               {
                 "$ref": "#/components/schemas/HeaderValueConfig"
+              },
+              {
+                "$ref": "#/components/schemas/BodyPaginationConfig"
               }
             ],
             "title": "Incremental load",
             "description": "The format of the messages from the source. This is used to convert messages coming from the source system to a format that can be inserted into CDF."
           },
           "pagination": {
+            "type": "object",
             "discriminator": {
               "mapping": {
                 "queryParam": "#/components/schemas/QueryParameterConfig",
                 "headerValue": "#/components/schemas/HeaderValueConfig",
-                "nextUrl": "#/components/schemas/NextUrlConfig"
+                "nextUrl": "#/components/schemas/NextUrlConfig",
+                "body": "#/components/schemas/BodyPaginationConfig"
               },
               "propertyName": "type"
             },
@@ -56935,6 +64547,9 @@
               },
               {
                 "$ref": "#/components/schemas/NextUrlConfig"
+              },
+              {
+                "$ref": "#/components/schemas/BodyPaginationConfig"
               }
             ],
             "title": "Incremental load",
@@ -57012,7 +64627,8 @@
               }
             ],
             "title": "Format",
-            "description": "The format of the messages from the source. This is used to convert messages coming from the source system to a format that can be inserted into CDF."
+            "description": "The format of the messages from the source. This is used to convert messages coming from the source system to a format that can be inserted into CDF.",
+            "type": "object"
           },
           "config": {
             "$ref": "#/components/schemas/JobConfig"
@@ -57022,7 +64638,8 @@
           "sourceId",
           "destinationId",
           "externalId",
-          "format"
+          "format",
+          "config"
         ],
         "title": "CreateJob",
         "type": "object"
@@ -57055,17 +64672,8 @@
             "minimum": 1,
             "maximum": 65535
           },
-          "username": {
-            "type": "string",
-            "title": "Username",
-            "description": "Username used for authenticating with the broker.",
-            "maxLength": 200
-          },
-          "password": {
-            "type": "string",
-            "title": "Password",
-            "description": "Password used for authenticating with the broker.",
-            "maxLength": 200
+          "authentication": {
+            "$ref": "#/components/schemas/MqttAuthenticationWrite"
           },
           "useTls": {
             "type": "boolean",
@@ -57115,17 +64723,8 @@
             "minimum": 1,
             "maximum": 65535
           },
-          "username": {
-            "type": "string",
-            "title": "Username",
-            "description": "Username used for authenticating with the broker.",
-            "maxLength": 200
-          },
-          "password": {
-            "type": "string",
-            "title": "Password",
-            "description": "Password used for authenticating with the broker.",
-            "maxLength": 200
+          "authentication": {
+            "$ref": "#/components/schemas/MqttAuthenticationWrite"
           },
           "useTls": {
             "type": "boolean",
@@ -57184,8 +64783,8 @@
             "minimum": 1,
             "maximum": 65535
           },
-          "interval": {
-            "$ref": "#/components/schemas/RestInterval"
+          "caCertificate": {
+            "$ref": "#/components/schemas/CACertificate"
           },
           "authentication": {
             "discriminator": {
@@ -57218,8 +64817,7 @@
         "required": [
           "type",
           "externalId",
-          "host",
-          "interval"
+          "host"
         ],
         "title": "CreateRestSource",
         "type": "object"
@@ -57266,6 +64864,7 @@
       "CreateProtobufConfig": {
         "additionalProperties": false,
         "description": "List of protobuf files used to define input to the mapping. This will be compiled to a collection of definitions which will be used to convert the input to JSON.",
+        "title": "ProtoBuf",
         "properties": {
           "type": {
             "type": "string",
@@ -57293,7 +64892,7 @@
         },
         "required": [
           "messageName",
-          "file",
+          "files",
           "type"
         ]
       },
@@ -57354,6 +64953,7 @@
       "CsvConfig": {
         "additionalProperties": false,
         "type": "object",
+        "title": "CSV",
         "description": "Transform the input from a CSV (Comma Separated Values) file to a list of JSON objects. The input to the mapping will be a list on the form `[{\\\"header1\\\": \\\"value1\\\", ...}, ...]`.\n",
         "properties": {
           "type": {
@@ -57390,6 +64990,7 @@
       "XmlConfig": {
         "additionalProperties": false,
         "type": "object",
+        "title": "XML",
         "description": "Transform the input from an XML file to a JSON object.\n",
         "properties": {
           "type": {
@@ -57409,6 +65010,7 @@
         "additionalProperties": false,
         "type": "object",
         "description": "Treat the input as UTF-8 encoded JSON.",
+        "title": "JSON",
         "properties": {
           "type": {
             "type": "string",
@@ -57426,6 +65028,7 @@
       "ProtobufConfig": {
         "additionalProperties": false,
         "description": "List of protobuf files used to define input to the mapping. This will be compiled to a collection of definitions which will be used to convert the input to JSON.",
+        "title": "ProtoBuf",
         "properties": {
           "type": {
             "type": "string",
@@ -57452,7 +65055,7 @@
         },
         "required": [
           "messageName",
-          "file",
+          "files",
           "type"
         ]
       },
@@ -57513,8 +65116,11 @@
             "description": "The ID of the mapping used for this format.",
             "maxLength": 255
           },
-          "preProcessingLayers": {
-            "$ref": "#/components/schemas/PreProcessingLayers"
+          "encoding": {
+            "$ref": "#/components/schemas/EncodingType"
+          },
+          "compression": {
+            "$ref": "#/components/schemas/CompressionType"
           },
           "expression": {
             "type": "string",
@@ -57545,7 +65151,7 @@
             "format": "int64",
             "description": "ID of the session tied to this destination."
           },
-          "datasetId": {
+          "targetDataSetId": {
             "type": "integer",
             "title": "Data Set ID",
             "minimum": 1,
@@ -57585,29 +65191,6 @@
         "title": "DestinationUpdateItem",
         "type": "object"
       },
-      "EncodingLayer": {
-        "additionalProperties": false,
-        "properties": {
-          "type": {
-            "enum": [
-              "encoding"
-            ],
-            "title": "Type",
-            "type": "string",
-            "description": "Pre-processing layer type."
-          },
-          "encodingType": {
-            "$ref": "#/components/schemas/EncodingType"
-          }
-        },
-        "required": [
-          "type",
-          "encodingType"
-        ],
-        "title": "EncodingLayer",
-        "type": "object",
-        "description": "Pre-processing layer converting from other encodings to UTF-8."
-      },
       "EncodingType": {
         "enum": [
           "utf16",
@@ -57615,6 +65198,14 @@
         ],
         "title": "EncodingType",
         "description": "The type of encoding to convert from.\nOptions are `utf16` (UTF-16 big endian), and `utf16le` (UTF-16 little endian).",
+        "type": "string"
+      },
+      "CompressionType": {
+        "enum": [
+          "gzip"
+        ],
+        "title": "CompressionType",
+        "description": "The compression applied to incoming messages. The messages are decompressed before being passed to transformations.\nThis is usually not relevant for REST, where this is handled automatically, but MQTT, Kafka, and EventHub have no such mechanisms.",
         "type": "string"
       },
       "EventHubSource": {
@@ -57675,25 +65266,6 @@
           "lastUpdatedTime"
         ],
         "title": "EventHubSource",
-        "type": "object"
-      },
-      "GzipLayer": {
-        "additionalProperties": false,
-        "description": "Un-gzip the payload before it is read as JSON. This is usually not relevant for REST, where this is handled automatically, but MQTT and EventHub have no such mechanisms.",
-        "properties": {
-          "type": {
-            "enum": [
-              "gzip"
-            ],
-            "title": "Type",
-            "type": "string",
-            "description": "Pre-processing layer type."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "title": "GzipLayer",
         "type": "object"
       },
       "ExternalIdWrapper": {
@@ -58212,10 +65784,10 @@
               "connection_error",
               "connected",
               "transform_error",
-              "destination_error",
+              "cdf_write_error",
               "ok"
             ],
-            "description": "Type of log entry.\n`paused` indicates that the job has been stopped manually,\n`startup_error` indicates that the job failed to start at all and requires changes to configuration,\n`connected` indicates that the job has connected to the source but did not yet receive any data,\n`transform_error` indicates that the job received data, but it failed to transform,\n`destination_error` indicates that ingesting the data to CDF failed,\n`ok` means that data was successfully ingested to CDF."
+            "description": "Type of log entry.\n`paused` indicates that the job has been stopped manually,\n`startup_error` indicates that the job failed to start at all and requires changes to configuration,\n`connected` indicates that the job has connected to the source but did not yet receive any data,\n`transform_error` indicates that the job received data, but it failed to transform,\n`cdf_write_error` indicates that ingesting the data to CDF failed,\n`ok` means that data was successfully ingested to CDF."
           },
           "message": {
             "type": "string",
@@ -58255,15 +65827,15 @@
             "type": "integer",
             "description": "Messages received from the source."
           },
-          "destinationInputValues": {
-            "title": "DestinationInputValues",
+          "cdfInputValues": {
+            "title": "CDFInputValues",
             "minimum": 0,
             "format": "int64",
             "type": "integer",
-            "description": "CDF resources successfully transformed and passed to the destination."
+            "description": "Destination resources successfully transformed and passed to CDF."
           },
-          "destinationRequests": {
-            "title": "DestinationRequests",
+          "cdfRequests": {
+            "title": "CDFRequests",
             "minimum": 0,
             "format": "int64",
             "type": "integer",
@@ -58276,35 +65848,47 @@
             "type": "integer",
             "description": "Source messages that failed to transform."
           },
-          "destinationWriteFailures": {
-            "title": "DestinationWriteFailures",
+          "cdfWriteFailures": {
+            "title": "CDFWriteFailures",
             "minimum": 0,
             "format": "int64",
             "type": "integer",
             "description": "Times the destination received data from transformations, but failed to produce a valid request to CDF."
           },
-          "destinationSkippedValues": {
-            "title": "DestinationSkippedValues",
+          "cdfSkippedValues": {
+            "title": "CDFSkippedValues",
             "minimum": 0,
             "format": "int64",
             "type": "integer",
             "description": "Values the destination received from the source, then decided to skip due to data type mismatch, invalid content, or other."
           },
-          "destinationFailedValues": {
-            "title": "DestinationFailedValues",
+          "cdfFailedValues": {
+            "title": "CDFFailedValues",
             "minimum": 0,
             "format": "int64",
             "type": "integer",
             "description": "Values the destination was unable to upload to CDF."
           },
-          "destinationUploadedValues": {
-            "title": "DestinationUploadedValues",
+          "cdfUploadedValues": {
+            "title": "CDFUploadedValues",
             "minimum": 0,
             "format": "int64",
             "type": "integer",
             "description": "Values the destination successfully uploaded to CDF."
           }
-        }
+        },
+        "required": [
+          "jobExternalId",
+          "timestamp",
+          "sourceMessages",
+          "cdfInputValues",
+          "cdfRequests",
+          "transformFailures",
+          "cdfWriteFailures",
+          "cdfSkippedValues",
+          "cdfFailedValues",
+          "cdfUploadedValues"
+        ]
       },
       "JobTargetStatus": {
         "enum": [
@@ -58379,7 +65963,9 @@
                 "$ref": "#/components/schemas/ValueFormat"
               }
             ],
-            "title": "Format"
+            "title": "Format",
+            "description": "The format of the messages from the source. This is used to convert messages coming from the source system to a format that can be inserted into CDF.",
+            "type": "object"
           },
           "targetStatus": {
             "$ref": "#/components/schemas/JobTargetStatus"
@@ -58395,7 +65981,7 @@
               "running",
               "waiting",
               "connection_error",
-              "destination_error",
+              "cdf_write_error",
               "transform_error"
             ],
             "type": "string"
@@ -58418,7 +66004,8 @@
           "lastUpdatedTime",
           "status",
           "targetStatus",
-          "format"
+          "format",
+          "config"
         ],
         "title": "Job",
         "type": "object"
@@ -58451,11 +66038,8 @@
             "minimum": 1,
             "maximum": 65535
           },
-          "username": {
-            "type": "string",
-            "title": "Username",
-            "description": "Username used for authenticating with the broker.",
-            "maxLength": 200
+          "authentication": {
+            "$ref": "#/components/schemas/MqttAuthentication"
           },
           "useTls": {
             "type": "boolean",
@@ -58513,11 +66097,8 @@
             "minimum": 1,
             "maximum": 65535
           },
-          "username": {
-            "type": "string",
-            "title": "Username",
-            "description": "Username used for authenticating with the broker.",
-            "maxLength": 200
+          "authentication": {
+            "$ref": "#/components/schemas/MqttAuthentication"
           },
           "useTls": {
             "type": "boolean",
@@ -58614,6 +66195,9 @@
             "minimum": 1,
             "maximum": 65535
           },
+          "caCertificate": {
+            "$ref": "#/components/schemas/CertificateDetails"
+          },
           "authentication": {
             "discriminator": {
               "mapping": {
@@ -58652,7 +66236,6 @@
           "type",
           "externalId",
           "host",
-          "interval",
           "createdTime",
           "lastUpdatedTime",
           "scheme"
@@ -58744,7 +66327,8 @@
         },
         "required": [
           "key",
-          "value"
+          "value",
+          "type"
         ],
         "title": "CreateQueryParamAuthentication",
         "type": "object"
@@ -58779,13 +66363,19 @@
             "title": "Scopes",
             "description": "A space separated list of scopes",
             "type": "string"
+          },
+          "defaultExpiresIn": {
+            "title": "Default expires in",
+            "description": "Default value for the expires_in OAuth 2.0 parameter. If the identity provider does not return expires_in in token requests, this parameter must be set or the request will fail.",
+            "type": "string"
           }
         },
         "required": [
           "clientId",
           "clientSecret",
           "tokenUrl",
-          "scopes"
+          "scopes",
+          "type"
         ],
         "title": "CreateClientCredentialsAuthentication",
         "type": "object"
@@ -58808,6 +66398,7 @@
           }
         },
         "required": [
+          "type",
           "username"
         ],
         "title": "BasicAuthentication",
@@ -58831,6 +66422,7 @@
           }
         },
         "required": [
+          "type",
           "key"
         ],
         "title": "HeaderValueAuthentication",
@@ -58854,6 +66446,7 @@
           }
         },
         "required": [
+          "type",
           "key"
         ],
         "title": "QueryParamAuthentication",
@@ -58884,9 +66477,15 @@
             "title": "Scopes",
             "description": "A space separated list of scopes",
             "type": "string"
+          },
+          "defaultExpiresIn": {
+            "title": "Default expires in",
+            "description": "Default value for the expires_in OAuth 2.0 parameter. If the identity provider does not return expires_in in token requests, this parameter must be set or the request will fail.",
+            "type": "string"
           }
         },
         "required": [
+          "type",
           "clientId",
           "tokenUrl",
           "scopes"
@@ -58905,8 +66504,11 @@
             "type": "string",
             "description": "Format type."
           },
-          "preProcessingLayers": {
-            "$ref": "#/components/schemas/PreProcessingLayers"
+          "encoding": {
+            "$ref": "#/components/schemas/EncodingType"
+          },
+          "compression": {
+            "$ref": "#/components/schemas/CompressionType"
           },
           "prefix": {
             "$ref": "#/components/schemas/PrefixConfig"
@@ -58918,22 +66520,6 @@
         "title": "RockwellFormat",
         "description": "Transform data on the Rockwell FactoryTalk format into CDF timeseries",
         "type": "object"
-      },
-      "SessionCredentials": {
-        "additionalProperties": false,
-        "properties": {
-          "nonce": {
-            "title": "Nonce",
-            "type": "string",
-            "description": "Session nonce for a recently created CDF Session."
-          }
-        },
-        "required": [
-          "nonce"
-        ],
-        "title": "SessionCredentials",
-        "type": "object",
-        "description": "Credentials for authenticating towards CDF using a CDF session."
       },
       "Mapping": {
         "additionalProperties": false,
@@ -59002,13 +66588,13 @@
             "title": "Credentials",
             "description": "Set a new session, or remove the value."
           },
-          "datasetId": {
+          "targetDataSetId": {
             "anyOf": [
               {
                 "$ref": "#/components/schemas/UpdateSetNull"
               },
               {
-                "$ref": "#/components/schemas/UpdateItem_DatasetId_"
+                "$ref": "#/components/schemas/UpdateItem_DataSetId_"
               }
             ],
             "title": "Dataset Id",
@@ -59148,7 +66734,9 @@
                 "$ref": "#/components/schemas/ValueFormat"
               }
             ],
-            "title": "Set"
+            "title": "Set",
+            "description": "The format of the messages from the source. This is used to convert messages coming from the source system to a format that can be inserted into CDF.",
+            "type": "object"
           }
         },
         "required": [
@@ -59213,20 +66801,6 @@
         "title": "UpdateItem_CustomMapping",
         "type": "object",
         "description": "Set a new mapping value."
-      },
-      "UpdateItem_RestInterval_": {
-        "additionalProperties": false,
-        "properties": {
-          "set": {
-            "$ref": "#/components/schemas/RestInterval"
-          }
-        },
-        "required": [
-          "set"
-        ],
-        "title": "UpdateItem_RestInterval",
-        "type": "object",
-        "description": "Set a new interval to execute the query on."
       },
       "UpdateItem_SessionCredentials_": {
         "additionalProperties": false,
@@ -59310,7 +66884,7 @@
         "type": "object",
         "description": "Set a new scheme for this source to use"
       },
-      "UpdateItem_DatasetId_": {
+      "UpdateItem_DataSetId_": {
         "additionalProperties": false,
         "properties": {
           "set": {
@@ -59344,37 +66918,33 @@
         "type": "object",
         "description": "Set a new source this job should write to."
       },
-      "UpdateItem_Username_": {
+      "UpdateItem_MqttAuthentication_": {
         "additionalProperties": false,
         "properties": {
           "set": {
-            "title": "Set",
-            "type": "string",
-            "maxLength": 200
+            "$ref": "#/components/schemas/MqttAuthenticationWrite"
           }
         },
         "required": [
           "set"
         ],
-        "title": "UpdateItem_Username",
+        "title": "UpdateItem_MqttAuthentication",
         "type": "object",
-        "description": "Set a new username used for authentication."
+        "description": "Set new credentials for authenticating with the broker."
       },
-      "UpdateItem_Password_": {
+      "UpdateItem_KafkaAuthentication_": {
         "additionalProperties": false,
         "properties": {
           "set": {
-            "title": "Set",
-            "type": "string",
-            "maxLength": 200
+            "$ref": "#/components/schemas/KafkaAuthenticationWrite"
           }
         },
         "required": [
           "set"
         ],
-        "title": "UpdateItem_Password",
+        "title": "UpdateItem_KafkaAuthentication",
         "type": "object",
-        "description": "Set a new password used for authentication."
+        "description": "Set new credentials for authenticating with the broker."
       },
       "JobUpdateItem": {
         "additionalProperties": false,
@@ -59412,29 +66982,17 @@
             "title": "Port",
             "description": "Set or remove the port on the MQTT broker."
           },
-          "username": {
+          "authentication": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/UpdateItem_Username_"
+                "$ref": "#/components/schemas/UpdateItem_MqttAuthentication_"
               },
               {
                 "$ref": "#/components/schemas/UpdateSetNull"
               }
             ],
-            "title": "Username",
-            "description": "Set or remove the username used for authentication."
-          },
-          "password": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UpdateItem_Password_"
-              },
-              {
-                "$ref": "#/components/schemas/UpdateSetNull"
-              }
-            ],
-            "title": "Password",
-            "description": "Set or remove the password used for authentication."
+            "title": "Authentication",
+            "description": "Set or remove the credentials used for authentication."
           },
           "useTls": {
             "additionalProperties": false,
@@ -59518,29 +67076,17 @@
             "title": "Port",
             "description": "Set or remove the port on the MQTT broker."
           },
-          "username": {
+          "authentication": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/UpdateItem_Username_"
+                "$ref": "#/components/schemas/UpdateItem_MqttAuthentication_"
               },
               {
                 "$ref": "#/components/schemas/UpdateSetNull"
               }
             ],
-            "title": "Username",
-            "description": "Set or remove the username used for authentication."
-          },
-          "password": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UpdateItem_Password_"
-              },
-              {
-                "$ref": "#/components/schemas/UpdateSetNull"
-              }
-            ],
-            "title": "Password",
-            "description": "Set or remove the password used for authentication."
+            "title": "Authentication",
+            "description": "Set or remove the credentials used for authentication."
           },
           "useTls": {
             "additionalProperties": false,
@@ -59611,9 +67157,6 @@
         "properties": {
           "host": {
             "$ref": "#/components/schemas/UpdateItem_Host_"
-          },
-          "interval": {
-            "$ref": "#/components/schemas/UpdateItem_RestInterval_"
           },
           "scheme": {
             "$ref": "#/components/schemas/UpdateItem_RestScheme_"
@@ -59712,8 +67255,11 @@
             "type": "string",
             "description": "Format type."
           },
-          "preProcessingLayers": {
-            "$ref": "#/components/schemas/PreProcessingLayers"
+          "encoding": {
+            "$ref": "#/components/schemas/EncodingType"
+          },
+          "compression": {
+            "$ref": "#/components/schemas/CompressionType"
           },
           "prefix": {
             "$ref": "#/components/schemas/PrefixConfig"
@@ -59726,28 +67272,6 @@
         "type": "object",
         "description": "Assume the source data is on the form `some string` or `123.456`, and convert these into CDF datapoints, using prefix config to determine the timeseries external ID, and current time as timestamp.\nIf no prefix config is set, use the topic name as timeseries ID."
       },
-      "PreProcessingLayers": {
-        "items": {
-          "discriminator": {
-            "mapping": {
-              "encoding": "#/components/schemas/EncodingLayer",
-              "gzip": "#/components/schemas/GzipLayer"
-            },
-            "propertyName": "type"
-          },
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/EncodingLayer"
-            },
-            {
-              "$ref": "#/components/schemas/GzipLayer"
-            }
-          ]
-        },
-        "type": "array",
-        "title": "PreProcessingLayers",
-        "description": "List of pre processing layers applied to the payload before it is sent to the transformation. The layers are applied in order."
-      },
       "WriteCustomFormat": {
         "additionalProperties": false,
         "properties": {
@@ -59759,8 +67283,11 @@
             "type": "string",
             "description": "Format type."
           },
-          "preProcessingLayers": {
-            "$ref": "#/components/schemas/PreProcessingLayers"
+          "encoding": {
+            "$ref": "#/components/schemas/EncodingType"
+          },
+          "compression": {
+            "$ref": "#/components/schemas/CompressionType"
           },
           "mappingId": {
             "title": "Mapping ID",
@@ -59794,7 +67321,7 @@
           "message": {
             "type": "string",
             "description": "Error message.",
-            "example": "Extra inputs are not permitted: tpye"
+            "example": "Extra inputs are not permitted: type"
           }
         }
       },
@@ -59803,7 +67330,7 @@
         "properties": {
           "expression": {
             "type": "string",
-            "description": "Custom transform expression written in the Kuiper transformation language.",
+            "description": "Custom transform expression written in the Cognite transformation language.",
             "maxLength": 2000
           }
         },
@@ -59860,11 +67387,8 @@
           "bootstrapBrokers": {
             "$ref": "#/components/schemas/KafkaBrokerList"
           },
-          "username": {
-            "type": "string",
-            "title": "Username",
-            "description": "Username used for authenticating with the broker.",
-            "maxLength": 200
+          "authentication": {
+            "$ref": "#/components/schemas/KafkaAuthentication"
           },
           "createdTime": {
             "$ref": "#/components/schemas/EpochTimestamp"
@@ -59887,7 +67411,9 @@
         "required": [
           "bootstrapBrokers",
           "externalId",
-          "type"
+          "type",
+          "createdTime",
+          "lastUpdatedTime"
         ]
       },
       "CreateKafkaSource": {
@@ -59908,17 +67434,8 @@
           "bootstrapBrokers": {
             "$ref": "#/components/schemas/KafkaBrokerList"
           },
-          "username": {
-            "type": "string",
-            "title": "Username",
-            "description": "Username used for authenticating with the broker.",
-            "maxLength": 200
-          },
-          "password": {
-            "type": "string",
-            "title": "Password",
-            "description": "Password used for authenticating with the broker.",
-            "maxLength": 200
+          "authentication": {
+            "$ref": "#/components/schemas/KafkaAuthenticationWrite"
           },
           "useTls": {
             "type": "boolean",
@@ -59958,7 +67475,7 @@
           "set": {
             "type": "integer",
             "title": "Partitions",
-            "description": "The number of partiitons in the broker",
+            "description": "The number of partitions in the broker.",
             "minimum": 1,
             "maximum": 10,
             "default": 1
@@ -59977,29 +67494,17 @@
           "bootstrapBrokers": {
             "$ref": "#/components/schemas/UpdateItem_KafkaBrokers_"
           },
-          "username": {
+          "authentication": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/UpdateItem_Username_"
+                "$ref": "#/components/schemas/UpdateItem_KafkaAuthentication_"
               },
               {
                 "$ref": "#/components/schemas/UpdateSetNull"
               }
             ],
-            "title": "Username",
-            "description": "Set or remove the username used for authentication."
-          },
-          "password": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UpdateItem_Password_"
-              },
-              {
-                "$ref": "#/components/schemas/UpdateSetNull"
-              }
-            ],
-            "title": "Password",
-            "description": "Set or remove the password used for authentication."
+            "title": "Authentication",
+            "description": "Set or remove the credentials used for authentication."
           },
           "useTls": {
             "additionalProperties": false,
@@ -60062,6 +67567,1792 @@
         ],
         "title": "UpdateKafkaSourceItem",
         "type": "object"
+      },
+      "SimpleBasicAuthentication": {
+        "additionalProperties": false,
+        "type": "object",
+        "title": "BasicAuthentication",
+        "description": "Username and password authentication.",
+        "properties": {
+          "type": {
+            "enum": [
+              "basic"
+            ],
+            "title": "Type",
+            "type": "string",
+            "description": "Authentication type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username",
+            "description": "Username used for authenticating with the broker.",
+            "maxLength": 200
+          }
+        },
+        "required": [
+          "username",
+          "type"
+        ]
+      },
+      "SimpleBasicAuthenticationWrite": {
+        "additionalProperties": false,
+        "type": "object",
+        "title": "BasicAuthenticationWrite",
+        "description": "Username and password authentication.",
+        "properties": {
+          "type": {
+            "enum": [
+              "basic"
+            ],
+            "title": "Type",
+            "type": "string",
+            "description": "Authentication type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username",
+            "description": "Username used for basic authentication.",
+            "maxLength": 200
+          },
+          "password": {
+            "type": "string",
+            "title": "Password",
+            "description": "Password used for basic authentication.",
+            "maxLength": 200
+          }
+        },
+        "required": [
+          "username",
+          "type"
+        ]
+      },
+      "KafkaAuthentication": {
+        "type": "object",
+        "discriminator": {
+          "mapping": {
+            "basic": "#/components/schemas/SimpleBasicAuthentication"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SimpleBasicAuthentication"
+          }
+        ],
+        "title": "Authentication",
+        "description": "Method used for authenticating with the kafka brokers.\nThis may be used together with auth certificate."
+      },
+      "KafkaAuthenticationWrite": {
+        "type": "object",
+        "discriminator": {
+          "mapping": {
+            "basic": "#/components/schemas/SimpleBasicAuthenticationWrite"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SimpleBasicAuthenticationWrite"
+          }
+        ],
+        "title": "Authentication",
+        "description": "Method used for authenticating with the kafka brokers.\nThis may be used together with auth certificate."
+      },
+      "MqttAuthentication": {
+        "type": "object",
+        "discriminator": {
+          "mapping": {
+            "basic": "#/components/schemas/SimpleBasicAuthentication"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SimpleBasicAuthentication"
+          }
+        ],
+        "title": "Authentication",
+        "description": "Method used for authenticating with the mqtt broker.\nThis may be used together with auth certificate."
+      },
+      "MqttAuthenticationWrite": {
+        "type": "object",
+        "discriminator": {
+          "mapping": {
+            "basic": "#/components/schemas/SimpleBasicAuthenticationWrite"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SimpleBasicAuthenticationWrite"
+          }
+        ],
+        "title": "Authentication",
+        "description": "Method used for authenticating with the mqtt broker.\nThis may be used together with auth certificate."
+      },
+      "FilterUsers": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "Filter Users",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "format": "int32"
+          },
+          "cursor": {
+            "type": "string",
+            "title": "Cursor",
+            "description": "Cursor for pagination"
+          }
+        }
+      },
+      "Username": {
+        "type": "string",
+        "title": "Username",
+        "description": "Username to authenticate the user on the DB."
+      },
+      "Tablename": {
+        "type": "string",
+        "title": "Tablename",
+        "maxLength": 60,
+        "minLength": 1
+      },
+      "UsernameWrapper": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "username"
+        ],
+        "properties": {
+          "username": {
+            "$ref": "#/components/schemas/Username"
+          }
+        }
+      },
+      "TablenameWrapper": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "tablename"
+        ],
+        "properties": {
+          "tablename": {
+            "$ref": "#/components/schemas/Tablename"
+          }
+        }
+      },
+      "FdwUser": {
+        "type": "object",
+        "required": [
+          "username",
+          "createdTime"
+        ],
+        "description": "A user",
+        "properties": {
+          "username": {
+            "$ref": "#/components/schemas/Username"
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "sessionId": {
+            "type": "integer",
+            "title": "Session ID",
+            "minimum": 1,
+            "maximum": 9007199254740991,
+            "format": "int64",
+            "description": "ID of the session tied to this user."
+          }
+        }
+      },
+      "TableType": {
+        "enum": [
+          "raw_rows",
+          "built_in",
+          "nodes",
+          "edges"
+        ],
+        "type": "string",
+        "title": "TableType",
+        "description": "The type of table (usually built_in) but could be any of raw_rows, nodes or edges when custom."
+      },
+      "RawTableOptions": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Raw rows options",
+        "required": [
+          "database",
+          "table"
+        ],
+        "properties": {
+          "database": {
+            "type": "string"
+          },
+          "table": {
+            "type": "string"
+          },
+          "primaryKey": {
+            "type": "string"
+          }
+        }
+      },
+      "FdmTableOptions": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Fdm table options",
+        "required": [
+          "space",
+          "externalId"
+        ],
+        "properties": {
+          "space": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "Column_": {
+        "type": "object",
+        "description": "Foreign table columns.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "TEXT",
+                "VARCHAR",
+                "BOOL",
+                "BIGINT",
+                "DOUBLE PRECISION",
+                "REAL",
+                "TIMESTAMPTZ",
+                "JSON",
+                "TEXT[]",
+                "VARCHAR[]",
+                "BOOL[]",
+                "BIGINT[]",
+                "DOUBLE PRECISION[]",
+                "REAL[]",
+                "JSON[]",
+                "BYTEA"
+              ]
+            }
+          }
+        }
+      },
+      "TableOptions": {
+        "description": "Table options",
+        "title": "Table Options",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FdmTableOptions"
+          },
+          {
+            "$ref": "#/components/schemas/RawTableOptions"
+          }
+        ]
+      },
+      "Table": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "(Custom) Table",
+        "description": "Foreign tables",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/Column_"
+          },
+          "options": {
+            "$ref": "#/components/schemas/TableOptions"
+          },
+          "type": {
+            "$ref": "#/components/schemas/TableType"
+          },
+          "tablename": {
+            "$ref": "#/components/schemas/Tablename"
+          }
+        }
+      },
+      "TableCreated": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "Table Created Response",
+        "description": "Foreign tables",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/Column_"
+          },
+          "options": {
+            "$ref": "#/components/schemas/TableOptions"
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "type": {
+            "type": "string",
+            "title": "Table Type",
+            "enum": [
+              "raw_rows",
+              "view"
+            ]
+          },
+          "tablename": {
+            "$ref": "#/components/schemas/Tablename"
+          }
+        }
+      },
+      "UserCreated": {
+        "type": "object",
+        "required": [
+          "username",
+          "password",
+          "createdTime",
+          "host"
+        ],
+        "description": "A user",
+        "properties": {
+          "host": {
+            "type": "string",
+            "title": "The connection host for the postgres instance.",
+            "example": "fdw.<CLUSTER>.cogniteapp.com"
+          },
+          "username": {
+            "$ref": "#/components/schemas/Username"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password",
+            "description": "Password to authenticate the user on the DB."
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "sessionId": {
+            "type": "integer",
+            "title": "Session ID",
+            "minimum": 1,
+            "maximum": 9007199254740991,
+            "format": "int64",
+            "description": "ID of the session tied to this user."
+          }
+        }
+      },
+      "UpdateItem_SessionCredentials": {
+        "additionalProperties": false,
+        "properties": {
+          "set": {
+            "$ref": "#/components/schemas/SessionCredentials"
+          }
+        },
+        "required": [
+          "set"
+        ],
+        "title": "UpdateItem_SessionCredentials",
+        "type": "object",
+        "description": "Set a new set of session credentials for writing to CDF."
+      },
+      "CreateUser": {
+        "type": "object",
+        "title": "Create User",
+        "additionalProperties": false,
+        "required": [
+          "credentials"
+        ],
+        "properties": {
+          "credentials": {
+            "$ref": "#/components/schemas/SessionCredentials"
+          }
+        }
+      },
+      "UpdateUser": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "credentials": {
+            "$ref": "#/components/schemas/UpdateItem_SessionCredentials"
+          }
+        }
+      },
+      "UserUpdateItem": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "username",
+          "update"
+        ],
+        "properties": {
+          "username": {
+            "$ref": "#/components/schemas/Username"
+          },
+          "update": {
+            "$ref": "#/components/schemas/UpdateUser"
+          }
+        }
+      },
+      "CreateTable_": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "tablename"
+        ],
+        "properties": {
+          "type": {
+            "enum": [
+              "raw_rows",
+              "view"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "tablename": {
+            "type": "string",
+            "title": "Tablename",
+            "maxLength": 60,
+            "minLength": 1,
+            "description": "Name of the foreign table.\\\n__CANNOT__ be any of the the built-in table names found [here](https://docs.cognite.com/cdf/integration/guides/interfaces/ingest_into_raw#create-a-table)\n"
+          }
+        }
+      },
+      "CreateRawTable": {
+        "type": "object",
+        "title": "Create Raw Table",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "options",
+          "columns"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTable_"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "raw_rows"
+                ],
+                "title": "Type",
+                "type": "string"
+              },
+              "options": {
+                "$ref": "#/components/schemas/RawTableOptions"
+              },
+              "columns": {
+                "$ref": "#/components/schemas/Column_"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "CreateFdmTable": {
+        "type": "object",
+        "title": "Create Fdm table",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "tablename",
+          "options"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTable_"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "view"
+                ],
+                "title": "Type",
+                "type": "string"
+              },
+              "options": {
+                "$ref": "#/components/schemas/FdmTableOptions"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "CreateTable": {
+        "type": "object",
+        "title": "Create Table",
+        "additionalProperties": false,
+        "discriminator": {
+          "mapping": {
+            "raw_rows": "#/components/schemas/CreateRawTable",
+            "view": "#/components/schemas/CreateFdmTable"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateRawTable"
+          },
+          {
+            "$ref": "#/components/schemas/CreateFdmTable"
+          }
+        ]
+      },
+      "Items_CreateTable_": {
+        "additionalProperties": false,
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CreateTable"
+            },
+            "title": "Items",
+            "type": "array",
+            "minLength": 1,
+            "maxLength": 10
+          }
+        }
+      },
+      "ItemsWithoutCursor_TableCreated_": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TableCreated"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ItemsWithoutCursor_Table_": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Table"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ItemsWithCursor_Table_": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Table"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          },
+          "nextCursor": {
+            "type": "string",
+            "title": "Next cursor",
+            "description": "Cursor for pagination"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ItemsWithIgnoreUnknown_Tablename_": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "List of postgres table names",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TablenameWrapper"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 10,
+            "minItems": 1
+          },
+          "ignoreUnknownIds": {
+            "type": "boolean",
+            "title": "IgnoreUnknown",
+            "description": "Ignore table names not found"
+          }
+        }
+      },
+      "ItemsWithCursor_User_": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FdwUser"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          },
+          "nextCursor": {
+            "type": "string",
+            "title": "Next cursor",
+            "description": "Cursor for pagination"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ItemsWithoutCursor_User_": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FdwUser"
+            },
+            "title": "Items",
+            "type": "array",
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ItemsWithCursor_UserCreated_": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserCreated"
+            },
+            "title": "Items",
+            "type": "array",
+            "minLength": 1,
+            "maxLength": 10
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "Items_CreateUser_": {
+        "type": "object",
+        "additionalProperties": false,
+        "title": "CreateUser list",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CreateUser"
+            },
+            "title": "Items",
+            "type": "array",
+            "minLength": 1,
+            "maxLength": 10
+          }
+        }
+      },
+      "ItemsWithIgnoreUnknown_Username_": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UsernameWrapper"
+            },
+            "type": "array",
+            "maxItems": 10,
+            "minItems": 1
+          },
+          "ignoreUnknownIds": {
+            "type": "boolean",
+            "description": "Ignore usernames that are not found"
+          }
+        }
+      },
+      "Items_UserUpdate_": {
+        "additionalProperties": false,
+        "title": "Items[UserUpdate]",
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserUpdateItem"
+            },
+            "title": "Items",
+            "maxItems": 10,
+            "minItems": 1
+          }
+        }
+      },
+      "ValidationErrorContent_": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "description": "Cognite API error.",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "description": "HTTP status code.",
+            "format": "int32",
+            "example": 422
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message.",
+            "example": "Extra inputs are not permitted: type"
+          }
+        }
+      },
+      "Instance": {
+        "additionalProperties": false,
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/CogniteExternalId"
+          },
+          "gatewayUrl": {
+            "title": "gatewayUrl",
+            "type": "string",
+            "description": "SAP NetWeaver Gateway URL"
+          },
+          "client": {
+            "title": "client",
+            "type": "integer",
+            "description": "SAP client number"
+          },
+          "username": {
+            "title": "username",
+            "type": "string",
+            "description": "SAP username to use when connecting to the SAP NetWeaver Gateway URL"
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        },
+        "required": [
+          "externalId",
+          "gatewayUrl",
+          "client",
+          "lastUpdatedTime",
+          "createdTime"
+        ],
+        "title": "Instance",
+        "type": "object"
+      },
+      "Endpoint": {
+        "additionalProperties": false,
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/CogniteExternalId"
+          },
+          "endpointType": {
+            "title": "endpointType",
+            "type": "string",
+            "description": "SAP OData endpoint type",
+            "enum": [
+              "notification",
+              "attachment"
+            ]
+          },
+          "instanceId": {
+            "title": "Instance ID",
+            "description": "ID of the SAP instance the endpoint should connect to.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "mappingId": {
+            "title": "SchemaMapping ID",
+            "description": "ID of the schema mapping used by this endpoint to transform the writeback request.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        },
+        "required": [
+          "externalId",
+          "endpointType",
+          "instanceId",
+          "lastUpdatedTime",
+          "createdTime"
+        ],
+        "title": "Endpoint",
+        "type": "object"
+      },
+      "SchemaMapping": {
+        "additionalProperties": false,
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/CogniteExternalId"
+          },
+          "expression": {
+            "type": "string",
+            "description": "Custom transform expression written in the Cognite mapping language.",
+            "maxLength": 2000
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        },
+        "required": [
+          "externalId",
+          "expression",
+          "lastUpdatedTime",
+          "createdTime"
+        ],
+        "title": "SchemaMapping",
+        "type": "object"
+      },
+      "Request": {
+        "additionalProperties": false,
+        "properties": {
+          "endpointId": {
+            "title": "Endpoint ID",
+            "description": "ID of the SAP endpoint the writeback request should be sent to.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "requestId": {
+            "title": "Request ID",
+            "description": "Unique request ID generated by the CDF writeback API.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "request": {
+            "$ref": "#/components/schemas/List_RequestItem_"
+          },
+          "status": {
+            "title": "status",
+            "type": "string",
+            "description": "Status of a writeback request",
+            "enum": [
+              "pending",
+              "in_progress",
+              "done",
+              "failed"
+            ]
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        },
+        "required": [
+          "endpointId",
+          "requestId",
+          "request",
+          "status",
+          "lastUpdatedTime",
+          "createdTime"
+        ],
+        "title": "Request",
+        "type": "object"
+      },
+      "RequestMinimal": {
+        "additionalProperties": false,
+        "properties": {
+          "requestId": {
+            "title": "Request ID",
+            "description": "Unique request ID generated by the CDF writeback API.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "request": {
+            "$ref": "#/components/schemas/List_RequestItemMinimal_"
+          },
+          "status": {
+            "title": "status",
+            "type": "string",
+            "description": "Status of the writeback request",
+            "enum": [
+              "pending",
+              "in_progress",
+              "done",
+              "failed"
+            ]
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Writeback request error message. This field only contains data when the writeback request status is set to `failed`"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        },
+        "required": [
+          "requestId",
+          "request",
+          "status",
+          "lastUpdatedTime",
+          "createdTime"
+        ],
+        "title": "Request",
+        "type": "object"
+      },
+      "RequestFull": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "title": "Request ID",
+            "description": "Unique request ID generated by the CDF writeback API.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "request": {
+            "$ref": "#/components/schemas/List_RequestItemFull_"
+          },
+          "status": {
+            "title": "status",
+            "type": "string",
+            "description": "Writeback request status",
+            "enum": [
+              "pending",
+              "in_progress",
+              "done",
+              "failed"
+            ]
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "errorMessage": {
+            "title": "errorMessage",
+            "type": "string",
+            "description": "Writeback request error message. This field only contains data when the request status is set to `failed`"
+          }
+        },
+        "required": [
+          "endpointId",
+          "requestId",
+          "request",
+          "status",
+          "lastUpdatedTime",
+          "createdTime"
+        ],
+        "title": "Request Full"
+      },
+      "CreateRequestResponse": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "title": "Request ID",
+            "description": "Unique request ID generated by the CDF writeback API.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "request": {
+            "$ref": "#/components/schemas/List_CreateRequestItemResponse_"
+          },
+          "status": {
+            "title": "status",
+            "type": "string",
+            "description": "Writeback request status",
+            "enum": [
+              "pending",
+              "in_progress",
+              "done",
+              "failed"
+            ]
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        },
+        "required": [
+          "endpointId",
+          "requestId",
+          "request",
+          "status",
+          "lastUpdatedTime",
+          "createdTime"
+        ],
+        "title": "Request Full"
+      },
+      "RequestItem": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "title": "key",
+            "description": "External object key related to this request",
+            "type": "string",
+            "maxLength": 255
+          },
+          "payload": {
+            "title": "payload",
+            "description": "Payload to send to the SAP endpoint",
+            "type": "object"
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "RequestItem"
+      },
+      "CreateRequestItemResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "title": "payload",
+            "description": "Payload to send to the SAP endpoint",
+            "type": "object"
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "Create RequestItem Response"
+      },
+      "RequestItemFull": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "title": "key",
+            "description": "External object key related to this request",
+            "type": "string",
+            "maxLength": 255
+          },
+          "payload": {
+            "title": "payload",
+            "description": "Payload to send to the SAP endpoint",
+            "type": "object"
+          },
+          "sapObjectId": {
+            "title": "sapObjectId",
+            "description": "Object key of the created records in the SAP destination.",
+            "type": "string",
+            "maxLength": 255
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "Instance",
+        "type": "object"
+      },
+      "RequestItemMinimal": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "title": "key",
+            "description": "External object key related to this request",
+            "type": "string",
+            "maxLength": 255
+          },
+          "sapObjectId": {
+            "title": "sapObjectId",
+            "description": "Object key of the created records in the SAP destination.",
+            "type": "string",
+            "maxLength": 255
+          }
+        },
+        "title": "Request Item Minimal",
+        "type": "object"
+      },
+      "List_RequestItem_": {
+        "items": {
+          "$ref": "#/components/schemas/RequestItem"
+        },
+        "title": "List RequestItem",
+        "type": "array",
+        "maxItems": 1000,
+        "minItems": 0
+      },
+      "List_CreateRequestItemResponse_": {
+        "items": {
+          "$ref": "#/components/schemas/CreateRequestItemResponse"
+        },
+        "title": "List RequestItem",
+        "type": "array",
+        "maxItems": 1000,
+        "minItems": 0
+      },
+      "List_RequestItemMinimal_": {
+        "items": {
+          "$ref": "#/components/schemas/RequestItemMinimal"
+        },
+        "title": "List RequestItem Minimal",
+        "type": "array",
+        "maxItems": 1000,
+        "minItems": 0
+      },
+      "List_RequestItemFull_": {
+        "additionalProperties": false,
+        "items": {
+          "$ref": "#/components/schemas/RequestItemFull"
+        },
+        "title": "List RequestItem Full",
+        "type": "array",
+        "maxItems": 1000,
+        "minItems": 0
+      },
+      "List_CreateRequestItem_": {
+        "additionalProperties": false,
+        "items": {
+          "$ref": "#/components/schemas/CreateRequestItem"
+        },
+        "title": "List CreateRequestItem",
+        "type": "array",
+        "maxItems": 1000,
+        "minItems": 0
+      },
+      "CreateInstance": {
+        "additionalProperties": false,
+        "properties": {
+          "externalId": {
+            "title": "External ID",
+            "$ref": "#/components/schemas/CogniteExternalId"
+          },
+          "gatewayUrl": {
+            "title": "gatewayUrl",
+            "type": "string",
+            "description": "SAP NetWeaver Gateway URL"
+          },
+          "client": {
+            "title": "client",
+            "type": "integer",
+            "description": "SAP client number"
+          },
+          "username": {
+            "title": "username",
+            "type": "string",
+            "description": "SAP username to use when connecting to the SAP NetWeaver Gateway URL"
+          },
+          "password": {
+            "title": "password",
+            "type": "string",
+            "description": "SAP password to use when connecting to the SAP NetWeaver Gateway URL"
+          }
+        },
+        "required": [
+          "externalId",
+          "gatewayUrl",
+          "client",
+          "username",
+          "password"
+        ],
+        "title": "CreateInstance",
+        "type": "object"
+      },
+      "CreateEndpoint": {
+        "additionalProperties": false,
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/CogniteExternalId"
+          },
+          "endpointType": {
+            "title": "endpointType",
+            "type": "string",
+            "description": "SAP OData endpoint",
+            "enum": [
+              "notification",
+              "attachment"
+            ]
+          },
+          "instanceId": {
+            "title": "Instance ID",
+            "description": "External ID of the SAP instance the endpoint should connect to.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "mappingId": {
+            "title": "SchemaMapping ID",
+            "description": "External ID of the schema mapping this endpoint should use to transform the writeback request.",
+            "type": "string",
+            "maxLength": 255
+          }
+        },
+        "required": [
+          "externalId",
+          "endpointType",
+          "instanceId"
+        ],
+        "title": "Instance",
+        "type": "object"
+      },
+      "CreateSchemaMapping": {
+        "additionalProperties": false,
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/CogniteExternalId"
+          },
+          "expression": {
+            "type": "string",
+            "description": "Custom transform expression written in the Cognite mapping language.",
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "externalId",
+          "expression"
+        ],
+        "title": "Create SchemaMapping",
+        "type": "object"
+      },
+      "CreateRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "endpointId": {
+            "title": "Endpoint ID",
+            "description": "External ID of the SAP endpoint the writeback request should be sent to.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "request": {
+            "$ref": "#/components/schemas/List_CreateRequestItem_"
+          }
+        },
+        "required": [
+          "endpointId",
+          "request"
+        ],
+        "title": "CreateRequest",
+        "type": "object"
+      },
+      "CreateRequestItem": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "title": "key",
+            "description": "External object key related to this request.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "fileId": {
+            "title": "fileId",
+            "description": "CDF File external Id. Only use when the SAP endpoint type is 'attachment'",
+            "type": "string",
+            "maxLength": 255
+          },
+          "payload": {
+            "title": "payload",
+            "description": "Payload to send to the SAP endpoint",
+            "type": "object"
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "Instance",
+        "type": "object"
+      },
+      "Items_Instance_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Instance"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_Endpoint_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Endpoint"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_SchemaMapping_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SchemaMapping"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_Request_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Request"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_RequestMinimal_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RequestMinimal"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_RequestFull_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RequestFull"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_CreateRequest_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CreateRequest"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_CreateRequestResponse_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CreateRequestResponse"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceList",
+        "type": "object"
+      },
+      "Items_CreateInstance_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CreateInstance"
+            },
+            "title": "Items",
+            "type": "array",
+            "minLength": 1,
+            "maxLength": 100
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "CreateInstancelist",
+        "type": "object"
+      },
+      "Items_CreateEndpoint_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CreateEndpoint"
+            },
+            "title": "Items",
+            "type": "array",
+            "minLength": 1,
+            "maxLength": 100
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "CreateEndpoint list",
+        "type": "object"
+      },
+      "Items_CreateSchemaMapping_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CreateSchemaMapping"
+            },
+            "title": "Items",
+            "type": "array",
+            "minLength": 1,
+            "maxLength": 100
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "CreateSchemaMapping list",
+        "type": "object"
+      },
+      "ItemsWithCursor_Instance_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Instance"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          },
+          "nextCursor": {
+            "type": "string",
+            "title": "Next cursor",
+            "description": "Cursor for pagination"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "InstanceListWithCursor",
+        "type": "object"
+      },
+      "ItemsWithCursor_Endpoint_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Endpoint"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          },
+          "nextCursor": {
+            "type": "string",
+            "title": "Next cursor",
+            "description": "Cursor for pagination"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "EndpointListWithCursor",
+        "type": "object"
+      },
+      "ItemsWithCursor_SchemaMapping_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SchemaMapping"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          },
+          "nextCursor": {
+            "type": "string",
+            "title": "Next cursor",
+            "description": "Cursor for pagination"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "MappingList",
+        "type": "object"
+      },
+      "ItemsWithCursor_ListRequestMinimal_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RequestMinimal"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 0
+          },
+          "nextCursor": {
+            "type": "string",
+            "title": "Next cursor",
+            "description": "Cursor for pagination"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "MappingList",
+        "type": "object"
+      },
+      "WritebackRequestId": {
+        "description": "Unique request ID generated by the CDF writeback API.",
+        "type": "string",
+        "maxLength": 255
+      },
+      "RequestIdWrapper": {
+        "additionalProperties": false,
+        "properties": {
+          "requestId": {
+            "$ref": "#/components/schemas/WritebackRequestId"
+          }
+        },
+        "required": [
+          "externalId"
+        ],
+        "title": "WritebackExternalIdWrapper",
+        "type": "object"
+      },
+      "ItemsWithIgnoreUnknownIds_RequestId_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RequestIdWrapper"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1
+          },
+          "ignoreUnknownIds": {
+            "type": "boolean",
+            "title": "IgnoreUnknownIds",
+            "description": "Ignore IDs and external IDs that are not found"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "ItemsWithIgnoreUnknownIds_RequestId",
+        "type": "object"
+      },
+      "ConnectionCheckContent": {
+        "type": "object",
+        "required": [
+          "status",
+          "error_message"
+        ],
+        "description": "Cognite API error.",
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "status",
+            "description": "Connectivity status between the writeback API and the SAP destination endpoint. `success` means that the CDF writeback API has successfully connected to the SAP endpoint destination.",
+            "default": "success"
+          },
+          "detail": {
+            "type": "string",
+            "description": "Description of the connection check"
+          }
+        }
+      },
+      "WritebackExternalIdWrapper": {
+        "additionalProperties": false,
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/CogniteExternalId"
+          }
+        },
+        "required": [
+          "externalId"
+        ],
+        "title": "WritebackExternalIdWrapper",
+        "type": "object"
+      },
+      "WritebackItemsWithIgnoreUnknownIds_ExternalId_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/WritebackExternalIdWrapper"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1
+          },
+          "ignoreUnknownIds": {
+            "type": "boolean",
+            "title": "IgnoreUnknownIds",
+            "description": "Ignore IDs and external IDs that are not found"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "ItemsWithIgnoreUnknownIds_ExternalId",
+        "type": "object"
+      },
+      "WritebackItemsWithIgnoreUnknownIdsAndForce_ExternalId_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/WritebackExternalIdWrapper"
+            },
+            "title": "Items",
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1
+          },
+          "ignoreUnknownIds": {
+            "type": "boolean",
+            "title": "IgnoreUnknownIds",
+            "description": "Ignore IDs and external IDs that are not found."
+          },
+          "force": {
+            "type": "boolean",
+            "title": "Force",
+            "description": "Delete any jobs associated with each item."
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "ItemsWithIgnoreUnknownIdsAndForce_ExternalId",
+        "type": "object"
+      },
+      "WritebackValidationErrorContent": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "description": "Cognite API error.",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "description": "HTTP status code.",
+            "format": "int32",
+            "example": 422
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message.",
+            "example": "Extra inputs are not permitted: type"
+          }
+        }
       },
       "APIError": {
         "properties": {
@@ -60536,6 +69827,763 @@
           "PUBLIC",
           "PRIVATE"
         ]
+      },
+      "LocationFilterRead": {
+        "type": "object",
+        "required": [
+          "id",
+          "createdTime",
+          "lastUpdatedTime"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LocationFilterWrite"
+          }
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/CogniteInternalId"
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          },
+          "lastUpdatedTime": {
+            "$ref": "#/components/schemas/EpochTimestamp"
+          }
+        }
+      },
+      "LocationFilterWrite": {
+        "type": "object",
+        "required": [
+          "externalId",
+          "name"
+        ],
+        "properties": {
+          "externalId": {
+            "$ref": "#/components/schemas/CogniteExternalId"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the location filter",
+            "maxLength": 255
+          },
+          "parentId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CogniteInternalId"
+              }
+            ],
+            "description": "The ID of the parent location filter"
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the location filter",
+            "maxLength": 255
+          },
+          "dataModels": {
+            "type": "array",
+            "description": "The data models in the location filter",
+            "items": {
+              "$ref": "#/components/schemas/LocationFilterDataModel"
+            }
+          },
+          "instanceSpaces": {
+            "type": "array",
+            "description": "The list of spaces that instances are in",
+            "items": {
+              "type": "string"
+            }
+          },
+          "scene": {
+            "$ref": "#/components/schemas/LocationFilterScene"
+          },
+          "assetCentric": {
+            "$ref": "#/components/schemas/LocationFilterAssetCentric"
+          },
+          "views": {
+            "type": "array",
+            "description": "The list of view mappings",
+            "items": {
+              "$ref": "#/components/schemas/LocationFilterView"
+            }
+          }
+        }
+      },
+      "LocationFilterView": {
+        "type": "object",
+        "description": "The view mappings for the location filter",
+        "required": [
+          "externalId",
+          "space",
+          "version",
+          "representsEntity"
+        ],
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "description": "The external ID of the view"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space that the view belongs to"
+          },
+          "version": {
+            "type": "string",
+            "description": "The version of the view"
+          },
+          "representsEntity": {
+            "type": "string",
+            "enum": [
+              "MAINTENANCE_ORDER",
+              "OPERATION",
+              "NOTIFICATION",
+              "ASSET"
+            ]
+          }
+        }
+      },
+      "LocationFilterAssetCentric": {
+        "type": "object",
+        "description": "The filter definition for asset centric resource types",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LocationFilterAssetCentricBaseFilter"
+          }
+        ],
+        "properties": {
+          "assets": {
+            "$ref": "#/components/schemas/LocationFilterAssetCentricBaseFilter"
+          },
+          "events": {
+            "$ref": "#/components/schemas/LocationFilterAssetCentricBaseFilter"
+          },
+          "files": {
+            "$ref": "#/components/schemas/LocationFilterAssetCentricBaseFilter"
+          },
+          "timeseries": {
+            "$ref": "#/components/schemas/LocationFilterAssetCentricBaseFilter"
+          },
+          "sequences": {
+            "$ref": "#/components/schemas/LocationFilterAssetCentricBaseFilter"
+          }
+        }
+      },
+      "LocationFilterAssetCentricBaseFilter": {
+        "type": "object",
+        "properties": {
+          "dataSetIds": {
+            "type": "array",
+            "description": "The list of data set IDs",
+            "items": {
+              "type": "number"
+            }
+          },
+          "assetSubtreeIds": {
+            "type": "array",
+            "description": "The list of asset subtree IDs",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/IdEither"
+                }
+              ]
+            }
+          },
+          "externalIdPrefix": {
+            "type": "string",
+            "description": "The external ID prefix"
+          }
+        }
+      },
+      "LocationFilterDataModel": {
+        "type": "object",
+        "required": [
+          "externalId",
+          "space",
+          "version"
+        ],
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "description": "The external ID of the data model"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space of the data model"
+          },
+          "version": {
+            "type": "string",
+            "description": "The version of the data model"
+          }
+        }
+      },
+      "LocationFilterScene": {
+        "type": "object",
+        "description": "The scene config for the location filter",
+        "required": [
+          "externalId",
+          "space",
+          "version"
+        ],
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "description": "The external ID of the scene"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space that the scene is in"
+          }
+        }
+      },
+      "OrgId": {
+        "type": "string",
+        "description": "The ID of an organization",
+        "minLength": 3,
+        "maxLength": 64,
+        "example": "my-org",
+        "pattern": "^([a-z][a-z0-9-]{1,62}[a-z0-9])$"
+      },
+      "ClusterName": {
+        "type": "string",
+        "description": "A CDF cluster name",
+        "minLength": 1,
+        "maxLength": 32,
+        "pattern": "^[a-z0-9-]{1,32}$",
+        "example": "westeurope-1"
+      },
+      "MigrationStatus": {
+        "type": "string",
+        "description": "This attribute will be removed in a future version, and it is recommended to not send it in requests and to ignore it in responses.\nIf it is present, the single valid value is equivalent to the attribute being null or absent.",
+        "enum": [
+          "EXCLUSIVE_LOGIN"
+        ]
+      },
+      "ExternalGroupId": {
+        "type": "string",
+        "description": "The ID of a group managed by the external identity provider",
+        "minLength": 3,
+        "maxLength": 64,
+        "example": "my-external-group"
+      },
+      "NullableExternalGroupId": {
+        "type": "string",
+        "description": "The ID of a group managed by the external identity provider.",
+        "minLength": 3,
+        "maxLength": 64,
+        "example": "my-external-group"
+      },
+      "IdentityProvider": {
+        "description": "Configuration for an external OIDC-compliant IdP.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AzureAdIdp"
+          },
+          {
+            "$ref": "#/components/schemas/Auth0Idp"
+          },
+          {
+            "$ref": "#/components/schemas/KeycloakIdp"
+          },
+          {
+            "$ref": "#/components/schemas/SAuthIdp"
+          }
+        ]
+      },
+      "IdpBase": {
+        "type": "object",
+        "required": [
+          "issuer"
+        ],
+        "properties": {
+          "issuer": {
+            "type": "string",
+            "format": "url",
+            "example": "https://login.microsoftonline.com/some-tenant-id/v2.0",
+            "description": "The issuer for the external IdP."
+          }
+        }
+      },
+      "AzureAdIdp": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Azure AD IdP configuration",
+            "required": [
+              "idpVendor"
+            ],
+            "properties": {
+              "idpVendor": {
+                "type": "string",
+                "enum": [
+                  "AZURE_AD"
+                ]
+              },
+              "issuer": {
+                "example": "https://login.microsoftonline.com/some-tenant-id/v2.0",
+                "description": "The issuer for the external IdP. For Azure AD, it conforms to the example URL and contains the tenant ID."
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/IdpBase"
+          }
+        ]
+      },
+      "Auth0Idp": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IdpBase"
+          },
+          {
+            "type": "object",
+            "description": "Auth0 IdP configuration",
+            "required": [
+              "idpVendor",
+              "clientId",
+              "clientSecret",
+              "groupsClaimName"
+            ],
+            "properties": {
+              "idpVendor": {
+                "type": "string",
+                "enum": [
+                  "AUTH0"
+                ]
+              },
+              "clientId": {
+                "type": "string",
+                "description": "The client ID of the Auth0 application"
+              },
+              "clientSecret": {
+                "type": "string",
+                "format": "password",
+                "description": "The client secret of the Auth0 application. It is write-only and cannot be read."
+              },
+              "groupsClaimName": {
+                "description": "The name of the claim that contains the groups in the token",
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9_\\-./:]{0,31}(?<![^a-z0-9])$",
+                "minLength": 1,
+                "maxLength": 32,
+                "example": "my-groups-claim"
+              },
+              "extraAuthParameters": {
+                "type": "array",
+                "description": "Extra parameters to be sent to the Auth0 token endpoint",
+                "items": {
+                  "$ref": "#/components/schemas/ExtraAuthParameter"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "KeycloakIdp": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IdpBase"
+          },
+          {
+            "type": "object",
+            "description": "Keycloak IdP configuration",
+            "required": [
+              "idpVendor",
+              "clientId"
+            ],
+            "properties": {
+              "idpVendor": {
+                "type": "string",
+                "enum": [
+                  "KEYCLOAK"
+                ]
+              },
+              "clientId": {
+                "type": "string",
+                "description": "The client ID of the Keycloak application"
+              }
+            }
+          }
+        ]
+      },
+      "SAuthIdp": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IdpBase"
+          },
+          {
+            "type": "object",
+            "description": "SAuth IdP configuration",
+            "required": [
+              "idpVendor",
+              "clientId",
+              "clientSecret",
+              "appKey",
+              "groupsUrl",
+              "idTokenAudience",
+              "extraScope"
+            ],
+            "properties": {
+              "idpVendor": {
+                "type": "string",
+                "enum": [
+                  "SAUTH"
+                ]
+              },
+              "clientId": {
+                "type": "string",
+                "description": "The client ID of the SAuth application"
+              },
+              "clientSecret": {
+                "type": "string",
+                "format": "password",
+                "description": "The client secret of the SAuth application. It is write-only and cannot be read."
+              },
+              "appKey": {
+                "type": "string",
+                "format": "password",
+                "description": "The app key of the SAuth application. It is write-only and cannot be read."
+              },
+              "groupsUrl": {
+                "type": "string",
+                "description": "The URL for the group membership callback endpoint of the SAuth server."
+              },
+              "idTokenAudience": {
+                "type": "string",
+                "description": "The expected value of the `aud` claim in the SAuth identity tokens."
+              },
+              "extraScope": {
+                "type": "string",
+                "description": "The extra scope to request from SAuth, in addition to the standard scopes `openid offline_access profile email`."
+              }
+            }
+          }
+        ]
+      },
+      "ExtraAuthParameter": {
+        "type": "object",
+        "description": "Extra parameters to send to the external IdP",
+        "required": [
+          "name",
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the parameter"
+          },
+          "value": {
+            "type": "string",
+            "description": "The value of the parameter"
+          }
+        }
+      },
+      "ContactPerson": {
+        "type": "object",
+        "description": "A contact person for an organization",
+        "required": [
+          "id",
+          "email"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          }
+        }
+      },
+      "Organization": {
+        "description": "An organization",
+        "type": "object",
+        "required": [
+          "id",
+          "parentId",
+          "idp",
+          "adminsCanCreateOrgsInSubtree",
+          "adminsCanCreateProjectsInSubtree",
+          "allowedClusters"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/OrgId"
+          },
+          "parentId": {
+            "allOf": [
+              {
+                "description": "The ID of the parent organization"
+              },
+              {
+                "$ref": "#/components/schemas/OrgId"
+              }
+            ]
+          },
+          "idp": {
+            "$ref": "#/components/schemas/IdentityProvider"
+          },
+          "adminGroupId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalGroupId"
+              },
+              {
+                "description": "The ID of the externally managed group that contains the organization's admins.",
+                "default": null
+              }
+            ]
+          },
+          "adminsCanCreateOrgsInSubtree": {
+            "type": "boolean",
+            "description": "Whether admins of the new organization are allowed to create organizations in the subtree of the\norganization.",
+            "default": false
+          },
+          "adminsCanCreateProjectsInSubtree": {
+            "type": "boolean",
+            "description": "Whether admins of the new organization are allowed to create CDF projects in the subtree of the\norganization.",
+            "default": false
+          },
+          "allowedClusters": {
+            "type": "array",
+            "description": "The clusters on which the admins of the organization will be able to create projects.\nThis must be a (non-strict) subset of the `allowedClusters` set of the parent organization.",
+            "default": [],
+            "example": [
+              "westeurope-1",
+              "asia-northeast1-1"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ClusterName"
+            }
+          }
+        }
+      },
+      "OrganizationWithContactPersons": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Organization"
+          },
+          {
+            "description": "An organization"
+          }
+        ]
+      },
+      "ClustersListRequestResponse": {
+        "type": "object",
+        "required": [
+          "clusters"
+        ],
+        "properties": {
+          "clusters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClusterName"
+            }
+          }
+        }
+      },
+      "ProjectCreateRequest": {
+        "type": "object",
+        "required": [
+          "name",
+          "clusterName"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/ProjectUrlName"
+          },
+          "clusterName": {
+            "$ref": "#/components/schemas/ClusterName"
+          },
+          "projectAdminGroupId": {
+            "allOf": [
+              {
+                "description": "The ID of the externally-managed group that contains the project's admins.\n\n- If omitted, the project will inherit the admin group ID of the organization under which it is created.\n  That value might be `null`.\n- If set to a (non-null) string, the project will have that group as its admin group, overriding\n  the organization's admin group ID.\n- If explicitly set to `null`, the project will not have an admin group ID. Note that this will make the\n  project inaccessible, and only a Cognite admin can make it accessible."
+              },
+              {
+                "$ref": "#/components/schemas/NullableExternalGroupId"
+              }
+            ]
+          }
+        }
+      },
+      "ProjectResponse": {
+        "type": "object",
+        "required": [
+          "name",
+          "apiUrl"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/ProjectUrlName"
+          },
+          "apiUrl": {
+            "$ref": "#/components/schemas/ProjectApiUrl"
+          }
+        }
+      },
+      "ProjectWithAdminPropertiesResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ProjectResponse"
+          },
+          {
+            "type": "object",
+            "required": [
+              "clusterName"
+            ],
+            "properties": {
+              "clusterName": {
+                "$ref": "#/components/schemas/ClusterName"
+              }
+            }
+          }
+        ]
+      },
+      "ProjectInternalV0Response": {
+        "type": "object",
+        "required": [
+          "name",
+          "apiUrl"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/ProjectUrlName"
+          },
+          "apiUrl": {
+            "$ref": "#/components/schemas/ProjectApiUrl"
+          },
+          "dataModelingStatus": {
+            "$ref": "#/components/schemas/DataModelingStatus"
+          }
+        }
+      },
+      "ProjectApiUrl": {
+        "type": "string",
+        "format": "url",
+        "description": "The base API URL for the project",
+        "example": "https://api.cognitedata.com"
+      },
+      "OrganizationRequestItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "idp"
+        ],
+        "properties": {
+          "id": {
+            "allOf": [
+              {
+                "description": "The ID of the new organization",
+                "example": "new-org"
+              },
+              {
+                "$ref": "#/components/schemas/OrgId"
+              }
+            ]
+          },
+          "idp": {
+            "$ref": "#/components/schemas/IdentityProvider"
+          },
+          "adminGroupId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalGroupId"
+              },
+              {
+                "description": "The ID of the externally managed group that contains the organization's admins.",
+                "default": null
+              }
+            ]
+          },
+          "adminsCanCreateOrgsInSubtree": {
+            "type": "boolean",
+            "description": "Whether admins of the new organization are allowed to create organizations in the subtree of the\norganization.",
+            "default": false
+          },
+          "adminsCanCreateProjectsInSubtree": {
+            "type": "boolean",
+            "description": "Whether admins of the new organization are allowed to create CDF projects in the subtree of the\norganization.",
+            "default": false
+          },
+          "allowedClusters": {
+            "type": "array",
+            "description": "The clusters on which the admins of the organization will be able to create projects.\nThis must be a (non-strict) subset of the `allowedClusters` set of the parent organization.",
+            "default": [],
+            "example": [
+              "westeurope-1",
+              "asia-northeast1-1"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ClusterName"
+            }
+          }
+        }
+      },
+      "OrganizationResponseItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "idp"
+        ],
+        "properties": {
+          "id": {
+            "allOf": [
+              {
+                "description": "The ID of the new organization",
+                "example": "new-org"
+              },
+              {
+                "$ref": "#/components/schemas/OrgId"
+              }
+            ]
+          },
+          "idp": {
+            "$ref": "#/components/schemas/IdentityProvider"
+          },
+          "adminGroupId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalGroupId"
+              },
+              {
+                "description": "The ID of the externally managed group that contains the organization's admins.",
+                "default": null
+              }
+            ]
+          },
+          "adminsCanCreateOrgsInSubtree": {
+            "type": "boolean",
+            "description": "Whether admins of the new organization are allowed to create organizations in the subtree of the\norganization.",
+            "default": false
+          },
+          "adminsCanCreateProjectsInSubtree": {
+            "type": "boolean",
+            "description": "Whether admins of the new organization are allowed to create CDF projects in the subtree of the\norganization.",
+            "default": false
+          },
+          "allowedClusters": {
+            "type": "array",
+            "description": "The clusters on which the admins of the organization will be able to create projects.\nThis must be a (non-strict) subset of the `allowedClusters` set of the parent organization.",
+            "default": [],
+            "example": [
+              "westeurope-1",
+              "asia-northeast1-1"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ClusterName"
+            }
+          }
+        }
       }
     },
     "parameters": {
@@ -60572,7 +70620,7 @@
         "in": "query",
         "name": "partition",
         "required": false,
-        "description": "Splits the data set into `N` partitions. \nThe attribute is specified as a \"M/N\" string, where `M` is a natural number in the interval of `[1, N]`.\nYou need to follow the cursors within each partition in order to receive all the data.\n\nTo prevent unexpected problems and maximize read throughput, you should at most use 10 (N <= 10) partitions.\n\nWhen using more than 10 partitions, CDF may reduce the number of partitions silently.\nFor example, CDF may reduce the number of partitions to `K = 10` so if you specify an `X/N` `partition` value where `X = 8` and `N = 20` - i.e. `\"partition\": \"8/20\"`- then\nCDF will change `N` to `N = K = 10` and process the request. \nBut if you  specify the `X/N` `partition` value where `X = 11` (`X > K`) and `N = 20` - i.e. `\"partition\": \"11/20\"`- then\nCDF will reply with an empty result list and no cursor in the response.  \n\nIn future releases of the resource APIs, Cognite may reject requests if you specify more than 10 partitions.\nWhen Cognite enforces this behavior, the requests will result in a 400 Bad Request status.\n",
+        "description": "Splits the data set into `N` partitions.\nThe attribute is specified as a \"M/N\" string, where `M` is a natural number in the interval of `[1, N]`.\nYou need to follow the cursors within each partition in order to receive all the data.\n\nTo prevent unexpected problems and maximize read throughput, you should at most use 10 (N <= 10) partitions.\n\nWhen using more than 10 partitions, CDF may reduce the number of partitions silently.\nFor example, CDF may reduce the number of partitions to `K = 10` so if you specify an `X/N` `partition` value where `X = 8` and `N = 20` - i.e. `\"partition\": \"8/20\"`- then\nCDF will change `N` to `N = K = 10` and process the request.\nBut if you  specify the `X/N` `partition` value where `X = 11` (`X > K`) and `N = 20` - i.e. `\"partition\": \"11/20\"`- then\nCDF will reply with an empty result list and no cursor in the response.\n\nIn future releases of the resource APIs, Cognite may reject requests if you specify more than 10 partitions.\nWhen Cognite enforces this behavior, the requests will result in a 400 Bad Request status.\n",
         "schema": {
           "type": "string",
           "example": "1/10"
@@ -60647,7 +70695,7 @@
       },
       "ReducedLimit": {
         "name": "limit",
-        "description": "Limit the number of results returned. The largest result-set returned by the server will be 1000 items, even   if you specify a higher limit.",
+        "description": "Limit the number of results returned. The largest result-set returned by the server will be 1000 items, even if you specify a higher limit.",
         "in": "query",
         "schema": {
           "type": "integer",
@@ -60934,6 +70982,46 @@
           "minimum": 1,
           "maximum": 100
         }
+      },
+      "100Limit_": {
+        "name": "limit",
+        "description": "Limits the number of results to be returned. The maximum results returned by the server is 100 even if you specify a higher limit.",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "default": 100,
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "Username": {
+        "name": "username",
+        "description": "The name of the username (a.k.a. database) to be managed from the API",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Username"
+        }
+      },
+      "Writeback100Limit": {
+        "name": "limit",
+        "description": "Limits the number of results to be returned. The maximum results returned by the server is 100 even if you specify a higher limit.",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "default": 100,
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "OrgId": {
+        "name": "org",
+        "in": "path",
+        "description": "ID of an organization",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/OrgId"
+        }
       }
     },
     "responses": {
@@ -61137,6 +71225,27 @@
           }
         }
       },
+      "AggregationResponseV2": {
+        "description": "Aggregated query results",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "aggregates"
+              ],
+              "properties": {
+                "typing": {
+                  "$ref": "#/components/schemas/TypeInformationOuter"
+                },
+                "aggregates": {
+                  "$ref": "#/components/schemas/AggregatesResultDefinition"
+                }
+              }
+            }
+          }
+        }
+      },
       "ByIdsResponse": {
         "description": "List of matching nodes and edges",
         "content": {
@@ -61210,6 +71319,28 @@
                         "description": "The value to use for the cursor"
                       }
                     ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "InstanceInspectResponse": {
+        "description": "Instances along with which containers/views they are associated with",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "description": "List of instance inspection results",
+                  "items": {
+                    "$ref": "#/components/schemas/InstanceInspectResultItem"
                   }
                 }
               }
@@ -61402,6 +71533,28 @@
                 },
                 "nextCursor": {
                   "$ref": "#/components/schemas/NextCursorV3"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ContainerInspectResponse": {
+        "description": "Containers along with the results of the inspection operations",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "description": "List of container inspection results",
+                  "items": {
+                    "$ref": "#/components/schemas/ContainerInspectResultItem"
+                  }
                 }
               }
             }
@@ -61681,6 +71834,107 @@
           }
         }
       },
+      "LogIngestResponse": {
+        "description": "Empty response in the case of a success.\n",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "title": "emptyResponse",
+              "description": "Currently, empty result in the case of a success logs ingestion.\n"
+            }
+          }
+        }
+      },
+      "LogListResponse": {
+        "description": "List of matching logs.\n",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "title": "logItems",
+                  "description": "List of logs.\n",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Log"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "LogAggregationResponse": {
+        "description": "Aggregated query results.\n",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "aggregates"
+              ],
+              "properties": {
+                "aggregates": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AggregatesResultDefinitionIla"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "LogSyncResponse": {
+        "description": "The next chunk of matching the filter logs starting from the cursor in the request.\n",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items",
+                "hasNext"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "title": "logItems",
+                  "description": "List of logs.\n",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Log"
+                      }
+                    ]
+                  }
+                },
+                "nextCursor": {
+                  "type": "string",
+                  "title": "nextCursor",
+                  "description": "A cursor to use in the next request as a starting point to get the next chunk of logs.\n",
+                  "example": "c29tZSBjdXJzb3I="
+                },
+                "hasNext": {
+                  "type": "boolean",
+                  "title": "hasNext",
+                  "description": "The attribute indicates if there are more logs to read in the storage or the cursor points to the last item.\n",
+                  "example": true
+                }
+              }
+            }
+          }
+        }
+      },
       "EventDataResponse": {
         "description": "Paged response with list of events",
         "content": {
@@ -61736,7 +71990,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/UploadFileMetadata"
+              "$ref": "#/components/schemas/DataFileUploadFileMetadata"
             }
           }
         }
@@ -61746,7 +72000,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/MultiPartUploadFileMetadata"
+              "$ref": "#/components/schemas/DataMultiPartUploadFileMetadata"
             }
           }
         }
@@ -62143,6 +72397,13 @@
                     "properties": {
                       "urlName": {
                         "$ref": "#/components/schemas/ProjectUrlName"
+                      },
+                      "dataModelingStatus": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/DataModelingStatus"
+                          }
+                        ]
                       }
                     }
                   }
@@ -62769,6 +73030,48 @@
           }
         }
       },
+      "DocumentSemanticSearchResponse": {
+        "description": "List of most relevant document passages for a given query. The results are sorted by relevance, and contains metadata such as page numbers.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DocumentSemanticSearchItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "DocumentStatusResponse": {
+        "description": "List of documents and their status to signify if they are ready for search.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DocumentStatusItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "DocumentsAggregateResponse": {
         "description": "The results of an aggregation request. The object returned depends on the aggregate specified.",
         "content": {
@@ -62849,6 +73152,27 @@
                       "$ref": "#/components/schemas/EpochTimestamp"
                     }
                   ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "DocumentElementsResponse": {
+        "description": "Parsed textual content for the document",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "elements"
+              ],
+              "properties": {
+                "elements": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DocumentElement"
+                  }
                 }
               }
             }
@@ -63095,6 +73419,16 @@
           }
         }
       },
+      "UserListResponseDto": {
+        "description": "A list of organization users",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/UserListResponse"
+            }
+          }
+        }
+      },
       "ValidationError": {
         "description": "Validation Error",
         "content": {
@@ -63107,6 +73441,294 @@
               "properties": {
                 "error": {
                   "$ref": "#/components/schemas/ValidationErrorContent"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ValidationError_": {
+        "description": "Validation Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "$ref": "#/components/schemas/ValidationErrorContent_"
+                }
+              }
+            }
+          }
+        }
+      },
+      "WritebackValidationError": {
+        "description": "Validation Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "$ref": "#/components/schemas/WritebackValidationErrorContent"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ConnectionCheck": {
+        "description": "Connection Check Result",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "$ref": "#/components/schemas/ConnectionCheckContent"
+                }
+              }
+            }
+          }
+        }
+      },
+      "LocationFilterResponse": {
+        "description": "Response with a single location filter.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LocationFilterRead"
+            }
+          }
+        }
+      },
+      "LocationFilterListResponse": {
+        "description": "Response with an array of location filters",
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "description": "The array of location filters",
+                  "items": {
+                    "$ref": "#/components/schemas/LocationFilterRead"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrganizationResponseDtoBeta": {
+        "description": "A successfully created organization",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Organization"
+            }
+          }
+        }
+      },
+      "OrganizationResponseDto": {
+        "description": "A successfully created organization",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "$ref": "#/components/schemas/Organization"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrganizationListResponseBeta": {
+        "description": "A list of organizations",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Organization"
+              }
+            }
+          }
+        }
+      },
+      "OrganizationListResponse": {
+        "description": "A list of organizations",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Organization"
+                  }
+                },
+                "nextCursor": {
+                  "type": "string",
+                  "description": "The cursor to get the next page of results (if available). Note that the server\nmay choose to paginate the results even though no limit can be specified by the user."
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrganizationWithContactPersonsResponseDto": {
+        "description": "An organization",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationWithContactPersons"
+            }
+          }
+        }
+      },
+      "ClustersListResponseDto": {
+        "description": "A successfully changed list of allowed clusters",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ClustersListRequestResponse"
+            }
+          }
+        }
+      },
+      "NewProjectResponseDto": {
+        "description": "A successfully created project",
+        "content": {
+          "application/json": {
+            "schema": {
+              "allOf": [
+                {
+                  "required": [
+                    "projectAdminGroupId"
+                  ],
+                  "properties": {
+                    "projectAdminGroupId": {
+                      "description": "The ID of the externally-managed group that was assigned as the admin group for the new project.\nThis may be different from what was specified in the request - see the description of the request\nfield `projectAdminGroupId`."
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/ProjectCreateRequest"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "NewProjectListResponseDto": {
+        "description": "A successfully created project",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "allOf": [
+                      {
+                        "required": [
+                          "projectAdminGroupId"
+                        ],
+                        "properties": {
+                          "projectAdminGroupId": {
+                            "description": "The ID of the externally-managed group that was assigned as the admin group for the new project.\nThis may be different from what was specified in the request - see the description of the request\nfield `projectAdminGroupId`."
+                          }
+                        }
+                      },
+                      {
+                        "$ref": "#/components/schemas/ProjectCreateRequest"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ProjectResponseDto": {
+        "description": "A list of projects",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ProjectResponse"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ProjectWithAdminPropertiesResponse"
+                      }
+                    ]
+                  }
+                },
+                "nextCursor": {
+                  "type": "string",
+                  "description": "The cursor to get the next page of results (if available). Note that the server\nmay choose to paginate the results even though no limit can be specified by the user."
+                }
+              }
+            }
+          }
+        }
+      },
+      "ProjectIntervalV0ResponseDto": {
+        "description": "A list of projects",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectInternalV0Response"
+                  }
+                },
+                "nextCursor": {
+                  "type": "string",
+                  "description": "The cursor to get the next page of results (if available). Note that the server\nmay choose to paginate the results even though no limit can be specified by the user."
                 }
               }
             }
@@ -63520,6 +74142,142 @@
                   "type": "string"
                 }
               }
+            }
+          }
+        }
+      },
+      "CreateLocationFilterRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LocationFilterWrite"
+            }
+          }
+        }
+      },
+      "ListLocationFiltersRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "flat": {
+                  "type": "boolean",
+                  "description": "Determines whether to return location filters in a flat list or in a hierarchical format",
+                  "default": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "ByIdsLocationFiltersRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "required": [
+                "ids"
+              ],
+              "properties": {
+                "ids": {
+                  "type": "array",
+                  "description": "The array of location filter ids to retrieve",
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrganizationRequestDtoBeta": {
+        "description": "A request to create an organization.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationRequestItem"
+            }
+          }
+        }
+      },
+      "OrganizationRequestDto": {
+        "description": "A request to create an organization.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "$ref": "#/components/schemas/OrganizationRequestItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ClustersListRequestDto": {
+        "description": "A request to change the allowed clusters for an organization",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ClustersListRequestResponse"
+            }
+          }
+        }
+      },
+      "NewProjectRequestDto": {
+        "description": "A request to create a new project",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProjectCreateRequest"
+            }
+          }
+        }
+      },
+      "NewProjectListRequestDto": {
+        "description": "A request to create a new project",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "items"
+              ],
+              "properties": {
+                "items": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectCreateRequest"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "UpdateIdpRequestDto": {
+        "required": true,
+        "description": "A request to update the IdP configuration of an organization",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/IdentityProvider"
             }
           }
         }
@@ -63962,9 +74720,15 @@
       ]
     },
     {
+      "name": "Organizations and projects",
+      "tags": [
+        "Organizations",
+        "Projects"
+      ]
+    },
+    {
       "name": "Identity and access management",
       "tags": [
-        "Projects",
         "Groups",
         "Security categories",
         "Sessions",
@@ -63974,7 +74738,19 @@
       ]
     },
     {
-      "name": "Core data model",
+      "name": "Data modeling",
+      "tags": [
+        "Data Modeling",
+        "Data models",
+        "Spaces",
+        "Views",
+        "Containers",
+        "Nodes",
+        "Instances"
+      ]
+    },
+    {
+      "name": "Asset-centric data model",
       "tags": [
         "Assets",
         "Time series",
@@ -64051,15 +74827,13 @@
       ]
     },
     {
-      "name": "Data Modeling",
+      "name": "Data workflows",
       "tags": [
-        "Data Modeling",
-        "Data models",
-        "Spaces",
-        "Views",
-        "Containers",
-        "Nodes",
-        "Instances"
+        "Workflows",
+        "Workflow versions",
+        "Workflow executions",
+        "Workflow triggers",
+        "Tasks"
       ]
     },
     {
@@ -64079,7 +74853,7 @@
   "tags": [
     {
       "name": "Changelog",
-      "description": "This article documents all notable changes to the Cognite Data Fusion (CDF) API v1.\n\n<!--\nGroup changes by release (and date), API area, and these types of changes:\n\n - **Added** for new features.\n - **Changed** for changes in existing functionality.\n - **Deprecated** for soon-to-be removed features.\n - **Removed** for now removed features.\n - **Fixed** for any bug fixes.\n - **Security** in case of vulnerabilities.-\n\nUse[ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) for dates: 2019-06-20\n\nAdd entries for new features on top of this page. Newest release goes on top.\nChanges only for API v1 series\n\nTemplate:\n\n## <YYYY-MM-DD>\n\n### <Core resource name>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n-->\n## 2024-05-01\n\n### Time series\n\n#### Added\n\n- Added support for [status codes](https://developer.cognite.com/dev/concepts/resource_types/timeseries#data-point-quality-status-codes) for data points.\n\n## 2024-04-02\n\n### Groups\n\n#### Added\n\n- Introduce the option to manage members of a group through CDF instead of through external groups in the identity provider. This is done through the new `members` field on the group object. Members can either be explicitly enumerated or one declare a group to include all users accounts. The latter is useful if one wants all existing users and new users who joins a project to automatically receive certain capabilities.\n\n## 2024-03-19\n\n### Engineering diagrams (beta)\n\n#### Added\n- Beta endpoint for retrieving ocr data for a file per page.\n  Currently, only files that have been run through diagram/detect will give any results.\n  This may be up for change in the future.\n  The endpoint replaces a previous playground endpoint which is no longer documented.\n\n## 2024-03-11\n\n### Default runtime in Cognite functions\n\n#### Changed\n- Default Python runtime in Cognite functions has been updated from Python 3.8 (py38) to Python 3.11 (py311) in response to the upcoming end of community support for Python 3.8 in October 14, 2024.\n\n## 2024-03-06\n\n### Files\n\n#### Updated\n- Files API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency rate limits added\n\n## 2024-02-29\n\n### Assets\n\n#### Updated\n- Assets API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency and items rate limits added\n\n## 2024-02-20\n\n### Data Modeling\n\n#### Added\n**Conversion between unit types for returned values during filter and query operations.**\n- Trigger conversion by setting the `targetUnit` by `externalId` or `unitSystemName` parameters for the data source in a query.\n- When using filters with unit conversion, the unit for filter value is determined by the corresponding property in the `source` object. When querying data in centimeters by setting `targetUnit` on a property in the `source`, the filter value for that property will also be considered to be in centimeters.\n- `typing` - `type.unit` on a property in a `typing` object is now always the same as the unit for the returned data.\n- Added `typing` to following endpoints:\n    - query\n    - sync\n    - aggregate\n    - search\n\n## 2024-02-19\n\n### Time series\n\n#### Added\n\n- Data point subscriptions reaches General Availability (GA).\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again.\n\n## 2024-02-08\n\n### Hosted Extractors\n\n#### Changed\n\n- `host` in kafka sources has been replaced with `bootstrapBrokers`, which is an array of objects with `host` and `port`.\n\n\n## 2024-02-01\n\n### Synthetic time series\n\n#### Added\n- Support for unit conversion by setting `targetUnit` or `targetUnitSystem` on time series or aggregates with a compatible `unitExternalId` field.\n\n\n## 2024-01-16\n\n### Sessions\n\n#### Added\n- Support for creating one-shot sessions by setting the `oneshotTokenExchange` flag. One-shot sessions are short-lived sessions that are not refreshed and do not require support for token exchange from the identity provider.\n\n## 2024-01-02\n\n### Data Modeling\n\n#### Added\n- Support for a `bySpace` flag on btree indexes and uniqueness constraints.\n\n\n## 2023-12-12\n\n### Data Modeling\n\n#### Added\n- **Units catalog support for container properties**: You can now specify a unit from [CDF units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) on `float32` and `float64` properties in containers.\n\n\n## 2023-12-11\n\n### Time series\n\n#### Changed\n\n- Data point subscriptions [list data (beta)](https://api-docs.cognite.com/20230101-beta/tag/Data-point-subscriptions/operation/listSubscriptionData/) now supports _long polling_ through the `pollTimeoutSeconds` parameter. The request will be kept active for the specified number of seconds, or until new data is available, whichever comes first.\n\n## 2023-12-06\n\n### Time series\n\n#### Added\n- [Units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) support to time series. This comes in addition to the existing free-text unit field.\n  - [Create timeseries](https://docs.cognite.com/api#tag/Time-series/operation/postTimeSeries) with a unitExternalId.\n  - [Update timeseries](https://docs.cognite.com/api#tag/Time-series/operation/alterTimeSeries) to add/remove unitExternalId.\n- Filter and aggregate time series by unitExternalId or unitQuantity (eg. \"volume\" or \"temperature\"). Both using regular filters and advanced filters.\n  - [Filter time series](https://docs.cognite.com/api#tag/Time-series/operation/listTimeSeries).\n  - [Aggregate time series](https://docs.cognite.com/api#tag/Time-series/operation/aggregateTimeSeries).\n  - [Search time series](https://docs.cognite.com/api#tag/Time-series/operation/searchTimeSeries).\n- Added unit conversion support to [retrieve data points/aggregates](https://docs.cognite.com/api#tag/Time-series/operation/getMultiTimeSeriesDatapoints) and [retrieve latest](https://docs.cognite.com/api#tag/Time-series/operation/getLatest). Specify a _targetUnit_ or _targetUnitSystem_ to convert the data points or aggregates to a different unit, or to the default unit of a given unit system.\n\n## 2023-11-30\n\n### Hosted extractors\n\n#### Changed\n\n- Hosted extractors API (Beta)\n  - Updates hosted extractor schema with tls certificate details hence users can now provide CA and authentication certificates for connection to MQTT brokers.\n  - Now includes schema requirements for connection to Kafka brokers i.e. connection to and extraction from Kafka brokers to Cognie Data fusion is not possible.\n\n## 2023-11-21\n\n### Units Catalog\n\n#### Added\n\n- Added the [Units Catalog](https://docs.cognite.com/api#tag/Units) API. The Units Catalog is a collection of units of measurement and their conversion factors. The Units Catalog is used within Cognite Data Fusion to easily convert between different units and unit systems when retrieving Time Series and Data Models.\n\n## 2023-11-17\n\n### Documents\n\n#### Added\n\n- Added support for sorting in the `/documents/list` endpoint. It works exactly the same as the sorting\n  in `/documents/search` except that you can not sort on search relevance.\n\n## 2023-11-08\n\n### Engineering diagrams\n\n#### Changed\n\n- Optional token mechanism for accessing detected results of engineering diagrams without read all access to assets.\n  See [diagram/detect](https://api-docs.cognite.com/20230101/tag/Engineering-diagrams/operation/diagramDetect) for details.\n\n## 2023-10-23\n\n### Files\n\n#### Added\n\n- Added multipart upload endpoints for the files API. This enables upload of files larger than 5 GiB, in a uniform way for all CDF cloud environments.\n  Optionally use parallel part upload, for greater upload speed.\n  See the documentation for the new endpoints at:\n  - [Upload multipart file](https://docs.cognite.com/api/20230101/#tag/Files/operation/initMultiPartUpload) and\n  - [Complete multipart upload](https://docs.cognite.com/api/20230101/#tag/Files/operation/completeMultiPartUpload) endpoints.\n\n## 2023-10-17\n### Events\n#### Added\n- New and old but previously undocumented API rate and concurrency limits have been documented.\nOverrides have been specified for existing customers, so that the new limits would not affect them.\n  - Service layer request rate and concurrency limits added.\n  - CRUD endpoints request rate and concurrency and items rate limits added\n\n## 2023-10-10\n\n### Entity matching\n\n#### Added\n\n- Entity matching pipelines are now in v1. We resuscitated the old playground API and made some changes.\n  We will keep the new v1 API in beta for the foreseeable future.\n\n### Vision (Contextualization)\n\n#### Added\n\n- New computer vision models (beta) are available in Vision extract service, including digital, dial and level gauge readers, valve state detection (open/closed) and model to segment objects in images.\n\n## 2023-10-05\n\n### Hosted extractors\n\n#### Added\n\n- Hosted extractors API (Beta)\n  - Use the new [Hosted extractors](https://docs.cognite.com/cdf/integration/guides/extraction/hosted_extractors)\n    feature to create simple streaming extractors running inside CDF, streaming data from sources available on the internet\n    directly into CDF.\n    Currently supports Azure Event Hub and MQTT. Support is planned for Kafka and REST APIs.\n\n## 2023-09-27\n\n### 3D\n\n#### Changed\n\n- If the 3d model processing is ongoing or has failed, the 3d api nodes endpoints will now return error code 400 with the response body \"Revision processing is not yet complete\" or \"Revision processing failed\" respectively.\n  The previous behavior was to return an empty or partial items list in these cases.\n  Before calling any 3d api nodes endpoints, clients should check that the model revision has \"status\":\"Done\".\n\n## 2023-08-25\n\n### Transformations\n\n#### Changed\n\n- Fixed wrong description for fields in \"transformations/update\" and \"/transformations/schedules/update\"\n\n## 2023-08-22\n\n### Functions\n\n#### Changed\n\n- Remove Functions runtime \"py37\".\n\n## 2023-08-22\n\n### Time series\n\n#### Added\n\n- Data point subscriptions (Beta)\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again. (Beta)\n\n## 2023-08-10\n\n### Time series\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-08-08\n\n### Assets\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-06-27\n\n### IAM (Identity and access management)\n\n#### Changed\n\n- Identity providers (IdP) are required to be compatible with the [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html) standard, and compliance will now be enforced by the [Projects](tag/Projects) API.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` can be entirely omitted when updating the OIDC configuration for a project.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` are preserved for backwards compatibility of the API. However, if these are specified as part of the request body, the value must match excatly the values that are specified in the OpenID provider configuration document for the configured issuer (can be found at `https://{issuer-url}/.well-known/openid-configuration`). If the values does not match, the API will return an error message.\n\n- The `oidcConfiguration.skewMs` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request. If included, it must always be set to `0`.\n\n- The `oidcConfiguration.isGroupCallbackEnabled` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request.\n  - For projects configured to use Azure Active Directory as the identity provider, if this value is specified in the request, it must always be set to `true`.\n\n## 2023-06-05\n\n### Data Modeling\n\n#### Added\n\n- Added support for an `autoCreateDirectRelations` option on the endpoint for ingesting instances.\nThis option lets the user specify whether to create missing target nodes of direct relations.\n\n#### Removed\n\n- Removed support for the deprecated per-item `sources` field on the `/instances/byids` endpoint.\n\n### Time series\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-05-19\n\n### Transformations\n\n#### Added\n\n- Adding support for data model centric and view centric schema.\n\n## 2023-04-24\n\n### Transformations\n\n#### Removed\n\n- Removing support for authentication via API keys when creating or updating transformations.\n\n## 2023-05-04\n\n### Annotations\n\n#### Added\n\n- Added `image.InstanceLink` and `diagrams.InstanceLink` annotation types to allow you to link from objects discovered in images and engineering diagrams to data model instances.\n\n## 2023-04-18\n\n### All resources\n\n#### Added\n\n- Added information about [Requests throttling](section/Requests-throttling).\n\n#### Changed\n\n- Updated the [Parallel retrieval](section/Parallel-retrieval) documentation.\n- Aligned endpoint naming within Assets, Data sets, Events, and Files.\n\n### Assets\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101-beta/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-04-12\n\n### Sessions\n\n#### Fixed\n\n- Fixed the API documentation for the request body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated the request body schema as specifying the list of session IDs to retrieve, in the form `{\"items\": [42]}` - it should in fact be `{\"items\": [{\"id\": 42}]}`. The documentation has been updated to reflect this.\n\n- Fixed the API documentation for the response body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated `nextCursor` and `previousCursor` fields as being returned from the response, which was not the case, and these fields have now been removed from the API documentation.\n\n## 2023-04-04\n\n### Transformations\n\n#### Change\n\n- Transformations support new target types for view-centric data model instances.\n\n#### Added\n\n- Added target types `nodes` and `edges`.\n\n## 2023-03-06\n\n### Documents\n\n#### Change\n\n- Renamed \"approximateCardinality\" aggregate to \"cardinalityValues\" to unify the search spec in Cognite.\n- \"uniqueProperties\" aggregate no longer supports pagination. It returns unique properties (up to 10000) in the specified path. The results are sorted by frequency.\n\n#### Added\n\n- Added \"allUniqueProperties\" aggregate that returns all unique properties. The response contains a cursor that can be used to fetch all pages of data.\n\n## 2023-02-03\n\n### Seismic\n\n#### Added\n\n- Batch downloading of seismics as a ZIP archive is now an experimental v1 endpoint. A user requires the experimental ACL to use this endpoint, and any other ACLs and scopes to read the downloadable seismics.\n\n#### Fixed\n\n- The documentation for downloading seismics as SEG-Y files is part of v1. The API documentation didn't reflect that the endpoint had been promoted to version 1.\n\n## 2023-02-07\n\n### Documents\n\n#### Added\n\n- Added `highlight` field in the `search` endpoint to indicate whether matches in search results should be highlighted.\n\n## 2023-01-18\n\n### 3D\n\n#### Added\n\n- Added support for using names filter in list nodes endpoint.\n\n## 2023-01-17\n\n### Authentication\n\n#### Removed\n\nWe've removed authentication via CDF service accounts and API keys, and user sign-in via `/login`.\n\n### 3D\n\n#### Added\n\n- Added support for storing translation and scale for model revision.\n\n## 2023-01-12\n\n### Documents\n\n#### Added\n\n- Added support for approximateCardinality aggregate.\n\n## 2023-01-10\n\n### Documents\n\n#### Added\n\n- Added the search leaf filter, to allow filtering by searching through specified properties.\n\n## 2023-01-09\n\n### Documents\n\n#### Added\n\n- Added the uniqueProperties aggregation, which can be used to find all the metadata keys in use.\n\n## 2023-01-06\n\n### Documents\n\n#### Added\n\n- Added inAssetSubtree filter to filter documents that have a related asset in a subtree rooted at any of the specified IDs.\n\n## 2023-01-02\n\n### Documents\n\n#### Added\n\n- Added advanced filters for metadata (prefix, in, equals)\n\n## 2022-12-06\n\n### 3D\n\n#### Added\n\n- Added get3DNodesById endpoint to be able to fetch 3D nodes mapped to an asset.\n\n## 2022-12-16\n\n### Time series\n\n#### Changed\n\n- Timestamps of data points may now be as large as 4102444799999 (23:59:59.999, December 31, 2099). The previous limit was the year 2050.\n\n## 2022-11-29\n\n### Events\n\n#### Added\n\n- Added `nulls` field to the sort property specification\n\n## 2022-11-17\n\n### Time series\n\n#### Added\n\n- Added `nextCursor` field to [Retrieve data points](tag/Time-series/operation/getMultiTimeSeriesDatapoints), to support cursor pagination\n\n## 2022-10-14\n\n### Geospatial\n\n#### Added\n\n- Added the [POST /projects/{project}/geospatial/compute](tag/Geospatial/operation/compute) endpoint.\n\n## 2022-10-11\n\n### Transformations\n\n#### Added\n\n- Added capability to run a transformation with Nonce credentials provided through the Run endpoint.\n\n## 2022-10-06\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\n\n## 2022-09-09\n\n### Vision (Contextualization)\n\n#### Added\n\n- Move Vision extract service from playground to V1.\n\n## 2022-08-12\n\n### Time series\n\n#### Changed\n\n- Updated datapoints timestamp range from 1971 - 2050 to 1900 - 2050.\n  Affected endpoints:\n  - [Insert data points](tag//Time-series/operation/postMultiTimeSeriesDatapoints)\n  - [Retrieve data points](tag//Time-series/operation/getMultiTimeSeriesDatapoints)\n  - [Delete data points](tag//Time-series/operation/deleteDatapoints)\n  - [Retrieve latest data point](tag//Time-series/operation/getLatest)\n  - [Synthetic query](tag//Synthetic-Time-Series/operation/querySyntheticTimeseries)\n\n## 2022-07-21\n\n### Transformations\n\n#### Added\n\n- Added authentication using nonce for transformation's exisiting endpoints.\n\n## 2022-06-21\n\n### Annotations (Data organization)\n\n#### Added\n\n- Moved the annotation service from playground to v1.\n\n## 2022-07-07\n\n### Events\n\n#### Removed\n\n- End-of-life for [filter.rootAssetIds](tag/Events/operation/advancedListEvents) filtering attribute.\n\n## 2022-06-13\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/revoke](tag/Sessions/operation/revokeSessions) endpoint.\n\n## 2022-05-20\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/aggregate` endpoint. The endpoint allows you to count documents optionally grouped by a property and also to retrieve all unique values of a property.\n\n## 2022-05-12\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/list` endpoint. The endpoint allows you to iterate through all the documents in a project.\n- Added the `POST /documents/{documentId}/content` endpoint. The endpoint lets you download the entire extracted plain text of a document.\n\n## 2022-04-11\n\n### Documents\n\n#### Added\n\n- Added the [GET /documents/{documentId}/preview/image/pages/{pageNumber}](tag/Document-preview/operation/documentsPreviewImagePage) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf](tag/Document-preview/operation/documentsPreviewPdf) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf/temporarylink](tag/Document-preview/operation/documentsPreviewPdfTemporaryLink) endpoint.\n\n## 2022-03-15\n\n### Sequences\n\n#### Changed\n\n- Changed sequences column limits. Old limit of maximum total 200 columns limits is updated to maximum 400 total columns, maximum 400 numeric columns and maximum 200 string columns.\n\n## 2022-03-02\n\n### Sequences\n\n#### Added\n\n- Added the [POST /sequences/data/latest](tag/Sequences/operation/getLatestSequenceRow) endpoint.\n\n## 2022-02-08\n\n### Time series\n\n#### Changed\n\n- Marked `isStep` parameter to be editable (i.e. removed description stating it is not updatable) in [POST /timeseries/create](tag/Time-series/operation/postTimeSeries).\n\n#### Added\n\n- Added `isStep` parameter to the `TimeSeriesPatch` object used in [POST /timeseries/update](tag/Time-series/operation/alterTimeSeries)\n\n## 2022-02-07\n\n### Documents\n\n#### Added\n\n- The [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint now supports pagination.\n\n## 2022-01-25\n\n### Documents\n\n#### Added\n\n- Added the [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint.\n\n## 2022-01-24\n\n### Time series\n\n#### Added\n\n- Added optional `ignoreUnknownIds` parameter to [POST /sequences/delete](tag/Sequences/operation/deleteSequences). Setting this to true will prevent the operation from failing if one or more of the given sequences do not exist; instead, those given sequences that do exist will be deleted.\n\n## 2021-12-07\n\n### Transformations\n\n#### Added\n\n- New [Transformations](tag//Transformations) APIs to v1 to create,retrieve,list and delete transformations\n- New [Transformation Jobs](tag//Transformation-Jobs) APIs to v1 to retrieve and list transformation jobs or job metrics\n- New [Transformation Schedule](tag//Transformation-Schedules) APIs to v1 to manage schedules of transformations\n- New [Transformation Notifications](tag//Transformation-Notifications) APIs to v1 to manage notifications from transformation job\n\n## 2021-11-22\n\n### Contextualization\n\n#### Added\n\n- Added [diagram detect](tag/Engineering-diagrams/operation/diagramDetect) endpoint to v1 to detect annotations in engineering diagrams\n- Added [diagram detect results](tag/Engineering-diagrams/operation/diagramDetectResults) endpoint to v1 to get the results from an engineering diagram detect job\n- Added [diagram convert](tag/Engineering-diagrams/operation/diagramConvert) endpoint to v1 to create interactive engineering diagrams in SVG format with highlighted annotations\n- Added [diagram convert results](tag/Engineering-diagrams/operation/diagramConvertResults) endpoint to v1 to get the results for a job converting engineering diagrams to SVGs\n\n## 2021-11-17\n\n### 3D\n\n#### Added\n\n- Added `dataSetId` support to 3D models enabling data access scoping of 3D data\n\n## 2021-10-13\n\n### Raw\n\n#### Changed\n\n- To align with Microsoft Azure clusters, table and database names are now sensitive to trailing spaces also in Google Cloud Platform clusters.\n\n## 2021-10-05\n\n### Extraction Pipelines\n\n#### Added\n\n- New [Extraction Pipelines](tag//Extraction-Pipelines) resource to document extractors and monitor the status of data ingestion to make sure reliable and trustworthy data are flowing into the CDF data sets.\n- API endpoints for creating, managing, and deleting extraction pipelines. Capture common attributes around extractors such as owners, contacts, schedule, destination RAW databases, and data set. Document structured metadata in the form of key-value attributes as well unstructured `documentation` attribute that supports Markdown (rendered as Markdown in Fusion).\n- Extraction Pipelines Runs are CDF objects to store statuses related to an extraction pipeline. The supported statuses are: `success`, `failure` and `seen`. They enable extractor developers to report status and error message after ingesting data. As well enables for reporting heartbeat through `seen` status by the extractor to easily identify issues related to crushed applications and scheduling issues.\n\n## 2021-09-28\n\n### Sequences\n\n#### Added\n\n- Added `partition` parameter to the [GET /sequences](tag/Sequences/operation/listSequences) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n- [POST /sequences/list](tag/Sequences/operation/advancedListSequences) now supports [parallel retrieval](section/Parallel-retrieval).\n\n### Time series\n\n#### Added\n\n- Added `partition` parameter to the [GET /timeseries](tag/Time-series/operation/getTimeSeries) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n\n## 2021-08-18\n\n### IAM (Identity and access management)\n\n#### Added\n\nAdded sessions to [v1](tag//Sessions). Sessions let you securely delegate access to CDF resources for CDF services (such as Functions) by an external principal and for an extended time.\n\n## 2021-08-12\n\n### Relationships\n\n#### Added\n\n- Relationships now support [Parallel Retrieval](section/Parallel-retrieval)\n\n## 2021-07-01\n\n### 3D\n\n#### Added\n\n- Added filter3dNodes endpoint to allow for more advanced filtering on node metadata\n\n## 2021-06-29\n\n### Labels\n\n#### Added\n\n- [Dataset scoping](tag/Labels/operation/listLabels) based on `dataSetIds`.\n\n## 2021-06-08\n\n### Sequences\n\n#### Added\n\n- Added [syntax for updating columns](tag/Sequences/operation/updateSequences) of existing sequences. Can `remove` columns, `modify` existing columns, and `add` new columns as well.\n\n## 2021-06-01\n\n### Assets\n\n#### Added\n\n- Added labels replace (set) method for [assets update](tag/Assets/operation/updateAssets).\n\n## 2021-04-28\n\n### Time series\n\n#### Changed granularity limits on hour aggreagates\n\nYou can now ask for a [granularity](https://docs.cognite.com/dev/concepts/aggregation/#granularity)\nof up to 100000 hours (previously 48 hours), both in normal aggregates and in synthetic time series.\n\n## 2021-04-12\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added a [projects list](tag/Projects/operation/listProjects) endpoint to v1\n- Added a [token inspection](tag/Token/operation/inspectToken) endpoint to v1\n\n## 2021-04-06\n\n### Authentication\n\n#### Deprecated\n\nWe are deprecating authentication via CDF service accounts and API keys, and user sign-in via `/login`, in favor of registering applications and services with your IdP (identity provider) and [using OpenID Connect](https://docs.cognite.com/cdf/access/) and the IdP framework to manage CDF access securely.\n\nThe legacy authentication flow is available for customers using Cognite Data Fusion (CDF) on GCP until further notice. We strongly encourage customers to adopt [the new authentication flows](https://docs.cognite.com/cdf/access/) as soon as possible.\n\nThe following API endpoints are deprecated:\n\n- `/api/v1/projects/*/apikeys`\n- `/api/v1/projects/*/serviceaccounts`\n- `/login`\n- `/logout`\n- `/api/v1/projects/*/groups/serviceaccounts` <sup>\\*</sup>\n\n<sup>\\*</sup>only the sub-resources for listing, adding, and removing members of groups.\n\n## 2021-03-22\n\nCDF API 0.5, 0.6 reached their end-of-life after its initial deprecation announcement in Summer 2019.\n\n## 2021-03-10\n\n### 3D\n\n#### Added\n\n- Added `partition` parameter to the List 3D Nodes endpoint for supporting parallel requests.\n- Added `sortByNodeId` parameter to the List 3D Nodes endpoint, improving request latency in most cases if set to `true`.\n\n## 2021-02-26\n\n### Entity matching\n\n#### Fixed\n\n- Fixed a bug in the documentation for Entity matching. The (job) `status` shall be capitalized string.\n\n## 2020-12-22\n\n### Files\n\n#### Added\n\n- New field `fileType` inside `derivedFields` to refer to a pre-defined subset of MIME types.\n- New filter `fileType` inside `derivedFields` to find files with a pre-defined subset of MIME types.\n\n## 2020-10-20\n\n### Files\n\n#### Added\n\n- New field `geoLocation` to refer to the geographic location of the file.\n- New filter `geoLocation` to find files matching a certain geographic location.\n\nTo learn how to leverage new geoLocation features, [follow our guide](https://developer.cognite.com/dev/concepts/resource_types/files.html).\n\n## 2020-08-29\n\n### Files\n\n#### Added\n\n- New field `directory` referring to the directory in the source containing the file.\n- New filter `directoryPrefix` allows you to find Files matching a certain directory prefix.\n\n## 2020-08-05\n\n### Files\n\n#### Added\n\n- New field `labels` allows you to attach labels to Files upon creation or updating.\n- New filter `labels` allows you to find Files that have been annotated with specific labels.\n\n## 2020-07-08\n\n### IAM (Identity and access management)\n\n#### Added\n\n- New project field `applicationDomains`. If this field is set, users only sign in to the project through applications hosted on\n  a whitelisted domain. [Read more](https://developer.cognite.com/dev/guides/iam/#application-domains).\n\n## 2020-07-01\n\n### Events\n\n#### Added\n\n- New aggregation [`uniqueValues`](tag/Events/operation/aggregateEvents) allows you to find different types, subtypes of events in your project.\n\n## 2020-06-29\n\n### Labels\n\n#### Added\n\n- New data organization resource: [labels](tag//Labels). Manage terms that you can use to annotate and group assets.\n\n### Assets\n\n#### Added\n\n- New filter `labels` allows you to find resources that have been annotated with specific labels.\n\n### Time series\n\n#### Added\n\n- Combine various input time series, constants and operators with on-the-fly [synthetic time series](https://developer.cognite.com/dev/concepts/resource_types/synthetic_timeseries.html).\n\n## 2020-04-28\n\n### Events\n\n#### Added\n\n- New filtering capabilities to find open events [`endTime=null`](tag/Events/operation/advancedListEvents).\n- New filtering capabilities to find all events intersecting a timespan using [activeAtTime](tag/Events/operation/advancedListEvents).\n\n## 2020-03-12\n\n### General\n\n#### Added\n\n- New data organization resource: [data sets](tag//Data-sets). Document and track data lineage, ensure data integrity, and allow 3rd parties to write their insights securely back to your Cognite Data Fusion (CDF) project.\n- New attribute `datasetId` introduced in assets, files, events, time series and sequences.\n- New filter `dataSetIds` allows you to narrow down results to resources containing `datasetId` by a list of ids or externalIds of a data set. Supported by assets, files, events, time series and sequences.\n- We have added a new aggregation endpoint for [time series](tag/Files/operation/aggregateFiles). With this endpoint, you can find out how many results in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Groups\n\n#### Added\n\n- Introduced a new capability: `datasetsAcl` for managing access to data set resources.\n- New scope `datasetScope` for assets, files, events, time series and sequences ACLs. Allows you to scope down access to resources contained within a specified set of data sets.\n\n## 2020-03-10\n\n### 3D\n\n#### Fixed\n\n- We fixed a bug in the documentation of [3D model revisions](tag/3D-Model-Revisions/operation/get3DNodesById). Applications should anticipate that 3D nodes may not have a bounding box.\n\n## 2020-02-25\n\n### Assets\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Assets/operation/aggregateAssets) for assets. With this endpoint, you can find out how many assets in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Events\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Events/operation/aggregateEvents) for events. With this endpoint, you can find out how many events in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n## 2020-02-12\n\n### Assets\n\n#### Added\n\n- We have added new aggregation properties: `depth` and `path`. You can use the properties in the filter and retrieve endpoints.\n\n## 2020-02-10\n\n### Assets\n\n#### Added\n\n- Added the property `parentExternalId` which is returned for all assets which have a parent with a defined `externalId`.\n\n## 2019-12-09\n\n### General\n\n#### Added\n\n- Added `assetSubtreeIds` as a parameter to filter, search, and list endpoints for all core resources. `assetSubtreeIds` allows you to specify assets that are subtree roots, and then only retrieve resources that are related to assets within those subtrees.\n\n## 2019-12-04\n\n### Assets\n\n#### Added\n\n- Added the ability to [filter](tag/Assets/operation/searchAssets) assets by parent external IDs.\n\n## 2019-11-18\n\n### Events\n\n#### Added\n\n- [Added the ability to filter events by the external ID of linked assets](tag/Events/operation/advancedListEvents)\n\n## 2019-11-12\n\n### Access control\n\n#### Removed\n\n- Groups can no longer be created with a permissions field in v0.5.\n\n## 2019-10-31\n\n### Assets\n\n#### Added\n\n- [Asset search](/api/v1/#operation/searchAssets) now has a `search.query` parameter. This uses an improved search algorithm that tries a wider range of variations of the input terms and gives much better relevancy ranking than the existing `search.name` and `search.description` fields.\n\n### Time Series\n\n#### Changed\n\n- The `search.query` parameter for [time series search](/api/v1/#operation/searchTimeSeries) now uses an improved search algorithm that tries a wider range of variations of the input terms, and gives much better relevancy ranking.\n\n## 2019-10-23\n\n### Files\n\n#### Added\n\n- Added support for updating the `mimeType` for existing files in files/update requests.\n\n## 2019-10-18\n\n### Time Series\n\n#### Added\n\n- Time series expanded their filtering capabilities with new `Filter time series` endpoint, allowing for additional filtering by:\n\n  - Name\n  - Unit\n  - Type of time series: string or step series\n  - Metadata objects\n  - ExternalId prefix filtering\n  - Create and last updated time ranges\n\n  Endpoint in addition support pagination and partitioning. Check out detailed API documentation [here](/api/v1/#operation/listTimeSeries).\n\n## 2019-10-16\n\n### Events\n\n#### Added\n\n- [Added the ability to sort events on startTime, endTime, createdTime, and lastUpdatedTime](tag/Events/operation/advancedListEvents)\n\n## 2019-10-02\n\n### Sequences\n\n#### Added\n\n- Introducing the new **sequences** core resource type that lets you store numerically indexed multi-column rows of data. Connect your sequences to physical assets and to their source systems through `externalId` and metadata support. Read more [here](https://developer.cognite.com/dev/concepts/resource_types/sequences.html).\n\n## 2019-09-30\n\n### 3D\n\n#### Added\n\n- Added endpoint to get multiple nodes for a 3D model by their IDs.\n- Added endpoint to get asset mappings for multiple node IDs or asset IDs.\n\n## 2019-09-23\n\n### Files\n\n#### Added\n\n- Added support for filter on `rootAssetIds` in files GET /files (using query parameter) and POST /files/list (in request body).\n\n## 2019-09-16\n\n### Assets and Events\n\n#### Added\n\n- Added support for `partition` in `/assets` and `/events` to support parallel retrieval. See guide for usage [here](./concepts/pagination)\n\n## 2019-08-22\n\n### 3D\n\n#### Added\n\n- Added the query parameter `intersectsBoundingBox` to the list asset mappings endpoint. The parameter filters asset mappings to the assets where the bounding box intersects (or is contained within) the specified bounding box.\n\n## 2019-08-21\n\n### Files\n\n#### Added\n\n- Added support for sourceCreatedTime and sourceModifiedTime fields in files v1 endpoints.\n\n### Assets\n\n#### Added\n\n- Allow the parent asset ID to be updated. The root asset ID must be preserved, and you can not convert a non-root asset to a root asset or vice versa.\n- Support for ignoreUnknownIds when deleting assets.\n\n## 2019-08-15\n\n### 3D\n\n#### Added\n\n- Properties field for 3D nodes, extracted from uploaded 3D files.\n- Ability to filter nodes with a specific set of properties.\n\n## 2019-07-24\n\n### Files\n\n#### Changed\n\n- Allow lookup of names with length up to 256 characters (was 50) for GET /files and POST /files/search operations.\n- Allow creating and retrieving files with mimeType length up to 256 characters (was 64).\n\n## 2019-07-15\n\n### Time series\n\n#### Added\n\n- Added query parameter `rootAssetIds` to list time series endpoint. Returns time series that are linked to an asset that has one of the root assets as an ancestor.\n\n## 2019-07-11\n\nList of changes for initial API v1 release in comparison to previous version - API 0.5\n\n### General\n\n#### Added\n\n- Support for `externalId` added across resource types. `externalId` lets you define a unique ID for a data object. Learn more: [External IDs](https://developer.cognite.com/dev/concepts/external_id.html)\n- `externalIdPrefix` added as a parameter to the list events, assets and files operations.\n- Richer filtering on the list assets, files and events operations.\n- Search, list and filter operations for assets, events and files now support filtering on source and metadata field values.\n\n#### Changed\n\n- Core resources standardize on HTTP methods and URI naming for common operations such as search, partial updates, delete, list and filter\n- API responses are no longer wrapped in a top level `data` object.\n- Standardized pagination across resources through `limit`, `cursor` and `nextCursor` parameters.\n- The `limit` parameter no longer implicitly rounds down requested page size to maximum page size.\n- Standardized error responses and codes across all resources. Errors across CDF can be parsed into a single model.\n- Overall improvements to reference documentation. Including documented input constraints, required fields, individual attribute descriptions.\n\n#### Removed\n\n- The `sourceId` field has been removed from resources. Use `externalId` instead of `sourceId`+`source` to define unique IDs for data objects.\n- Sorting is removed from the search operations for files, assets, events and time series. Results are sorted by relevance.\n- `offset` and `previousCursor` parameters are no longer supported for pagination across resources.\n- Fetching an asset subtree is no longer supported by files, assets, events and time series.\n\n### Assets\n\n#### Added\n\n- Ability to select only root assets though new `root` filter.\n- Added the `rootId` field to specify the top element in an asset hierarchy.\n- Added the ability to filter by the root asset ID. This allows you to scope queries for one or many asset hierarchies.\n- List Assets allows for filtering assets belonging to set of root assets, specified by list of asset internal ids. New query parameter: `rootIds`.\n- Filter and Search Assets allows or filtering assets belonging to a set of root assets, specified by combination of internal and external asset identifiers. New body attribute: `rootIds`.\n\n#### Changed\n\n- Updating a single asset is no longer supported through a separate endpoint. Use the update multiple endpoint instead.\n- Delete assets by default removes only leaf assets (assets without children). New parameter 'recursive' allows for enabling recursive removal of the entire subtree of the asset pointed by ID (API 0.5 behaviour).\n\n#### Removed\n\n- Overwriting assets is no longer supported.\n- Filtering assets by their complete description is no longer supported.\n- Locating assets fuzzily by name has been removed. Instead, search for assets on the `name` property.\n- When searching assets, querying over both name and description in the same query is no longer supported.\n- The experimental query parameter `boostName` has been removed from the search for assets operation.\n- Removed the `path` and `depth` fields.\n\n### Events\n\n#### Added\n\n- Events can now be filtered on asset ID in combination with other filters.\n- New filter `rootAssetIds` allows for narrowing down events belonging only to list or specified root assets. Supported by Filter and Search API\n\n#### Removed\n\n- Events can no longer be filtered by empty description.\n- The 'dir' parameter has been removed from the search events operation.\n\n### Files\n\n#### Added\n\n- Filtering files by `assetIds` in list files operations now support multiple assets in the same request.\n\n#### Changed\n\n- Download file content has changed from HTTP GET to HTTP POST method.\n- We have renamed the `fileType` field to `mimeType`. The field now requires a MIME formatted string (e.g. `text/plain`).\n- We have renamed the `uploadedAt` field to `uploadedTime`.\n- Resumable is now the default behavior for file uploads.\n- Update metadata for single files is no longer supported by a separate operation. Instead, use the update multiple operation.\n\n#### Removed\n\n- Replace files metadata endpoint has been removed.\n- Directory has been removed as a property of files.\n- Updating the `name` or `mimeType` of a file through the update multiple files operation is no longer supported.\n- Query parameter for specifying the sort direction has been removed from list all files operations.\n\n### Raw\n\n#### Changed\n\n- Raw has changed structure to become resource-oriented. The URL structure has changed.\n- Recursively delete of tables and rows when deleting a database is now the default behavior without a control parameter.\n\n### Time series\n\n#### Added\n\n- Support for adding datapoints by `id` and `externalId` of time series. Adding datapoints to time series by `name` has been removed.\n- Add ability to update the new `externalId` attribute for time series.\n- Allow to set `externalId` during creation of time series. `ExternalId` requires uniqueness across time series.\n- Consolidate multiple APIs to allow adding datapoints into a single endpoint. Allows datapoints to be added to multiple time series at the same time.\n- Retrieve data points by using `id` and `externalId` of the time series.\n- Time series created through API v1 are not discoverable by API 0.3, 0.4, 0.5 and 0.6 by default. Introduce the option to enable this compatibility by setting new attribute - `legacyName` on time series creation. Value is required to be unique.\n\n#### Changed\n\n- Get latest datapoints has been reworked. Introduces support for `id` and `externalId` lookup as well retrieval for multiple time series within the same request.\n- Time series name is no longer limited by uniqueness. Note that time series (meta objects) created by API v1 will not be discoverable by older API versions.\n- Delete time series endpoint has been redesigned to allow deletion of multiple time series by `id` and `externalId`.\n- Delete single and multiple datapoints endpoint has been redesigned and consolidated into a single endpoint. New delete allows selection of multiple time series and time ranges by `id` and `externalId`. Selecting by `name` is no longer available.\n- Update multiple time series restructured to support lookup by `externalId`.\n- Retrieve time series by ID endpoint restructured adding the ability to get time series by `externalId`.\n- Set limit for data point value to min -1E100, max 1E100.\n\n#### Removed\n\n- Experimental feature for performing calculations across multiple time series (synthetic time series), function and alias attributes are no longer available.\n- The experimental query parameter `boostName` has been removed from search operation.\n- Short names for aggregate functions are no longer supported.\n- Ability to remove time series by `name` have been removed as names are no longer unique identifiers.\n- Select multiple time series and time ranges by `name` is no longer available.\n- The ability to update `isString` and `isStep` attributes is removed. The attributes are not intended to be modified after creation of time series.\n- The endpoint for updating single time series is removed. Use the update multiple time series endpoint instead.\n- Remove ability to overwrite time series object by `id`. Use the update multiple time series endpoint instead.\n- The ability to retrieve time series matching by `name` has been removed. Use `externalId` instead.\n- The ability to retrieve by `id` from a single time series has been removed. Use retrieve multiple datapoints for multiple time series instead.\n- The ability to retrieve time-aligned datapoints through \"dataframe\" API has been removed. Similar functionality is available through our supported SDKs.\n- The ability to add datapoints to time series by `name` has been removed.\n- The ability to look up by time series `name` has been removed.\n\n### IAM (Identity and access management)\n\n#### Added\n\n- The login status endpoint includes the ID of the API key making the request (new attribute: `apiKeyId`), if the request used an API key.\n\n#### Changed\n\n- The user resource type has been replaced with service accounts. Users from previous API versions are equivalent to service accounts.\n- Adding, listing and removing users from a group has been replaced by equivalent operations for service accounts.\n- Retrieve project returns a single object instead of a list.\n- API keys endpoints for list/create rename `userId` attribute to `serviceAccountId`.\n\n#### Removed\n\n- List and create groups no longer use the `permissions` and `source` attributes.\n\n### 3D\n\n#### Added\n\n- New 3D API lets you upload and process 3D models. Supported format: FBX.\n- Ability to create and maintain multiple revisions for the 3D models.\n- API for mapping relationships between 3D model nodes and asset hierarchy.\n"
+      "description": "This article documents all notable changes to the Cognite Data Fusion (CDF) API v1.\n\n<!--\nGroup changes by release (and date), API area, and these types of changes:\n\n - **Added** for new features.\n - **Changed** for changes in existing functionality.\n - **Deprecated** for soon-to-be removed features.\n - **Removed** for now removed features.\n - **Fixed** for any bug fixes.\n - **Security** in case of vulnerabilities.-\n\nUse[ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) for dates: 2019-06-20\n\nAdd entries for new features on top of this page. Newest release goes on top.\nChanges only for API v1 series\n\nTemplate:\n\n## <YYYY-MM-DD>\n\n### <Core resource name>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n\n#### <Group name -- see top of the page>\n\n    - <my change>\n    - <my change>\n-->\n\n## 2024-10-11\n### Organizations and Projects\n#### Added\n- Allow non-admin users to list all projects in an organization.\n  - `GET /api/v1/orgs/{orgId}/projects` can be called by all users of an organization.\n- Include `apiUrl` when listing projects in an organization.\n  - `GET /api/v1/orgs/{orgId}/projects` will include `apiUrl` for each project.\n\n## 2024-09-31\n### Time Series API\n#### Added\n- Introduced support for time series managed by Data modeling in data point subscriptions.\n  - `GET subscriptions/members` can contain members with `instanceId`.\n  - `POST subscriptions` can be used to create subscriptions with an defined set of instance ids.\n  - `POST subscriptions/update` can be used to add/remove/set the instance id time series members.\n\n\n## 2024-09-19\n### Contextualization / Vision\n#### Added\n- Support for Vision endpoints referencing files by data modeling instance IDs, as an alternative to ID and external ID. \n\n## 2024-09-14\n### Simulator integration API\n#### Added\n- The simulator integration API endpoints have now been promoted to public beta. The following is just a brief list of endpoints. Go to the Cognite API [reference documentation (beta)](https://api-docs.cognite.com/20230101-beta/tag/Simulators/) to view all endpoints and their functionalities.\n  - `POST /simulators/*` to access the simulators API and list simulators enabled for the project\n  - `POST /simulators/integrations/*` to list simulator connectors and their state\n  - `POST /simulators/models/*` to create/list/remove simulator models and their revisions\n  - `POST /simulators/routines/*` to create/list/remove simulator routines and their revisions\n  - `POST /simulators/runs/*` to create/schedule simulation runs\n  - `POST /simulators/logs/*` to access simulator logs\n\n## 2024-09-13\n### Contextualization / Engineering diagrams\n#### Added\n- Support for detecting tags in diagrams referencing files by data modelling instance ids as an alternative to id and externalId. \n\n## 2024-09-12\n### Files API\n#### Added\n- Add support for `ignoreUnknownIds` to the `files/delete` endpoint.\n\n### SAP Writeback\n#### Added\n- SAP Writeback API (Beta)\n\n## 2024-09-10\n### Time Series API\n#### Added\n- Introduces support for Time Series managed by Data modeling.\n  - `/timeseries/*` endpoints will return data modeling instance Id in time series objects where applicable.\n  - `POST /timeseries/update` can be used to update properties of data modeling time series, but only fields that are not managed by data modeling.\n  - `POST /timeseries/byids` can be used to retrieve time series by instance Id.\n  - `POST /timeseries/list` and `POST /timeseries/aggregate` support advanced filters with `instanceId.space` and `instanceId.externalId` fields. (No changes to regular filters)\n  - `POST /timeseries/data/*` can be used with instance Id to ingest/delete/query data points.\n  - `POST /timeseries/synthetic/query` can lookup by instance Id.\n\n### Subscriptions API\n#### Added\n- Subscription filters support advanced filters with `instanceId.space` and `instanceId.externalId` fields.\n- List subscription members will show time series instance Ids, if available.\n\n## 2024-09-02\n### Files API\n#### Added\n- Introduces support for Files managed by Data modeling, which means following endpoints will allow specifying instance Id\n  - `POST /files/uploadlink` to get upload links for files\n  - `POST /files/multiuploadlink` to get multipart upload link for files\n  - `POST /files/completemultipartupload` to complete a multipart file upload\n  - `POST /files/downloadlink` to get download links for files\n  - `GET /files/icon` to get an image representation of a file\n  - `POST /files/byids` to retrieve metadata information about multiple specific files\n  - `POST /files/update` to updates the information for the files\n\n## 2024-08-23\n### Data Workflows\n#### Added\n- subworkflow task: add support for referencing other workflow versions to run as part of a workflow\n\n## 2024-08-20\n### Data Workflows\n#### Added\n- Introduces the trigger resource for Data Workflows, which adds support for scheduling the execution of workflows and the management thereof.\n  - `POST /workflows/triggers` to create a UNIX cron trigger for a workflow\n  - `GET /workflows/triggers` to list all triggers\n  - `POST /workflows/triggers/delete` to delete a trigger\n  - `GET /workflows/triggers/{triggerExternalId}/history` which keeps a ledger of when the trigger fired and if it successfully started a workflow or not.\n\n## 2024-07-18\n### Organizations and Projects\n#### Added\n- Selected endpoints are promoted from beta to v1 (all under https://auth.cognite.com; note that the routes are \n  different from the beta routes, and that some request and response signatures have changed):\n  - `GET /api/v1/orgs/{orgId}` to get organization info\n  - `POST /api/v1/orgs/{orgId}/orgs` to create an organization\n  - `POST /api/v1/orgs/{orgId}/delete` to delete an organization\n  - `GET /api/v1/orgs/{orgId}/orgs` to list the child organizations of an organization\n  - `POST /api/v1/orgs/{orgId}/projects` to create a project in an organization\n  - `GET /api/v1/orgs/{orgId}/projects` to list the projects in an organization\n\n#### Deprecated\n- The six beta endpoints that have been published as new V1 endpoints (just above) are deprecated and will be removed in\n  a future release.\n\n## 2024-06-24\n### Data Modeling\n\n#### Added\n- Support marking properties as immutable\n\n## 2024-06-17\n### Data Modeling\n\n#### Added\n- Support for creating properties of type `direct_relation[]`, allowing direct relations to point to multiple nodes.\n- /containers/inspect endpoint to retrieve information about which views map a container.\n- /instances/inspect endpoint to retrieve information about which containers an instance has data in.\n\n## 2024-06-13\n### Organizations and Projects\n#### Added\n- Projects API (Beta): Allow for parametrization of the initial admin group when creating a project.\n\n### Time Series\n#### Added\n- Time zone aware aggregate queries. Align aggregates with a given time zone. Also works with half-hour offsets like Asia/Kolkata (UTC+5:30). Takes DST transitions into account.\n- New `month` (mo) granularity.\n- Also applies to synthetic time series.\n\n## 2024-05-24\n### Organizations and Projects\n#### Added\n- Organizations API (Beta): create, list, and delete CDF organizations\n- Organizations API (Alpha): update CDF organizations\n- Projects API (Beta): create and list projects in CDF organizations\n\n### User profiles\n#### Added\n- Organization user profiles (Beta): list users in CDF organizations\n\n### Projects\n#### Removed\n- Removed the previous Projects API from public documentation, as those endpoints are available to Cognite and resellers\n  only.\n\n## 2024-05-23\n\n### Time series\n\n#### Added\n- Beta support for time zone aware aggregate queries. Align aggregates with a given time zone. Also works with half-hour offsets like Asia/Kolkata (UTC+5:30). Takes DST transitions into account.\n- Beta support for new `month` (mo) granularity.\n- Also applies to synthetic time series.\n\n## 2024-05-02\n\n### Postgres gateway\n\n#### Added\n- Endpoints for managing PostgreSQL gateway \n\n## 2024-05-01\n\n### Time series\n\n#### Added\n\n- Added support for [status codes](https://developer.cognite.com/dev/concepts/resource_types/timeseries#data-point-quality-status-codes) for data points.\n\n## 2024-04-02\n\n### Groups\n\n#### Added\n\n- Introduce the option to manage members of a group through CDF instead of through external groups in the identity provider. This is done through the new `members` field on the group object. Members can either be explicitly enumerated or one declare a group to include all users accounts. The latter is useful if one wants all existing users and new users who joins a project to automatically receive certain capabilities.\n\n## 2024-03-19\n\n### Engineering diagrams (beta)\n\n#### Added\n- Beta endpoint for retrieving ocr data for a file per page.\n  Currently, only files that have been run through diagram/detect will give any results.\n  This may be up for change in the future.\n  The endpoint replaces a previous playground endpoint which is no longer documented.\n\n## 2024-03-11\n\n### Default runtime in Cognite functions\n\n#### Changed\n- Default Python runtime in Cognite functions has been updated from Python 3.8 (py38) to Python 3.11 (py311) in response to the upcoming end of community support for Python 3.8 in October 14, 2024.\n\n## 2024-03-06\n\n### Files\n\n#### Updated\n- Files API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency rate limits added\n\n## 2024-02-29\n\n### Assets\n\n#### Updated\n- Assets API rate and concurrency limits have been documented.\n  -- Service layer request rate and concurrency limits added\n  -- CRUD endpoints request rate, concurrency and items rate limits added\n  -- Analytic endpoints request rate, concurrency and items rate limits added\n\n## 2024-02-20\n\n### Data Modeling\n\n#### Added\n**Conversion between unit types for returned values during filter and query operations.**\n- Trigger conversion by setting the `targetUnit` by `externalId` or `unitSystemName` parameters for the data source in a query.\n- When using filters with unit conversion, the unit for filter value is determined by the corresponding property in the `source` object. When querying data in centimeters by setting `targetUnit` on a property in the `source`, the filter value for that property will also be considered to be in centimeters.\n- `typing` - `type.unit` on a property in a `typing` object is now always the same as the unit for the returned data.\n- Added `typing` to following endpoints:\n    - query\n    - sync\n    - aggregate\n    - search\n\n## 2024-02-19\n\n### Time series\n\n#### Added\n\n- Data point subscriptions reaches General Availability (GA).\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again.\n\n## 2024-02-08\n\n### Hosted Extractors\n\n#### Changed\n\n- `host` in kafka sources has been replaced with `bootstrapBrokers`, which is an array of objects with `host` and `port`.\n\n\n## 2024-02-01\n\n### Synthetic time series\n\n#### Added\n- Support for unit conversion by setting `targetUnit` or `targetUnitSystem` on time series or aggregates with a compatible `unitExternalId` field.\n\n\n## 2024-01-16\n\n### Sessions\n\n#### Added\n- Support for creating one-shot sessions by setting the `oneshotTokenExchange` flag. One-shot sessions are short-lived sessions that are not refreshed and do not require support for token exchange from the identity provider.\n\n## 2024-01-02\n\n### Data Modeling\n\n#### Added\n- Support for a `bySpace` flag on btree indexes and uniqueness constraints.\n\n\n## 2023-12-12\n\n### Data Modeling\n\n#### Added\n- **Units catalog support for container properties**: You can now specify a unit from [CDF units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) on `float32` and `float64` properties in containers.\n\n\n## 2023-12-11\n\n### Time series\n\n#### Changed\n\n- Data point subscriptions [list data (beta)](https://api-docs.cognite.com/20230101-beta/tag/Data-point-subscriptions/operation/listSubscriptionData/) now supports _long polling_ through the `pollTimeoutSeconds` parameter. The request will be kept active for the specified number of seconds, or until new data is available, whichever comes first.\n\n## 2023-12-06\n\n### Time series\n\n#### Added\n- [Units catalog](https://developer.cognite.com/dev/concepts/resource_types/units) support to time series. This comes in addition to the existing free-text unit field.\n  - [Create timeseries](https://docs.cognite.com/api#tag/Time-series/operation/postTimeSeries) with a unitExternalId.\n  - [Update timeseries](https://docs.cognite.com/api#tag/Time-series/operation/alterTimeSeries) to add/remove unitExternalId.\n- Filter and aggregate time series by unitExternalId or unitQuantity (eg. \"volume\" or \"temperature\"). Both using regular filters and advanced filters.\n  - [Filter time series](https://docs.cognite.com/api#tag/Time-series/operation/listTimeSeries).\n  - [Aggregate time series](https://docs.cognite.com/api#tag/Time-series/operation/aggregateTimeSeries).\n  - [Search time series](https://docs.cognite.com/api#tag/Time-series/operation/searchTimeSeries).\n- Added unit conversion support to [retrieve data points/aggregates](https://docs.cognite.com/api#tag/Time-series/operation/getMultiTimeSeriesDatapoints) and [retrieve latest](https://docs.cognite.com/api#tag/Time-series/operation/getLatest). Specify a _targetUnit_ or _targetUnitSystem_ to convert the data points or aggregates to a different unit, or to the default unit of a given unit system.\n\n## 2023-11-30\n\n### Hosted extractors\n\n#### Changed\n\n- Hosted extractors API (Beta)\n  - Updates hosted extractor schema with tls certificate details hence users can now provide CA and authentication certificates for connection to MQTT brokers.\n  - Now includes schema requirements for connection to Kafka brokers i.e. connection to and extraction from Kafka brokers to Cognie Data fusion is not possible.\n\n## 2023-11-21\n\n### Units Catalog\n\n#### Added\n\n- Added the [Units Catalog](https://docs.cognite.com/api#tag/Units) API. The Units Catalog is a collection of units of measurement and their conversion factors. The Units Catalog is used within Cognite Data Fusion to easily convert between different units and unit systems when retrieving Time Series and Data Models.\n\n## 2023-11-17\n\n### Documents\n\n#### Added\n\n- Added support for sorting in the `/documents/list` endpoint. It works exactly the same as the sorting\n  in `/documents/search` except that you can not sort on search relevance.\n\n## 2023-11-08\n\n### Engineering diagrams\n\n#### Changed\n\n- Optional token mechanism for accessing detected results of engineering diagrams without read all access to assets.\n  See [diagram/detect](https://api-docs.cognite.com/20230101/tag/Engineering-diagrams/operation/diagramDetect) for details.\n\n## 2023-10-23\n\n### Files\n\n#### Added\n\n- Added multipart upload endpoints for the files API. This enables upload of files larger than 5 GiB, in a uniform way for all CDF cloud environments.\n  Optionally use parallel part upload, for greater upload speed.\n  See the documentation for the new endpoints at:\n  - [Upload multipart file](https://docs.cognite.com/api/20230101/#tag/Files/operation/initMultiPartUpload) and\n  - [Complete multipart upload](https://docs.cognite.com/api/20230101/#tag/Files/operation/completeMultiPartUpload) endpoints.\n\n## 2023-10-17\n### Events\n#### Added\n- New and old but previously undocumented API rate and concurrency limits have been documented.\nOverrides have been specified for existing customers, so that the new limits would not affect them.\n  - Service layer request rate and concurrency limits added.\n  - CRUD endpoints request rate and concurrency and items rate limits added\n\n## 2023-10-10\n\n### Entity matching\n\n#### Added\n\n- Entity matching pipelines are now in v1. We resuscitated the old playground API and made some changes.\n  We will keep the new v1 API in beta for the foreseeable future.\n\n### Vision (Contextualization)\n\n#### Added\n\n- New computer vision models (beta) are available in Vision extract service, including digital, dial and level gauge readers, valve state detection (open/closed) and model to segment objects in images.\n\n## 2023-10-05\n\n### Hosted extractors\n\n#### Added\n\n- Hosted extractors API (Beta)\n  - Use the new [Hosted extractors](https://docs.cognite.com/cdf/integration/guides/extraction/hosted_extractors)\n    feature to create simple streaming extractors running inside CDF, streaming data from sources available on the internet\n    directly into CDF.\n    Currently supports Azure Event Hub and MQTT. Support is planned for Kafka and REST APIs.\n\n## 2023-09-27\n\n### 3D\n\n#### Changed\n\n- If the 3d model processing is ongoing or has failed, the 3d api nodes endpoints will now return error code 400 with the response body \"Revision processing is not yet complete\" or \"Revision processing failed\" respectively.\n  The previous behavior was to return an empty or partial items list in these cases.\n  Before calling any 3d api nodes endpoints, clients should check that the model revision has \"status\":\"Done\".\n\n## 2023-08-25\n\n### Transformations\n\n#### Changed\n\n- Fixed wrong description for fields in \"transformations/update\" and \"/transformations/schedules/update\"\n\n## 2023-08-22\n\n### Functions\n\n#### Changed\n\n- Remove Functions runtime \"py37\".\n\n## 2023-08-22\n\n### Time series\n\n#### Added\n\n- Data point subscriptions (Beta)\n  - Use the new [Data point subscriptions](https://developer.cognite.com/dev/concepts/data_point_subscriptions/)\n    feature to configure a subscription to listen to changes in one or more\n    time series (in ingestion order).\n    The feature is intended to be used where data points consumers need to keep up to date with\n    changes to one or more time series without the need to read the entire time series again. (Beta)\n\n## 2023-08-10\n\n### Time series\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](https://docs.cognite.com/api/20230101/#tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](https://docs.cognite.com/api/20230101/#tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-08-08\n\n### Assets\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Advanced query language support reaches General Availability (GA).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-06-27\n\n### IAM (Identity and access management)\n\n#### Changed\n\n- Identity providers (IdP) are required to be compatible with the [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html) standard, and compliance will now be enforced by the [Projects](tag/Projects) API.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` can be entirely omitted when updating the OIDC configuration for a project.\n  - The `oidcConfiguration.jwksUrl` and `oidcConfiguration.tokenUrl` are preserved for backwards compatibility of the API. However, if these are specified as part of the request body, the value must match excatly the values that are specified in the OpenID provider configuration document for the configured issuer (can be found at `https://{issuer-url}/.well-known/openid-configuration`). If the values does not match, the API will return an error message.\n\n- The `oidcConfiguration.skewMs` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request. If included, it must always be set to `0`.\n\n- The `oidcConfiguration.isGroupCallbackEnabled` has been deprecated but remains part of the API for backwards compatibility. It can be omitted from the request.\n  - For projects configured to use Azure Active Directory as the identity provider, if this value is specified in the request, it must always be set to `true`.\n\n## 2023-06-05\n\n### Data Modeling\n\n#### Added\n\n- Added support for an `autoCreateDirectRelations` option on the endpoint for ingesting instances.\nThis option lets the user specify whether to create missing target nodes of direct relations.\n\n#### Removed\n\n- Removed support for the deprecated per-item `sources` field on the `/instances/byids` endpoint.\n\n### Time series\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter time series](tag/Time-series/operation/listTimeSeries) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate time series](tag/Time-series/operation/aggregateTimeSeries) endpoint.\n\n### Sequences\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter sequences](tag/Sequences/operation/advancedListSequences) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate sequences](tag/Sequences/operation/aggregateSequences) endpoint.\n\n## 2023-05-19\n\n### Transformations\n\n#### Added\n\n- Adding support for data model centric and view centric schema.\n\n## 2023-04-24\n\n### Transformations\n\n#### Removed\n\n- Removing support for authentication via API keys when creating or updating transformations.\n\n## 2023-05-04\n\n### Annotations\n\n#### Added\n\n- Added `image.InstanceLink` and `diagrams.InstanceLink` annotation types to allow you to link from objects discovered in images and engineering diagrams to data model instances.\n\n## 2023-04-18\n\n### All resources\n\n#### Added\n\n- Added information about [Requests throttling](section/Requests-throttling).\n\n#### Changed\n\n- Updated the [Parallel retrieval](section/Parallel-retrieval) documentation.\n- Aligned endpoint naming within Assets, Data sets, Events, and Files.\n\n### Assets\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/listAssets) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate assets](https://docs.cognite.com/api/20230101-beta/#tag/Assets/operation/aggregateAssets) endpoint.\n\n### Events\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced search, filtering, and sorting capabilities in the [Filter events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/advancedListEvents) endpoint.\n  - Advanced aggregation capabilities in the [Aggregate events](https://docs.cognite.com/api/20230101-beta/#tag/Events/operation/aggregateEvents) endpoint.\n\n### Documents\n\n#### Added\n\n- Added advanced query language support (Beta).\n  - Advanced aggregation capabilities in the [Aggregate documents](https://docs.cognite.com/api/20230101-beta/#tag/Documents/operation/documentsAggregate) endpoint.\n\n## 2023-04-12\n\n### Sessions\n\n#### Fixed\n\n- Fixed the API documentation for the request body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated the request body schema as specifying the list of session IDs to retrieve, in the form `{\"items\": [42]}` - it should in fact be `{\"items\": [{\"id\": 42}]}`. The documentation has been updated to reflect this.\n\n- Fixed the API documentation for the response body of the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\nThe documentation incorrectly stated `nextCursor` and `previousCursor` fields as being returned from the response, which was not the case, and these fields have now been removed from the API documentation.\n\n## 2023-04-04\n\n### Transformations\n\n#### Change\n\n- Transformations support new target types for view-centric data model instances.\n\n#### Added\n\n- Added target types `nodes` and `edges`.\n\n## 2023-03-06\n\n### Documents\n\n#### Change\n\n- Renamed \"approximateCardinality\" aggregate to \"cardinalityValues\" to unify the search spec in Cognite.\n- \"uniqueProperties\" aggregate no longer supports pagination. It returns unique properties (up to 10000) in the specified path. The results are sorted by frequency.\n\n#### Added\n\n- Added \"allUniqueProperties\" aggregate that returns all unique properties. The response contains a cursor that can be used to fetch all pages of data.\n\n## 2023-02-03\n\n### Seismic\n\n#### Added\n\n- Batch downloading of seismics as a ZIP archive is now an experimental v1 endpoint. A user requires the experimental ACL to use this endpoint, and any other ACLs and scopes to read the downloadable seismics.\n\n#### Fixed\n\n- The documentation for downloading seismics as SEG-Y files is part of v1. The API documentation didn't reflect that the endpoint had been promoted to version 1.\n\n## 2023-02-07\n\n### Documents\n\n#### Added\n\n- Added `highlight` field in the `search` endpoint to indicate whether matches in search results should be highlighted.\n\n## 2023-01-18\n\n### 3D\n\n#### Added\n\n- Added support for using names filter in list nodes endpoint.\n\n## 2023-01-17\n\n### Authentication\n\n#### Removed\n\nWe've removed authentication via CDF service accounts and API keys, and user sign-in via `/login`.\n\n### 3D\n\n#### Added\n\n- Added support for storing translation and scale for model revision.\n\n## 2023-01-12\n\n### Documents\n\n#### Added\n\n- Added support for approximateCardinality aggregate.\n\n## 2023-01-10\n\n### Documents\n\n#### Added\n\n- Added the search leaf filter, to allow filtering by searching through specified properties.\n\n## 2023-01-09\n\n### Documents\n\n#### Added\n\n- Added the uniqueProperties aggregation, which can be used to find all the metadata keys in use.\n\n## 2023-01-06\n\n### Documents\n\n#### Added\n\n- Added inAssetSubtree filter to filter documents that have a related asset in a subtree rooted at any of the specified IDs.\n\n## 2023-01-02\n\n### Documents\n\n#### Added\n\n- Added advanced filters for metadata (prefix, in, equals)\n\n## 2022-12-06\n\n### 3D\n\n#### Added\n\n- Added get3DNodesById endpoint to be able to fetch 3D nodes mapped to an asset.\n\n## 2022-12-16\n\n### Time series\n\n#### Changed\n\n- Timestamps of data points may now be as large as 4102444799999 (23:59:59.999, December 31, 2099). The previous limit was the year 2050.\n\n## 2022-11-29\n\n### Events\n\n#### Added\n\n- Added `nulls` field to the sort property specification\n\n## 2022-11-17\n\n### Time series\n\n#### Added\n\n- Added `nextCursor` field to [Retrieve data points](tag/Time-series/operation/getMultiTimeSeriesDatapoints), to support cursor pagination\n\n## 2022-10-14\n\n### Geospatial\n\n#### Added\n\n- Added the [POST /projects/{project}/geospatial/compute](tag/Geospatial/operation/compute) endpoint.\n\n## 2022-10-11\n\n### Transformations\n\n#### Added\n\n- Added capability to run a transformation with Nonce credentials provided through the Run endpoint.\n\n## 2022-10-06\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/byids](tag/Sessions/operation/getSessionsByIds) endpoint.\n\n## 2022-09-09\n\n### Vision (Contextualization)\n\n#### Added\n\n- Move Vision extract service from playground to V1.\n\n## 2022-08-12\n\n### Time series\n\n#### Changed\n\n- Updated datapoints timestamp range from 1971 - 2050 to 1900 - 2050.\n  Affected endpoints:\n  - [Insert data points](tag//Time-series/operation/postMultiTimeSeriesDatapoints)\n  - [Retrieve data points](tag//Time-series/operation/getMultiTimeSeriesDatapoints)\n  - [Delete data points](tag//Time-series/operation/deleteDatapoints)\n  - [Retrieve latest data point](tag//Time-series/operation/getLatest)\n  - [Synthetic query](tag//Synthetic-Time-Series/operation/querySyntheticTimeseries)\n\n## 2022-07-21\n\n### Transformations\n\n#### Added\n\n- Added authentication using nonce for transformation's exisiting endpoints.\n\n## 2022-06-21\n\n### Annotations (Data organization)\n\n#### Added\n\n- Moved the annotation service from playground to v1.\n\n## 2022-07-07\n\n### Events\n\n#### Removed\n\n- End-of-life for [filter.rootAssetIds](tag/Events/operation/advancedListEvents) filtering attribute.\n\n## 2022-06-13\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added the [POST /projects/{project}/sessions/revoke](tag/Sessions/operation/revokeSessions) endpoint.\n\n## 2022-05-20\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/aggregate` endpoint. The endpoint allows you to count documents optionally grouped by a property and also to retrieve all unique values of a property.\n\n## 2022-05-12\n\n### Documents\n\n#### Added\n\n- Added the `POST /documents/list` endpoint. The endpoint allows you to iterate through all the documents in a project.\n- Added the `POST /documents/{documentId}/content` endpoint. The endpoint lets you download the entire extracted plain text of a document.\n\n## 2022-04-11\n\n### Documents\n\n#### Added\n\n- Added the [GET /documents/{documentId}/preview/image/pages/{pageNumber}](tag/Document-preview/operation/documentsPreviewImagePage) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf](tag/Document-preview/operation/documentsPreviewPdf) endpoint.\n- Added the [GET /documents/{documentId}/preview/pdf/temporarylink](tag/Document-preview/operation/documentsPreviewPdfTemporaryLink) endpoint.\n\n## 2022-03-15\n\n### Sequences\n\n#### Changed\n\n- Changed sequences column limits. Old limit of maximum total 200 columns limits is updated to maximum 400 total columns, maximum 400 numeric columns and maximum 200 string columns.\n\n## 2022-03-02\n\n### Sequences\n\n#### Added\n\n- Added the [POST /sequences/data/latest](tag/Sequences/operation/getLatestSequenceRow) endpoint.\n\n## 2022-02-08\n\n### Time series\n\n#### Changed\n\n- Marked `isStep` parameter to be editable (i.e. removed description stating it is not updatable) in [POST /timeseries/create](tag/Time-series/operation/postTimeSeries).\n\n#### Added\n\n- Added `isStep` parameter to the `TimeSeriesPatch` object used in [POST /timeseries/update](tag/Time-series/operation/alterTimeSeries)\n\n## 2022-02-07\n\n### Documents\n\n#### Added\n\n- The [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint now supports pagination.\n\n## 2022-01-25\n\n### Documents\n\n#### Added\n\n- Added the [POST /documents/search](tag/Documents/operation/documentsSearch) endpoint.\n\n## 2022-01-24\n\n### Time series\n\n#### Added\n\n- Added optional `ignoreUnknownIds` parameter to [POST /sequences/delete](tag/Sequences/operation/deleteSequences). Setting this to true will prevent the operation from failing if one or more of the given sequences do not exist; instead, those given sequences that do exist will be deleted.\n\n## 2021-12-07\n\n### Transformations\n\n#### Added\n\n- New [Transformations](tag//Transformations) APIs to v1 to create,retrieve,list and delete transformations\n- New [Transformation Jobs](tag//Transformation-Jobs) APIs to v1 to retrieve and list transformation jobs or job metrics\n- New [Transformation Schedule](tag//Transformation-Schedules) APIs to v1 to manage schedules of transformations\n- New [Transformation Notifications](tag//Transformation-Notifications) APIs to v1 to manage notifications from transformation job\n\n## 2021-11-22\n\n### Contextualization\n\n#### Added\n\n- Added [diagram detect](tag/Engineering-diagrams/operation/diagramDetect) endpoint to v1 to detect annotations in engineering diagrams\n- Added [diagram detect results](tag/Engineering-diagrams/operation/diagramDetectResults) endpoint to v1 to get the results from an engineering diagram detect job\n- Added [diagram convert](tag/Engineering-diagrams/operation/diagramConvert) endpoint to v1 to create interactive engineering diagrams in SVG format with highlighted annotations\n- Added [diagram convert results](tag/Engineering-diagrams/operation/diagramConvertResults) endpoint to v1 to get the results for a job converting engineering diagrams to SVGs\n\n## 2021-11-17\n\n### 3D\n\n#### Added\n\n- Added `dataSetId` support to 3D models enabling data access scoping of 3D data\n\n## 2021-10-13\n\n### Raw\n\n#### Changed\n\n- To align with Microsoft Azure clusters, table and database names are now sensitive to trailing spaces also in Google Cloud Platform clusters.\n\n## 2021-10-05\n\n### Extraction Pipelines\n\n#### Added\n\n- New [Extraction Pipelines](tag//Extraction-Pipelines) resource to document extractors and monitor the status of data ingestion to make sure reliable and trustworthy data are flowing into the CDF data sets.\n- API endpoints for creating, managing, and deleting extraction pipelines. Capture common attributes around extractors such as owners, contacts, schedule, destination RAW databases, and data set. Document structured metadata in the form of key-value attributes as well unstructured `documentation` attribute that supports Markdown (rendered as Markdown in Fusion).\n- Extraction Pipelines Runs are CDF objects to store statuses related to an extraction pipeline. The supported statuses are: `success`, `failure` and `seen`. They enable extractor developers to report status and error message after ingesting data. As well enables for reporting heartbeat through `seen` status by the extractor to easily identify issues related to crushed applications and scheduling issues.\n\n## 2021-09-28\n\n### Sequences\n\n#### Added\n\n- Added `partition` parameter to the [GET /sequences](tag/Sequences/operation/listSequences) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n- [POST /sequences/list](tag/Sequences/operation/advancedListSequences) now supports [parallel retrieval](section/Parallel-retrieval).\n\n### Time series\n\n#### Added\n\n- Added `partition` parameter to the [GET /timeseries](tag/Time-series/operation/getTimeSeries) endpoint to support [parallel retrieval](section/Parallel-retrieval).\n\n## 2021-08-18\n\n### IAM (Identity and access management)\n\n#### Added\n\nAdded sessions to [v1](tag//Sessions). Sessions let you securely delegate access to CDF resources for CDF services (such as Functions) by an external principal and for an extended time.\n\n## 2021-08-12\n\n### Relationships\n\n#### Added\n\n- Relationships now support [Parallel Retrieval](section/Parallel-retrieval)\n\n## 2021-07-01\n\n### 3D\n\n#### Added\n\n- Added filter3dNodes endpoint to allow for more advanced filtering on node metadata\n\n## 2021-06-29\n\n### Labels\n\n#### Added\n\n- [Dataset scoping](tag/Labels/operation/listLabels) based on `dataSetIds`.\n\n## 2021-06-08\n\n### Sequences\n\n#### Added\n\n- Added [syntax for updating columns](tag/Sequences/operation/updateSequences) of existing sequences. Can `remove` columns, `modify` existing columns, and `add` new columns as well.\n\n## 2021-06-01\n\n### Assets\n\n#### Added\n\n- Added labels replace (set) method for [assets update](tag/Assets/operation/updateAssets).\n\n## 2021-04-28\n\n### Time series\n\n#### Changed granularity limits on hour aggreagates\n\nYou can now ask for a [granularity](https://docs.cognite.com/dev/concepts/aggregation/#granularity)\nof up to 100000 hours (previously 48 hours), both in normal aggregates and in synthetic time series.\n\n## 2021-04-12\n\n### IAM (Identity and access management)\n\n#### Added\n\n- Added a [projects list](tag/Projects/operation/listProjects) endpoint to v1\n- Added a [token inspection](tag/Token/operation/inspectToken) endpoint to v1\n\n## 2021-04-06\n\n### Authentication\n\n#### Deprecated\n\nWe are deprecating authentication via CDF service accounts and API keys, and user sign-in via `/login`, in favor of registering applications and services with your IdP (identity provider) and [using OpenID Connect](https://docs.cognite.com/cdf/access/) and the IdP framework to manage CDF access securely.\n\nThe legacy authentication flow is available for customers using Cognite Data Fusion (CDF) on GCP until further notice. We strongly encourage customers to adopt [the new authentication flows](https://docs.cognite.com/cdf/access/) as soon as possible.\n\nThe following API endpoints are deprecated:\n\n- `/api/v1/projects/*/apikeys`\n- `/api/v1/projects/*/serviceaccounts`\n- `/login`\n- `/logout`\n- `/api/v1/projects/*/groups/serviceaccounts` <sup>\\*</sup>\n\n<sup>\\*</sup>only the sub-resources for listing, adding, and removing members of groups.\n\n## 2021-03-22\n\nCDF API 0.5, 0.6 reached their end-of-life after its initial deprecation announcement in Summer 2019.\n\n## 2021-03-10\n\n### 3D\n\n#### Added\n\n- Added `partition` parameter to the List 3D Nodes endpoint for supporting parallel requests.\n- Added `sortByNodeId` parameter to the List 3D Nodes endpoint, improving request latency in most cases if set to `true`.\n\n## 2021-02-26\n\n### Entity matching\n\n#### Fixed\n\n- Fixed a bug in the documentation for Entity matching. The (job) `status` shall be capitalized string.\n\n## 2020-12-22\n\n### Files\n\n#### Added\n\n- New field `fileType` inside `derivedFields` to refer to a pre-defined subset of MIME types.\n- New filter `fileType` inside `derivedFields` to find files with a pre-defined subset of MIME types.\n\n## 2020-10-20\n\n### Files\n\n#### Added\n\n- New field `geoLocation` to refer to the geographic location of the file.\n- New filter `geoLocation` to find files matching a certain geographic location.\n\nTo learn how to leverage new geoLocation features, [follow our guide](https://developer.cognite.com/dev/concepts/resource_types/files.html).\n\n## 2020-08-29\n\n### Files\n\n#### Added\n\n- New field `directory` referring to the directory in the source containing the file.\n- New filter `directoryPrefix` allows you to find Files matching a certain directory prefix.\n\n## 2020-08-05\n\n### Files\n\n#### Added\n\n- New field `labels` allows you to attach labels to Files upon creation or updating.\n- New filter `labels` allows you to find Files that have been annotated with specific labels.\n\n## 2020-07-08\n\n### IAM (Identity and access management)\n\n#### Added\n\n- New project field `applicationDomains`. If this field is set, users only sign in to the project through applications hosted on\n  a whitelisted domain. [Read more](https://developer.cognite.com/dev/guides/iam/#application-domains).\n\n## 2020-07-01\n\n### Events\n\n#### Added\n\n- New aggregation [`uniqueValues`](tag/Events/operation/aggregateEvents) allows you to find different types, subtypes of events in your project.\n\n## 2020-06-29\n\n### Labels\n\n#### Added\n\n- New data organization resource: [labels](tag//Labels). Manage terms that you can use to annotate and group assets.\n\n### Assets\n\n#### Added\n\n- New filter `labels` allows you to find resources that have been annotated with specific labels.\n\n### Time series\n\n#### Added\n\n- Combine various input time series, constants and operators with on-the-fly [synthetic time series](https://developer.cognite.com/dev/concepts/resource_types/synthetic_timeseries.html).\n\n## 2020-04-28\n\n### Events\n\n#### Added\n\n- New filtering capabilities to find open events [`endTime=null`](tag/Events/operation/advancedListEvents).\n- New filtering capabilities to find all events intersecting a timespan using [activeAtTime](tag/Events/operation/advancedListEvents).\n\n## 2020-03-12\n\n### General\n\n#### Added\n\n- New data organization resource: [data sets](tag//Data-sets). Document and track data lineage, ensure data integrity, and allow 3rd parties to write their insights securely back to your Cognite Data Fusion (CDF) project.\n- New attribute `datasetId` introduced in assets, files, events, time series and sequences.\n- New filter `dataSetIds` allows you to narrow down results to resources containing `datasetId` by a list of ids or externalIds of a data set. Supported by assets, files, events, time series and sequences.\n- We have added a new aggregation endpoint for [time series](tag/Files/operation/aggregateFiles). With this endpoint, you can find out how many results in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Groups\n\n#### Added\n\n- Introduced a new capability: `datasetsAcl` for managing access to data set resources.\n- New scope `datasetScope` for assets, files, events, time series and sequences ACLs. Allows you to scope down access to resources contained within a specified set of data sets.\n\n## 2020-03-10\n\n### 3D\n\n#### Fixed\n\n- We fixed a bug in the documentation of [3D model revisions](tag/3D-Model-Revisions/operation/get3DNodesById). Applications should anticipate that 3D nodes may not have a bounding box.\n\n## 2020-02-25\n\n### Assets\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Assets/operation/aggregateAssets) for assets. With this endpoint, you can find out how many assets in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n### Events\n\n#### Added\n\n- We have added a new [aggregation endpoint](tag/Events/operation/aggregateEvents) for events. With this endpoint, you can find out how many events in a tenant meet the criteria of a filter. We will expand this feature to add more aggregates than `count`.\n\n## 2020-02-12\n\n### Assets\n\n#### Added\n\n- We have added new aggregation properties: `depth` and `path`. You can use the properties in the filter and retrieve endpoints.\n\n## 2020-02-10\n\n### Assets\n\n#### Added\n\n- Added the property `parentExternalId` which is returned for all assets which have a parent with a defined `externalId`.\n\n## 2019-12-09\n\n### General\n\n#### Added\n\n- Added `assetSubtreeIds` as a parameter to filter, search, and list endpoints for all core resources. `assetSubtreeIds` allows you to specify assets that are subtree roots, and then only retrieve resources that are related to assets within those subtrees.\n\n## 2019-12-04\n\n### Assets\n\n#### Added\n\n- Added the ability to [filter](tag/Assets/operation/searchAssets) assets by parent external IDs.\n\n## 2019-11-18\n\n### Events\n\n#### Added\n\n- [Added the ability to filter events by the external ID of linked assets](tag/Events/operation/advancedListEvents)\n\n## 2019-11-12\n\n### Access control\n\n#### Removed\n\n- Groups can no longer be created with a permissions field in v0.5.\n\n## 2019-10-31\n\n### Assets\n\n#### Added\n\n- [Asset search](/api/v1/#operation/searchAssets) now has a `search.query` parameter. This uses an improved search algorithm that tries a wider range of variations of the input terms and gives much better relevancy ranking than the existing `search.name` and `search.description` fields.\n\n### Time Series\n\n#### Changed\n\n- The `search.query` parameter for [time series search](/api/v1/#operation/searchTimeSeries) now uses an improved search algorithm that tries a wider range of variations of the input terms, and gives much better relevancy ranking.\n\n## 2019-10-23\n\n### Files\n\n#### Added\n\n- Added support for updating the `mimeType` for existing files in files/update requests.\n\n## 2019-10-18\n\n### Time Series\n\n#### Added\n\n- Time series expanded their filtering capabilities with new `Filter time series` endpoint, allowing for additional filtering by:\n\n  - Name\n  - Unit\n  - Type of time series: string or step series\n  - Metadata objects\n  - ExternalId prefix filtering\n  - Create and last updated time ranges\n\n  Endpoint in addition support pagination and partitioning. Check out detailed API documentation [here](/api/v1/#operation/listTimeSeries).\n\n## 2019-10-16\n\n### Events\n\n#### Added\n\n- [Added the ability to sort events on startTime, endTime, createdTime, and lastUpdatedTime](tag/Events/operation/advancedListEvents)\n\n## 2019-10-02\n\n### Sequences\n\n#### Added\n\n- Introducing the new **sequences** core resource type that lets you store numerically indexed multi-column rows of data. Connect your sequences to physical assets and to their source systems through `externalId` and metadata support. Read more [here](https://developer.cognite.com/dev/concepts/resource_types/sequences.html).\n\n## 2019-09-30\n\n### 3D\n\n#### Added\n\n- Added endpoint to get multiple nodes for a 3D model by their IDs.\n- Added endpoint to get asset mappings for multiple node IDs or asset IDs.\n\n## 2019-09-23\n\n### Files\n\n#### Added\n\n- Added support for filter on `rootAssetIds` in files GET /files (using query parameter) and POST /files/list (in request body).\n\n## 2019-09-16\n\n### Assets and Events\n\n#### Added\n\n- Added support for `partition` in `/assets` and `/events` to support parallel retrieval. See guide for usage [here](./concepts/pagination)\n\n## 2019-08-22\n\n### 3D\n\n#### Added\n\n- Added the query parameter `intersectsBoundingBox` to the list asset mappings endpoint. The parameter filters asset mappings to the assets where the bounding box intersects (or is contained within) the specified bounding box.\n\n## 2019-08-21\n\n### Files\n\n#### Added\n\n- Added support for sourceCreatedTime and sourceModifiedTime fields in files v1 endpoints.\n\n### Assets\n\n#### Added\n\n- Allow the parent asset ID to be updated. The root asset ID must be preserved, and you can not convert a non-root asset to a root asset or vice versa.\n- Support for ignoreUnknownIds when deleting assets.\n\n## 2019-08-15\n\n### 3D\n\n#### Added\n\n- Properties field for 3D nodes, extracted from uploaded 3D files.\n- Ability to filter nodes with a specific set of properties.\n\n## 2019-07-24\n\n### Files\n\n#### Changed\n\n- Allow lookup of names with length up to 256 characters (was 50) for GET /files and POST /files/search operations.\n- Allow creating and retrieving files with mimeType length up to 256 characters (was 64).\n\n## 2019-07-15\n\n### Time series\n\n#### Added\n\n- Added query parameter `rootAssetIds` to list time series endpoint. Returns time series that are linked to an asset that has one of the root assets as an ancestor.\n\n## 2019-07-11\n\nList of changes for initial API v1 release in comparison to previous version - API 0.5\n\n### General\n\n#### Added\n\n- Support for `externalId` added across resource types. `externalId` lets you define a unique ID for a data object. Learn more: [External IDs](https://developer.cognite.com/dev/concepts/external_id.html)\n- `externalIdPrefix` added as a parameter to the list events, assets and files operations.\n- Richer filtering on the list assets, files and events operations.\n- Search, list and filter operations for assets, events and files now support filtering on source and metadata field values.\n\n#### Changed\n\n- Core resources standardize on HTTP methods and URI naming for common operations such as search, partial updates, delete, list and filter\n- API responses are no longer wrapped in a top level `data` object.\n- Standardized pagination across resources through `limit`, `cursor` and `nextCursor` parameters.\n- The `limit` parameter no longer implicitly rounds down requested page size to maximum page size.\n- Standardized error responses and codes across all resources. Errors across CDF can be parsed into a single model.\n- Overall improvements to reference documentation. Including documented input constraints, required fields, individual attribute descriptions.\n\n#### Removed\n\n- The `sourceId` field has been removed from resources. Use `externalId` instead of `sourceId`+`source` to define unique IDs for data objects.\n- Sorting is removed from the search operations for files, assets, events and time series. Results are sorted by relevance.\n- `offset` and `previousCursor` parameters are no longer supported for pagination across resources.\n- Fetching an asset subtree is no longer supported by files, assets, events and time series.\n\n### Assets\n\n#### Added\n\n- Ability to select only root assets though new `root` filter.\n- Added the `rootId` field to specify the top element in an asset hierarchy.\n- Added the ability to filter by the root asset ID. This allows you to scope queries for one or many asset hierarchies.\n- List Assets allows for filtering assets belonging to set of root assets, specified by list of asset internal ids. New query parameter: `rootIds`.\n- Filter and Search Assets allows or filtering assets belonging to a set of root assets, specified by combination of internal and external asset identifiers. New body attribute: `rootIds`.\n\n#### Changed\n\n- Updating a single asset is no longer supported through a separate endpoint. Use the update multiple endpoint instead.\n- Delete assets by default removes only leaf assets (assets without children). New parameter 'recursive' allows for enabling recursive removal of the entire subtree of the asset pointed by ID (API 0.5 behaviour).\n\n#### Removed\n\n- Overwriting assets is no longer supported.\n- Filtering assets by their complete description is no longer supported.\n- Locating assets fuzzily by name has been removed. Instead, search for assets on the `name` property.\n- When searching assets, querying over both name and description in the same query is no longer supported.\n- The experimental query parameter `boostName` has been removed from the search for assets operation.\n- Removed the `path` and `depth` fields.\n\n### Events\n\n#### Added\n\n- Events can now be filtered on asset ID in combination with other filters.\n- New filter `rootAssetIds` allows for narrowing down events belonging only to list or specified root assets. Supported by Filter and Search API\n\n#### Removed\n\n- Events can no longer be filtered by empty description.\n- The 'dir' parameter has been removed from the search events operation.\n\n### Files\n\n#### Added\n\n- Filtering files by `assetIds` in list files operations now support multiple assets in the same request.\n\n#### Changed\n\n- Download file content has changed from HTTP GET to HTTP POST method.\n- We have renamed the `fileType` field to `mimeType`. The field now requires a MIME formatted string (e.g. `text/plain`).\n- We have renamed the `uploadedAt` field to `uploadedTime`.\n- Resumable is now the default behavior for file uploads.\n- Update metadata for single files is no longer supported by a separate operation. Instead, use the update multiple operation.\n\n#### Removed\n\n- Replace files metadata endpoint has been removed.\n- Directory has been removed as a property of files.\n- Updating the `name` or `mimeType` of a file through the update multiple files operation is no longer supported.\n- Query parameter for specifying the sort direction has been removed from list all files operations.\n\n### Raw\n\n#### Changed\n\n- Raw has changed structure to become resource-oriented. The URL structure has changed.\n- Recursively delete of tables and rows when deleting a database is now the default behavior without a control parameter.\n\n### Time series\n\n#### Added\n\n- Support for adding datapoints by `id` and `externalId` of time series. Adding datapoints to time series by `name` has been removed.\n- Add ability to update the new `externalId` attribute for time series.\n- Allow to set `externalId` during creation of time series. `ExternalId` requires uniqueness across time series.\n- Consolidate multiple APIs to allow adding datapoints into a single endpoint. Allows datapoints to be added to multiple time series at the same time.\n- Retrieve data points by using `id` and `externalId` of the time series.\n- Time series created through API v1 are not discoverable by API 0.3, 0.4, 0.5 and 0.6 by default. Introduce the option to enable this compatibility by setting new attribute - `legacyName` on time series creation. Value is required to be unique.\n\n#### Changed\n\n- Get latest datapoints has been reworked. Introduces support for `id` and `externalId` lookup as well retrieval for multiple time series within the same request.\n- Time series name is no longer limited by uniqueness. Note that time series (meta objects) created by API v1 will not be discoverable by older API versions.\n- Delete time series endpoint has been redesigned to allow deletion of multiple time series by `id` and `externalId`.\n- Delete single and multiple datapoints endpoint has been redesigned and consolidated into a single endpoint. New delete allows selection of multiple time series and time ranges by `id` and `externalId`. Selecting by `name` is no longer available.\n- Update multiple time series restructured to support lookup by `externalId`.\n- Retrieve time series by ID endpoint restructured adding the ability to get time series by `externalId`.\n- Set limit for data point value to min -1E100, max 1E100.\n\n#### Removed\n\n- Experimental feature for performing calculations across multiple time series (synthetic time series), function and alias attributes are no longer available.\n- The experimental query parameter `boostName` has been removed from search operation.\n- Short names for aggregate functions are no longer supported.\n- Ability to remove time series by `name` have been removed as names are no longer unique identifiers.\n- Select multiple time series and time ranges by `name` is no longer available.\n- The ability to update `isString` and `isStep` attributes is removed. The attributes are not intended to be modified after creation of time series.\n- The endpoint for updating single time series is removed. Use the update multiple time series endpoint instead.\n- Remove ability to overwrite time series object by `id`. Use the update multiple time series endpoint instead.\n- The ability to retrieve time series matching by `name` has been removed. Use `externalId` instead.\n- The ability to retrieve by `id` from a single time series has been removed. Use retrieve multiple datapoints for multiple time series instead.\n- The ability to retrieve time-aligned datapoints through \"dataframe\" API has been removed. Similar functionality is available through our supported SDKs.\n- The ability to add datapoints to time series by `name` has been removed.\n- The ability to look up by time series `name` has been removed.\n\n### IAM (Identity and access management)\n\n#### Added\n\n- The login status endpoint includes the ID of the API key making the request (new attribute: `apiKeyId`), if the request used an API key.\n\n#### Changed\n\n- The user resource type has been replaced with service accounts. Users from previous API versions are equivalent to service accounts.\n- Adding, listing and removing users from a group has been replaced by equivalent operations for service accounts.\n- Retrieve project returns a single object instead of a list.\n- API keys endpoints for list/create rename `userId` attribute to `serviceAccountId`.\n\n#### Removed\n\n- List and create groups no longer use the `permissions` and `source` attributes.\n\n### 3D\n\n#### Added\n\n- New 3D API lets you upload and process 3D models. Supported format: FBX.\n- Ability to create and maintain multiple revisions for the 3D models.\n- API for mapping relationships between 3D model nodes and asset hierarchy.\n"
     },
     {
       "name": "Token",
@@ -64087,7 +74861,7 @@
     },
     {
       "name": "Assets",
-      "description": "The assets resource type stores digital representations of objects or\ngroups of objects from the physical world. Assets are organized in hierarchies.\nFor example, a water pump asset can be a part of a subsystem asset on an\noil platform asset.\n\n## Rate and concurrency limits\n\nBoth the rate of requests (denoted as request per second, or ‘**rps**’) and the number of concurrent (parallel) requests are governed by limits, \nfor all CDF API endpoints.  If a request exceeds one of the limits, \nit will be throttled with a `429: Too Many Requests` response. More on limit types \nand how to avoid being throttled is described \n[here](https://developer.cognite.com/dev/concepts/request_throttling/).\n\nLimits are defined at both the overall API service level, and on the API endpoints belonging to the service.  \nSome types of requests consume more resources (compute, storage IO) than others, and where a service handles \nmultiple concurrent requests with varying resource consumption. \nFor example, ‘CRUD’ type requests (**C**reate, **R**etrieve, **R**equest ByIDs, **U**pdate and **D**elete) are far less resource \nintensive than ‘Analytical’ type requests (List, Search and Filter) and in addition, the most resource \nintensive Analytical endpoint of all, Aggregates, receives its own request budget within the overall Analytical request budget.  \nThe version 1.0 limits for the overall API service and its constituent endpoints are illustrated in the diagram below.  \nThese limits are subject to change, pending review of changing consumption patterns and resource availability over time:\n\n<img src=\"https://apps-cdn.cogniteapp.com/@cognite/docs-portal-images/1.0.0/images/api-docs/AssetsLimitsFeb2023.png\" alt=\" \" width=\"80%\"/>\n\n### Translating RPS into data speed\nA single request may retrieve up to 1000 items.  In the context of Assets, 1 item = 1 asset record  \nTherefore, the maximum theoretical data speed at the top API service level is 200,000 items per second for all consumers, \nand 150,000 for a single identity or client in a project.\n\n### Use of Partitions / Parallel Retrieval\nAs a general guidance, Parallel Retrieval is a technique that should be used where due to query complexity, retrieval of data in a \nsingle request session turns out to be slow.  By parallelizing such requests, data retrieval performance can be tuned to meet the \nclient application needs.  Parallel retrieval may also be used where retrieval of large sets of data is required, up to the \ncapacity limits defined for a given API service.  For example (using the Assets API request budget):\n\n* A single request may retrieve up to 1000 items\n* Up to 23 requests per second may be issued for an analytical query (per identity), such as when using /list or /filter API endpoints\n* This provides a theoretical maximum of 23,000 items read per second per identity\n* The query complexity may result in it taking longer than 1s to read or write 1000 items in a single request\n* Therefore, it is appropriate to specify the query to retrieve a lower number of items per request, and retrieve more items in parallel, up to the theoretical maximum performance of 23,000 items per second.\n\n**Important Note:** \nParallel retrieval should be only used in situations where, due to query complexity, \na single request flow provides data retrieval speeds that are significantly less than the theoretical maximum.  \nParallel retrieval does not act as a speed multiplier on optimally running queries.  Regardless of the number \nof concurrent requests issued, the overall requests per second limit still applies.  \nSo for example, a single request returning data at approximately 18,000 items per second will only \nbenefit from adding a second parallel request, the capacity of which goes somewhat wasted \nas only an additional 5,000 items per second will return before the request rate budget limit is reached."
+      "description": "The assets resource type stores digital representations of objects or\ngroups of objects from the physical world. Assets are organized in hierarchies.\nFor example, a water pump asset can be a part of a subsystem asset on an\noil platform asset.\n\n## Rate and concurrency limits\n\nBoth the rate of requests (denoted as request per second, or ‘**rps**’) and the number of concurrent (parallel) requests are governed by limits,\nfor all CDF API endpoints.  If a request exceeds one of the limits,\nit will be throttled with a `429: Too Many Requests` response. More on limit types\nand how to avoid being throttled is described\n[here](https://developer.cognite.com/dev/concepts/request_throttling/).\n\nLimits are defined at both the overall API service level, and on the API endpoints belonging to the service.\\\nSome types of requests consume more resources (compute, storage IO) than others, and where a service handles\nmultiple concurrent requests with varying resource consumption.\nFor example, ‘CRUD’ type requests (**C**reate, **R**etrieve, **R**equest ByIDs, **U**pdate and **D**elete) are far less resource\nintensive than ‘Analytical’ type requests (List, Search and Filter) and in addition, the most resource\nintensive Analytical endpoint of all, Aggregates, receives its own request budget within the overall Analytical request budget.\\\nThe version 1.0 limits for the overall API service and its constituent endpoints are illustrated in the diagram below.\\\nThese limits are subject to change, pending review of changing consumption patterns and resource availability over time:\n\n<img src=\"https://apps-cdn.cogniteapp.com/@cognite/docs-portal-images/1.0.0/images/api-docs/AssetsLimitsFeb2023.png\" alt=\" \" width=\"80%\"/>\n\n### Translating RPS into data speed\nA single request may retrieve up to 1000 items.  In the context of Assets, 1 item = 1 asset record\\\nTherefore, the maximum theoretical data speed at the top API service level is 200,000 items per second for all consumers,\nand 150,000 for a single identity or client in a project.\n\n### Use of Partitions / Parallel Retrieval\nAs a general guidance, Parallel Retrieval is a technique that should be used where due to query complexity, retrieval of data in a\nsingle request session turns out to be slow.  By parallelizing such requests, data retrieval performance can be tuned to meet the\nclient application needs.  Parallel retrieval may also be used where retrieval of large sets of data is required, up to the\ncapacity limits defined for a given API service.  For example (using the Assets API request budget):\n\n* A single request may retrieve up to 1000 items\n* Up to 23 requests per second may be issued for an analytical query (per identity), such as when using /list or /filter API endpoints\n* This provides a theoretical maximum of 23,000 items read per second per identity\n* The query complexity may result in it taking longer than 1s to read or write 1000 items in a single request\n* Therefore, it is appropriate to specify the query to retrieve a lower number of items per request, and retrieve more items in parallel, up to the theoretical maximum performance of 23,000 items per second.\n\n**Important Note:**\nParallel retrieval should be only used in situations where, due to query complexity,\na single request flow provides data retrieval speeds that are significantly less than the theoretical maximum.\\\nParallel retrieval does not act as a speed multiplier on optimally running queries.  Regardless of the number\nof concurrent requests issued, the overall requests per second limit still applies.\\\nSo for example, a single request returning data at approximately 18,000 items per second will only\nbenefit from adding a second parallel request, the capacity of which goes somewhat wasted\nas only an additional 5,000 items per second will return before the request rate budget limit is reached."
     },
     {
       "name": "Data Modeling",
@@ -64095,7 +74869,7 @@
     },
     {
       "name": "Events",
-      "description": "Events objects store complex information about multiple assets over a time period.  \nTypical types of events that would be stored in this service might include Alarms, Process Data, and Logs.  \nFor the storage of low volume, manually generated, schedulable activities (such as maintenance schedules, \nwork orders or other ‘appointment’ type activities, the Data Modelling service is now recommended.\n\n#### Important Note: \nEvents and Time Series are somewhat closely related in that both are high volume types of data, \ncapable of recording data in microsecond resolutions.  However, Events is not recommended as a Time Series store, \nsuch as where the data flow is from a single instance of sensors (i.e. temperature, pressure, voltage), \nsimulators or state machines (on, off, disconnected, etc).  \nTime Series offers very low latency read and write performance, as well as specialised filters and aggregations that \nare tailored to the analysis of time series data.\n\nAn event’s time period is defined by a start time and end time, both millisecond timestamps since the UNIX epoch. \nThe timestamps can be in the future. In addition, events can have a text description as well as arbitrary metadata and properties.  \nWhen storing event information in metadata, it should be considered that all data is stored as string format.\n\n**Caveats:**  \nDue to the eventually consistent nature of Asset IDs stored in Events, \nit should be noted that Asset ID references obtained from the Events API may \noccasionally be invalid (such as if an Asset ID is deleted, \nbut the reference to that ID remains in the Event record for a time).\n\nAsset references obtained from an event - through asset ids - may be\ninvalid, simply by the non-transactional nature of HTTP.\nThey are maintained in an eventual consistent manner.\n\n## Rate and concurrency limits\n\nBoth the rate of requests (denoted as request per second, or ‘**rps**’) and the number of concurrent (parallel) requests are governed by limits, \nfor all CDF API endpoints.  If a request exceeds one of the limits, \nit will be throttled with a `429: Too Many Requests` response. More on limit types \nand how to avoid being throttled is described \n[here](https://developer.cognite.com/dev/concepts/request_throttling/).\n\nLimits are defined at both the overall API service level, and on the API endpoints belonging to the service.  \nSome types of requests consume more resources (compute, storage IO) than others, and where a service handles \nmultiple concurrent requests with varying resource consumption. \nFor example, ‘CRUD’ type requests (**C**reate, **R**etrieve, **R**equest ByIDs, **U**pdate and **D**elete) are far less resource \nintensive than ‘Analytical’ type requests (List, Search and Filter) and in addition, the most resource \nintensive Analytical endpoint of all, Aggregates, receives its own request budget within the overall Analytical request budget.  \nThe version 1.0 limits for the overall API service and its constituent endpoints are illustrated in the diagram below.  \nThese limits are subject to change, pending review of changing consumption patterns and resource availability over time:\n\n<img src=\"https://apps-cdn.cogniteapp.com/@cognite/docs-portal-images/1.0.0/images/api-docs/EventsLimitsNov23.png\" alt=\" \" width=\"80%\"/>\n\n### Translating RPS into data speed\nA single request may retrieve up to 1000 items.  In the context of Events, 1 item = 1 event record  \nTherefore, the maximum theoretical data speed at the top API service level is 200,000 items per second for all consumers, \nand 150,000 for a single identity or client in a project.\n\n### Use of Partitions / Parallel Retrieval\nAs a general guidance, Parallel Retrieval is a technique that should be used where due to query complexity, retrieval of data in a \nsingle request session turns out to be slow.  By parallelizing such requests, data retrieval performance can be tuned to meet the \nclient application needs.  Parallel retrieval may also be used where retrieval of large sets of data is required, up to the \ncapacity limits defined for a given API service.  For example (using the Events API request budget):\n\n* A single request may retrieve up to 1000 items\n* Up to 23 requests per second may be issued for an analytical query (per identity), such as when using /list or /filter API endpoints\n* This provides a theoretical maximum of 23,000 items read per second per identity\n* The query complexity may result in it taking longer than 1s to read or write 1000 items in a single request\n* Therefore, it is appropriate to specify the query to retrieve a lower number of items per request, and retrieve more items in parallel, up to the theoretical maximum performance of 23,000 items per second.\n\n**Important Note:** \nParallel retrieval should be only used in situations where, due to query complexity, \na single request flow provides data retrieval speeds that are significantly less than the theoretical maximum.  \nParallel retrieval does not act as a speed multiplier on optimally running queries.  Regardless of the number \nof concurrent requests issued, the overall requests per second limit still applies.  \nSo for example, a single request returning data at approximately 18,000 items per second will only \nbenefit from adding a second parallel request, the capacity of which goes somewhat wasted \nas only an additional 5,000 items per second will return before the request rate budget limit is reached."
+      "description": "Events objects store complex information about multiple assets over a time period.\nTypical types of events that would be stored in this service might include Alarms, Process Data, and Logs.\\\nFor the storage of low volume, manually generated, schedulable activities (such as maintenance schedules,\nwork orders or other ‘appointment’ type activities, the Data Modelling service is now recommended.\n\n#### Important Note:\nEvents and Time Series are somewhat closely related in that both are high volume types of data,\ncapable of recording data in microsecond resolutions.  However, Events is not recommended as a Time Series store,\nsuch as where the data flow is from a single instance of sensors (i.e. temperature, pressure, voltage),\nsimulators or state machines (on, off, disconnected, etc).\\\nTime Series offers very low latency read and write performance, as well as specialised filters and aggregations that\nare tailored to the analysis of time series data.\n\nAn event’s time period is defined by a start time and end time, both millisecond timestamps since the UNIX epoch.\nThe timestamps can be in the future. In addition, events can have a text description as well as arbitrary metadata and properties.\\\nWhen storing event information in metadata, it should be considered that all data is stored as string format.\n\n#### Note:\nIn Events API, timestamps are treated as strings when added to\nmetadata fields and aren’t converted to the user’s local time zone.\n\n**Caveats:**\\\nDue to the eventually consistent nature of Asset IDs stored in Events,\nit should be noted that Asset ID references obtained from the Events API may\noccasionally be invalid (such as if an Asset ID is deleted,\nbut the reference to that ID remains in the Event record for a time).\n\nAsset references obtained from an event - through asset ids - may be\ninvalid, simply by the non-transactional nature of HTTP.\nThey are maintained in an eventual consistent manner.\n\n## Rate and concurrency limits\n\nBoth the rate of requests (denoted as request per second, or ‘**rps**’) and the number of concurrent (parallel) requests are governed by limits,\nfor all CDF API endpoints.  If a request exceeds one of the limits,\nit will be throttled with a `429: Too Many Requests` response. More on limit types\nand how to avoid being throttled is described\n[here](https://developer.cognite.com/dev/concepts/request_throttling/).\n\nLimits are defined at both the overall API service level, and on the API endpoints belonging to the service.\\\nSome types of requests consume more resources (compute, storage IO) than others, and where a service handles\nmultiple concurrent requests with varying resource consumption.\nFor example, ‘CRUD’ type requests (**C**reate, **R**etrieve, **R**equest ByIDs, **U**pdate and **D**elete) are far less resource\nintensive than ‘Analytical’ type requests (List, Search and Filter) and in addition, the most resource\nintensive Analytical endpoint of all, Aggregates, receives its own request budget within the overall Analytical request budget.\\\nThe version 1.0 limits for the overall API service and its constituent endpoints are illustrated in the diagram below.\\\nThese limits are subject to change, pending review of changing consumption patterns and resource availability over time:\n\n<img src=\"https://apps-cdn.cogniteapp.com/@cognite/docs-portal-images/1.0.0/images/api-docs/EventsLimitsNov23.png\" alt=\" \" width=\"80%\"/>\n\n### Translating RPS into data speed\nA single request may retrieve up to 1000 items.  In the context of Events, 1 item = 1 event record\\\nTherefore, the maximum theoretical data speed at the top API service level is 200,000 items per second for all consumers,\nand 150,000 for a single identity or client in a project.\n\n### Use of Partitions / Parallel Retrieval\nAs a general guidance, Parallel Retrieval is a technique that should be used where due to query complexity, retrieval of data in a\nsingle request session turns out to be slow.  By parallelizing such requests, data retrieval performance can be tuned to meet the\nclient application needs.  Parallel retrieval may also be used where retrieval of large sets of data is required, up to the\ncapacity limits defined for a given API service.  For example (using the Events API request budget):\n\n* A single request may retrieve up to 1000 items\n* Up to 23 requests per second may be issued for an analytical query (per identity), such as when using /list or /filter API endpoints\n* This provides a theoretical maximum of 23,000 items read per second per identity\n* The query complexity may result in it taking longer than 1s to read or write 1000 items in a single request\n* Therefore, it is appropriate to specify the query to retrieve a lower number of items per request, and retrieve more items in parallel, up to the theoretical maximum performance of 23,000 items per second.\n\n**Important Note:**\nParallel retrieval should be only used in situations where, due to query complexity,\na single request flow provides data retrieval speeds that are significantly less than the theoretical maximum.\\\nParallel retrieval does not act as a speed multiplier on optimally running queries.  Regardless of the number\nof concurrent requests issued, the overall requests per second limit still applies.\\\nSo for example, a single request returning data at approximately 18,000 items per second will only\nbenefit from adding a second parallel request, the capacity of which goes somewhat wasted\nas only an additional 5,000 items per second will return before the request rate budget limit is reached."
     },
     {
       "name": "Files",
@@ -64123,15 +74897,15 @@
     },
     {
       "name": "Data point subscriptions",
-      "description": "A data point subscription is a way to listen to changes to time series data points, in ingestion order.\n\nA single subscription can listen to many time series, and a time series can be part of many subscriptions.\n\nYou listen to subscriptions by calling the “list subscription data“ endpoint. It will return\na list of data point upserts and deleted ranges, together with a cursor to retrieve the next\nbatch of updates. Updates written since the creation of the subscription, up to 7 days ago, can be\nretrieved through the subscription.\n\nSubscriptions can be defined explicitly through a list of time series external ids, or\nimplicitly through a filter. The filter is a subset of the advanced filter query in the regular\n“time series search“ endpoint.\n\nPartitions:\nSubscriptions can be further divided into a number of partitions, for the purpose of\nfetching subscription data in parallel. Each partition will return data in ingestion order,\nbut the order between partitions is not guaranteed.\n\nLimitations:\n- Each subscription can have at most 10000 time series\n- A time series can be part of at most 10 subscriptions\n- A project can have at most 1000 subscriptions, of which 100 filter subscriptions\n- Time series with security categories can not be shown in filter subscriptions\n- Time series without externalId cannot be added to non-filter subscriptions\n- The number of partitions cannot be changed after creation\n\nAccess control: You need READ access to subscriptions ACL to read/list\nsubscriptions or list data, and you need WRITE access to create/update/delete subscriptions.\nFurthermore, you need READ access to the time series you want to get updates from.\nFor filter subscriptions, you either need READ access to all time series, or the filter must\nbe restricted according to your access rights (e.g. by filtering on specific data set IDs).\n\nSubscriptions can have data sets that allow for more granular access\ncontrol. The data set on a subscription does not influence the data\nstream, but allows you to restrict who can read/update the subscription.\n\nExample capabilities:\n```\n[\n    {\"timeSeriesAcl\":{\"actions\":[\"READ\"], \"scope\":{\"all\":{}}}},\n    {\"timeSeriesSubscriptionsAcl\":{\"actions\":[\"WRITE\", \"READ\"], \"scope\":{\"all\":{}}}}\n]\n```"
+      "description": "A data point subscription is a way to listen to changes to time series data points, in ingestion order.\n\nA single subscription can listen to many time series, and a time series can be part of many subscriptions.\n\nYou listen to subscriptions by calling the “list subscription data“ endpoint. It will return\na list of data point upserts and deleted ranges, together with a cursor to retrieve the next\nbatch of updates. Updates written since the creation of the subscription, up to 7 days ago, can be\nretrieved through the subscription.\n\nSubscriptions can be defined explicitly through a list of time series external ids and\ninstance ids, or implicitly through a filter. The filter is a subset of the advanced filter\nquery in the regular “time series search“ endpoint.\n\nPartitions:\nSubscriptions can be further divided into a number of partitions, for the purpose of\nfetching subscription data in parallel. Each partition will return data in ingestion order,\nbut the order between partitions is not guaranteed.\n\nLimitations:\n- Each subscription can have at most 10000 time series.\n- A time series can be part of at most 10 subscriptions.\n- A project can have at most 1000 subscriptions, of which 100 are filter subscriptions.\n- Time series with security categories can not be shown in filter subscriptions.\n- Time series with neither external id nor instance id cannot be added to non-filter subscriptions.\n- The number of partitions cannot be changed after creation.\n\nAccess control:\nYou need READ access to subscriptions ACL to read/list\nsubscriptions or list data, and you need WRITE access to create/update/delete subscriptions.\nFurthermore, you need READ access to the time series you want to get updates from.\nFor filter subscriptions, you either need READ access to all time series, or the filter must\nbe restricted according to your access rights (e.g. by filtering on specific data set IDs).\n\nSubscriptions can have data sets that allow for more granular access\ncontrol. The data set on a subscription does not influence the data\nstream, but allows you to restrict who can read/update the subscription.\n\nExample capabilities:\n```\n[\n    {\"timeSeriesAcl\":{\"actions\":[\"READ\"], \"scope\":{\"all\":{}}}},\n    {\"timeSeriesSubscriptionsAcl\":{\"actions\":[\"WRITE\", \"READ\"], \"scope\":{\"all\":{}}}}\n]\n```"
     },
     {
       "name": "Synthetic Time Series",
-      "description": "Synthetic Time Series (STS) is a way to combine various input time series, constants and operators, to create completely new time series.\n\nFor example can we use the expression `24 * TS{externalId='production/hour'}` to convert from hourly to daily production rates.\n\nBut STS is not limited to simple conversions.\n* We support combination of different time series `TS{id=123} + TS{externalId='hei'}`.\n* Functions of time series `sin(pow(TS{id=123}, 2))`.\n* Aggregations of time series `TS{id=123, aggregate='average', granularity='1h'}+TS{id=456}`\n* Convert time series with `unitExternalId` to another unit `TS{externalId='temp_c', targetUnit='temperature:deg_f'}`.\n\nTo learn more about synthetic time series please follow [our guide](https://developer.cognite.com/dev/concepts/resource_types/synthetic_timeseries.html)."
+      "description": "Synthetic Time Series (STS) is a way to combine various input time series, constants and operators, to create completely new time series.\n\nFor example can we use the expression `24 * TS{externalId='production/hour'}` to convert from hourly to daily production rates.\n\nBut STS is not limited to simple conversions.\n* We support combination of different time series `TS{id=123} + TS{externalId='hei'} / TS{space='data modeling space', externalId='dm id'}`.\n* Functions of time series `sin(pow(TS{id=123}, 2))`.\n* Aggregations of time series `TS{id=123, aggregate='average', granularity='1h'}+TS{id=456}`\n* Convert time series with `unitExternalId` to another unit `TS{externalId='temp_c', targetUnit='temperature:deg_f'}`.\n\nTo learn more about synthetic time series please follow [our guide](https://developer.cognite.com/dev/concepts/resource_types/synthetic_timeseries.html)."
     },
     {
       "name": "Raw",
-      "description": "Manage data in the raw NoSQL database. \nEach project will have a variable number of raw databases, each of which will have a variable number of tables, each of which will have a variable number of key-value objects. \nOnly queries on key are supported through this API.  \n\n### Request and concurrency limits\n\nBoth the rate of requests and the number of concurrent (parallel) requests are governed by limits, \nfor all CDF API endpoints.  If a request exceeds one of the limits, \nit will be throttled with a `429: Too Many Requests` response. More on limit types \nand how to avoid being throttled is described \n[here](https://developer.cognite.com/dev/concepts/request_throttling/).\n\nThe limits for the Raw service are described in the table below. Note that under high load,\nsome deviation from the limits might occur for short periods of time as the service is scaling up.\nThe `/rows` endpoints for inserting and retrieving data are governed by specific data rate limits. \n\n| Limit                 | Per project           | Per user (identity) |\n|-----------------------|-----------------------|---------------------|\n| Concurrency           | 64 parallel requests  | 48 parallel requests|\n| Data rate (retrieve)  | 8.3 GB / 10 minutes   | 6.6 GB / 10 minutes |\n| Data rate (insert)    | 1.6 GB / 10 minutes   | 1.3 GB / 10 minutes |"
+      "description": "Manage data in the raw NoSQL database.\nEach project will have a variable number of raw databases, each of which will have a variable number of tables, each of which will have a variable number of key-value objects.\nOnly queries on key are supported through this API.\\\n\n### Request and concurrency limits\n\nBoth the rate of requests and the number of concurrent (parallel) requests are governed by limits,\nfor all CDF API endpoints.  If a request exceeds one of the limits,\nit will be throttled with a `429: Too Many Requests` response. More on limit types\nand how to avoid being throttled is described\n[here](https://developer.cognite.com/dev/concepts/request_throttling/).\n\nThe limits for the Raw service are described in the table below. Note that under high load,\nsome deviation from the limits might occur for short periods of time as the service is scaling up.\nThe `/rows` endpoints for inserting and retrieving data are governed by specific data rate limits.\n\n| Limit                 | Per project           | Per user (identity) |\n|-----------------------|-----------------------|---------------------|\n| Concurrency           | 64 parallel requests  | 48 parallel requests|\n| Data rate (retrieve)  | 8.3 GB / 10 minutes   | 6.6 GB / 10 minutes |\n| Data rate (insert)    | 1.6 GB / 10 minutes   | 1.3 GB / 10 minutes |"
     },
     {
       "name": "Groups",
@@ -64166,7 +74940,7 @@
     },
     {
       "name": "Vision",
-      "description": "The Vision contextualization endpoints enable extraction of information from imagery data based on their visual content. For example, you can detect external ID or name of assets, detect and read value of gauges or identify common industrial objects in images. \n\nThis service has support for batch processing which enables processing of multiple image files via an asynchronous prediction request. A new contextualization job is triggered by sending a POST request to the service. The response of the POST request contains a job ID, which can then be used to make subsequent calls to check the status and retrieve the results of the job once it is completed."
+      "description": "The Vision contextualization endpoints enable extraction of information from imagery data based on their visual content. For example, you can detect external ID or name of assets, detect and read value of gauges or identify common industrial objects in images.\n\nThis service has support for batch processing which enables processing of multiple image files via an asynchronous prediction request. A new contextualization job is triggered by sending a POST request to the service. The response of the POST request contains a job ID, which can then be used to make subsequent calls to check the status and retrieve the results of the job once it is completed."
     },
     {
       "name": "Documents",
@@ -64202,7 +74976,7 @@
     },
     {
       "name": "Transformations",
-      "description": "Transformations enable users to use Spark SQL queries to transform data from the CDF staging area, RAW, into the CDF data model."
+      "description": "Transformations enable users to use Spark SQL queries to transform\ndata from the CDF staging area, RAW, into the CDF data model.\n\n### Concurrency limits\n\nThe number of concurrent (parallel) jobs are governed by limits. If a request exceeds one of the limits,\nthe job fails to run. This limitation also applies to scheduled transformations.\n\nThe limits for the transformation service are described in the table below. Note that under high load,\nsome deviation from the limits might occur for short periods as the service scales up.\n\n| Limit                 | Per project           |\n|-----------------------|-----------------------|\n| Concurrency           | 10 parallel jobs  |"
     },
     {
       "name": "Transformation Jobs",
@@ -64234,11 +75008,11 @@
     },
     {
       "name": "User profiles",
-      "description": "User profiles is an authoritative source of core user profile information (email, \nname, job title, etc.) for principals based on data from the identity provider \nconfigured for the CDF project.\n\nUser profiles are first created (usually within a few seconds) when a principal issues \na request against a CDF API. We currently don't support automatic exchange of user identity\ninformation between the identity provider and CDF, but the profile data is updated regularly \nwith the latest data from the identity provider for the principals issuing requests against\na CDF API. \n\nNote that the user profile data is mutable, and any updates in the external identity \nprovider may also cause updates in this API. Therefore, you cannot use profile data, \nfor example a user's email, to uniquely identify a principal. The exception is the \n`userIdentifier` property which is _guaranteed_ to be immutable.\n"
+      "description": "User profiles is an authoritative source of core user profile information (email,\nname, job title, etc.) for principals based on data from the identity provider\nconfigured for the CDF project.\n\nUser profiles are first created (usually within a few seconds) when a principal issues\na request against a CDF API. We currently don't support automatic exchange of user identity\ninformation between the identity provider and CDF, but the profile data is updated regularly\nwith the latest data from the identity provider for the principals issuing requests against\na CDF API.\n\nNote:\n- Do not use other fields than `userIdentifier` (e.g. email) to uniquely identify a\nprincipal. User profile data is mutable and is not guaranteed to be stable or unique (except\n`userIdentifier`).\n- Do not use user profile data for authentication or authorization purposes. It is not\nguaranteed to be under the strict governance necessary for that. For example, one should not\nuse email address as proof of identity or job title to give access to resources.\n- We strongly recommend _against_ storing any user profile data. It is intended for display\npurposes only and may update at any time. Clients should fetch user profile data at demand,\nand optionally cache for performance reasons.\n"
     },
     {
       "name": "Workflows",
-      "description": "Define and orchestrate data workflows consisting of CDF Transformations, Cognite Functions, and other processes.  This service enables you to build data pipelines and business solutions leveraging the capabilities of CDF and external tools."
+      "description": "Define and orchestrate data workflows consisting of CDF Transformations, Cognite Functions, and other processes. This service enables you to build data pipelines and business solutions leveraging the capabilities of CDF and external tools."
     },
     {
       "name": "Workflow versions"
@@ -64248,6 +75022,10 @@
     },
     {
       "name": "Tasks"
+    },
+    {
+      "name": "Workflow triggers",
+      "description": "Triggers allow you to automate the execution of your data workflows based on specific conditions, such as scheduled times (defined by cron expressions)."
     },
     {
       "name": "Sources",
@@ -64266,12 +75044,40 @@
       "description": "A **mapping** is a custom transformation, translating the source format to a format that can be ingested into CDF. Mappings are written in the Cognite transformation language. For more details see documentation [here](https://docs.cognite.com/cdf/integration/guides/extraction/hosted_extractors/hosted_extractors_custom_mappings).\nThis API is in beta. The endpoints listed here are available only when the `cdf-version` header with the value `beta` is provided."
     },
     {
+      "name": "Postgres Gateway Users",
+      "description": "A postgres gateway **user** (also a typical postgres user) owns the foreign tables (built in or custom).\n\nThe created postgres user only has access to use foreign tables and cannot directly create tables users. To create foreign tables use the Postgres Gateway Tables APIs\n"
+    },
+    {
+      "name": "Postgres Gateway Tables",
+      "description": "View and create foreign **tables** for a given **user**"
+    },
+    {
+      "name": "SAP Instances",
+      "description": "This API is in beta. Do not use for production workloads. The endpoints listed here are available only when the `cdf-version` header with the value `beta` is provided.\n\nAn SAP **instance** represents a configuration to an external SAP S/4HANA destination system. The **instance** resource\ncontains all the information this API service needs to connect to an SAP S/4HANA destination.\n\nSupported SAP S/4HANA versions:\n* SAP S/4HANA OnPremise 2021 FPS01, and later\n* SAP S/4HANA Cloud"
+    },
+    {
+      "name": "SAP Endpoints",
+      "description": "This API is in beta. Do not use for production workloads. The endpoints listed here are available only when the `cdf-version` header with the value `beta` is provided.\n\nAn SAP **endpoint** represents a configuration to an SAP S/4HANA OData endpoint (and its related OData entity) the API will send the writeback requests.\nIt defines which SAP Instance destination and which schema mapping should be used when processing a writeback request.\n\nSupported SAP entities:\n* [Maintenance Notifications](https://api.sap.com/api/OP_API_MAINTNOTIFICATION/overview)\n* [Attachments](https://api.sap.com/api/OP_API_CV_ATTACHMENT_SRV_0001/overview)"
+    },
+    {
+      "name": "Schema Mappings",
+      "description": "This API is in beta. Do not use for production workloads. The endpoints listed here are available only when the `cdf-version` header with the value `beta` is provided.\nA **mapping** uses field and value mapping(s) to perform an in-flight transformation from source CDF entities to SAP S/4HANA entities. Mappings are written in the Cognite transformation language. For more details see the [documentation](https://docs.cognite.com/cdf/integration/guides/extraction/hosted_extractors/hosted_extractors_custom_mappings)."
+    },
+    {
+      "name": "Writeback Requests",
+      "description": "This API is in beta. Do not use for production workloads. The endpoints listed here are available only when the `cdf-version` header with the value `beta` is provided. A writeback **request** to the SAP S/4HANA destination. The request body contains the target SAP endpoint destination, and the payload to send."
+    },
+    {
       "name": "Units",
       "description": "Units Catalog API provides a standardized list of units that can be used in Cognite Data Fusion.\nThe content this API serves is based on the [CDF Units Catalog](https://github.com/cognitedata/units-catalog)"
     },
     {
       "name": "Unit Systems",
       "description": "Unit system is a collection of default units for different quantities.\nThis API provides a list of supported unit systems and their associated quantities and respective unit."
+    },
+    {
+      "name": "Organizations",
+      "description": "An **organization** is used to group CDF projects and facilitate their management.\n\nAn organization holds users, projects, and perhaps other organizations. The organization ID is what the users enter\nwhen logging into Cognite apps, such as Cognite Data Fusion. The organization has one IdP configuration, which is used\nfor both interactive login and service account authentication against all projects in the organization.\n\n### External identity providers (IdP)\nCDF supports interfacing with external IdPs to manage users and groups. The following vendors are supported:\n- Microsoft Entra ID (formerly known as Azure AD or Azure Active Directory)\n- Auth0\n- Keycloak\n\n### Users\nIf a user can log into the external IdP configured for the organization, then they have access to the CDF organization.\nWhich of the organization's projects they have access to, and what they may do inside those projects, is determined by\nthe access settings within each project.\n\nAfter a user has logged into the organization for the first time, they will be visible in the organization's user list.\nUsers can see each other, which enables them to collaborate on projects.\n\n### Organization hierarchy\nAn organization can have child organizations. The ownership relationship is materialized through the `parentId`\nfield of the organization resource.\n\n### Projects\nAn organization holds CDF projects. The users that are logged into the organization can see all the projects in the\norganization, but what they can actually do within each project is controlled by the project's access control lists\n(ACLs) and other access control settings.\n\n### Allowed clusters\nAn organization has a list of clusters on which it can hold projects. This is the `allowedClusters` field on the\nresource.\n\n### Organization admins\nAn organization can have admins, which are identified principals that can perform an extended set of modifications on\nthe organization, such as creating projects, changing who the admins are, and so on.\n\nAdmins are identified by the `adminGroupId` field on the organization resource, which is the ID of a group that is\nmanaged in the external IdP.\n\nThe different organization API endpoints have different access rules, which are documented under each endpoint.\nThe general rule is that admins of a given organization have control over most aspects of the organization itself\nand full control of any sub-organizations.\n\n### Authentication for this API\nOrganizations are global, which means that they are not tied to specific projects or clusters.\nAPI requests against organizations are directed to `auth.cognite.com`, instead of a specific cluster and projects\nas for other resources.\n\nOnly OAuth tokens issued by `https://auth.cognite.com` (such as the ones issued when logging into Fusion) are accepted\nby the organizations API.\n\nIt is also possible to obtain a token by initiating a login flow against the authorization server directly. See\nthe \"Authorizations\" sections for more information.\n"
     }
   ]
 }

--- a/packages/stable/src/api/annotations/types.gen.ts
+++ b/packages/stable/src/api/annotations/types.gen.ts
@@ -353,21 +353,21 @@ export interface AnnotationsInstanceRef {
 export interface AnnotationsIsoPlanAnnotation {
   /** Detail describing the equipment. */
   detail?: string;
-  /** Contains a link to a file in CDF. This is used to navigate between files. */
+  /** The asset this annotation is pointing at. Store the id of the file assets to generate downloadable URL. */
   fileRef?: AnnotationsFileRef;
-  /** The indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. E.g. first valve upstreams of <indirectExternalId>. */
+  /** The indirectExternalId is the external id of the equipment used to identify the hotspot indirectly. Exa. this is the <indirectRelation> of <indirectExternalId>. */
   indirectExternalId?: AnnotationsAssetRef;
-  /** Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'upstreams of'. This references the 'indirectExternalId'. */
+  /** Relation connecting this hotspot to a tag in case the hotspot has no tag. E.g. 'second valve upstreams of'. This references the 'indirectExternalId'. */
   indirectRelation?: string;
   /** The id of the Pipe that the hotspot belongs to. */
   lineExternalId?: AnnotationsAssetRef;
-  /** Stores Functional Location (FLOC) external ID represented by the hotspot. */
+  /** Stores Functional Locations (FLOC) external ID linked to the annotation. */
   linkedResourceExternalId?: string;
-  /** Stores the Functional Location (FLOC) ID represented by the hotspot. */
+  /** Stores Functional Locations' (FLOC) ID linked to the annotation. */
   linkedResourceInternalId?: number;
-  /** Whether the hotspot represents an asset (FLOC) or file. */
+  /** Stores Functional Location (FLOC) type the annotation linked to. */
   linkedResourceType?: 'asset' | 'file';
-  /** Temporary field for migration purposes. Id of corresponding legacy annotation. */
+  /** Keep track of data link with old annotations. */
   oldAnnotationId?: string;
   /**
    * The number of the page on which this annotation is located. The first page has number 1.
@@ -375,17 +375,17 @@ export interface AnnotationsIsoPlanAnnotation {
    * @max 100000
    */
   pageNumber?: number;
-  /** Relative position of the relation connecting the hotspot to a tag. E.g. '2nd'. This references the 'indirectExternalId'. */
+  /** Indicate the relative position of an annotation. */
   relativePosition?: string;
-  /** Revision number of the P&ID file that the hotspot is valid for. */
+  /** Keeps track of the modification to an annotation. */
   revision?: string;
   /** Stores the dimensions of a valve or spade. */
   sizeAndClass?: AnnotationsSizeAndClassType;
-  /** Marks the hotspot as user created or detected via pipeline. */
+  /** Use to identify whether the annotation is user created one or ditected via pipeline. */
   sourceType?: 'pipeline' | 'user';
-  /** Additional details, the fluid code for pipes e.g. LO for Lube oil etc. */
+  /** Use to save the fluid code of pipes Exa. LO for Lube oil and etc. */
   subDetail?: string;
-  /** Text found in the area, might be a FLOC, valve detail, pipe or diagram name. */
+  /** The pattern identified by the detection API results. */
   text?: string;
   /** The location of the hotspot represented with a bounding box. */
   textRegion?: AnnotationsBoundingBox;

--- a/packages/stable/src/api/vision/types.gen.ts
+++ b/packages/stable/src/api/vision/types.gen.ts
@@ -333,7 +333,7 @@ export interface FeatureParameters {
   valveDetectionParameters?: ValveDetectionParameters;
 }
 /**
- * An object containing file (external) id.
+ * An external-id or instance-id reference to the referenced file.
  */
 export type FileReference =
   | {
@@ -341,6 +341,9 @@ export type FileReference =
     }
   | {
       fileExternalId: VisionFileExternalId;
+    }
+  | {
+      fileInstanceId: VisionInstanceId;
     };
 /**
  * Detect industrial objects such as gauges and valves in images. In beta. Available only when the `cdf-version: beta` header is provided.
@@ -357,6 +360,14 @@ export interface IndustrialObjectDetectionParameters {
    */
   threshold?: ThresholdParameter;
 }
+/**
+ * @pattern ^[a-zA-Z]([a-zA-Z0-9_]{0,253}[a-zA-Z0-9])?$
+ */
+export type InstanceExternalId = string;
+/**
+ * @pattern ^[a-zA-Z][a-zA-Z0-9_-]{0,41}[a-zA-Z0-9]?$
+ */
+export type InstanceSpace = string;
 /**
  * Contextualization job ID.
  * @format int64
@@ -500,6 +511,8 @@ export interface VisionAllOfFileId {
   fileExternalId?: VisionFileExternalId;
   /** The ID of a file in CDF. */
   fileId: VisionFileId;
+  /** The instance id of a file in CDF. */
+  fileInstanceId?: VisionInstanceId;
 }
 export type VisionExtractFeature =
   | TextDetection
@@ -572,3 +585,11 @@ export type VisionFileExternalId = string;
  * @example 1234
  */
 export type VisionFileId = number;
+/**
+ * The instance id of a file in CDF.
+ * @example {"space":"space","externalId":"externalId"}
+ */
+export interface VisionInstanceId {
+  externalId: InstanceExternalId;
+  space: InstanceSpace;
+}

--- a/packages/stable/src/exports.gen.ts
+++ b/packages/stable/src/exports.gen.ts
@@ -157,6 +157,8 @@ export type {
   FileReference,
   IndustrialObjectDetection,
   IndustrialObjectDetectionParameters,
+  InstanceExternalId,
+  InstanceSpace,
   JobId,
   JobStatus,
   LevelGaugeDetection,
@@ -184,4 +186,5 @@ export type {
   VisionExtractPredictions,
   VisionFileExternalId,
   VisionFileId,
+  VisionInstanceId,
 } from './api/vision/types.gen';


### PR DESCRIPTION
Note: Manually override annotation types that due to being autogenerated from paths got the "cogmono" prefix.

We should address this in the future.