### PR TITLE
chore: bump RC version due to npm version conflict

### DIFF
--- a/packages/alpha/package.json
+++ b/packages/alpha/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",
@@ -23,8 +23,8 @@
     "test-snippets": ""
   },
   "dependencies": {
-    "@cognite/sdk": "^10.0.0-rc.1",
-    "@cognite/sdk-core": "^5.0.0-rc.1"
+    "@cognite/sdk": "^10.0.0-rc.2",
+    "@cognite/sdk-core": "^5.0.0-rc.2"
   },
   "files": [
     "dist"

--- a/packages/beta/package.json
+++ b/packages/beta/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "type": "module",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",
     "test": "yarn g:vitest run",
@@ -22,8 +22,8 @@
     "test-snippets": "yarn extract-snippets && yarn g:tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/sdk": "^10.0.0-rc.1",
-    "@cognite/sdk-core": "^5.0.0-rc.1"
+    "@cognite/sdk": "^10.0.0-rc.2",
+    "@cognite/sdk-core": "^5.0.0-rc.2"
   },
   "files": [
     "dist"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
-  "version": "5.0.0-rc.1",
+  "version": "5.0.0-rc.2",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "type": "module",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0-rc.2",
   "scripts": {
     "clean": "rm -rf dist/ docs/",
     "test": "yarn g:vitest run",
@@ -22,8 +22,8 @@
     "test-snippets": ""
   },
   "dependencies": {
-    "@cognite/sdk": "^10.0.0-rc.1",
-    "@cognite/sdk-core": "^5.0.0-rc.1"
+    "@cognite/sdk": "^10.0.0-rc.2",
+    "@cognite/sdk-core": "^5.0.0-rc.2"
   },
   "files": [
     "dist"

--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",
@@ -22,7 +22,7 @@
     "test-snippets": "yarn extract-snippets && yarn g:tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/sdk-core": "^5.0.0-rc.1",
+    "@cognite/sdk-core": "^5.0.0-rc.2",
     "@types/geojson": "^7946.0.14",
     "geojson": "^0.5.0",
     "lodash": "^4.17.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,8 +204,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-alpha@workspace:packages/alpha"
   dependencies:
-    "@cognite/sdk": "npm:^10.0.0-rc.1"
-    "@cognite/sdk-core": "npm:^5.0.0-rc.1"
+    "@cognite/sdk": "npm:^10.0.0-rc.2"
+    "@cognite/sdk-core": "npm:^5.0.0-rc.2"
   languageName: unknown
   linkType: soft
 
@@ -213,8 +213,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-beta@workspace:packages/beta"
   dependencies:
-    "@cognite/sdk": "npm:^10.0.0-rc.1"
-    "@cognite/sdk-core": "npm:^5.0.0-rc.1"
+    "@cognite/sdk": "npm:^10.0.0-rc.2"
+    "@cognite/sdk-core": "npm:^5.0.0-rc.2"
   languageName: unknown
   linkType: soft
 
@@ -224,7 +224,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk-core@npm:^5.0.0-rc.0, @cognite/sdk-core@npm:^5.0.0-rc.1, @cognite/sdk-core@workspace:packages/core":
+"@cognite/sdk-core@npm:^5.0.0-rc.0, @cognite/sdk-core@npm:^5.0.0-rc.2, @cognite/sdk-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-core@workspace:packages/core"
   dependencies:
@@ -271,8 +271,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-playground@workspace:packages/playground"
   dependencies:
-    "@cognite/sdk": "npm:^10.0.0-rc.1"
-    "@cognite/sdk-core": "npm:^5.0.0-rc.1"
+    "@cognite/sdk": "npm:^10.0.0-rc.2"
+    "@cognite/sdk-core": "npm:^5.0.0-rc.2"
   languageName: unknown
   linkType: soft
 
@@ -285,11 +285,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk@npm:^10.0.0-rc.0, @cognite/sdk@npm:^10.0.0-rc.1, @cognite/sdk@workspace:packages/stable":
+"@cognite/sdk@npm:^10.0.0-rc.0, @cognite/sdk@npm:^10.0.0-rc.2, @cognite/sdk@workspace:packages/stable":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk@workspace:packages/stable"
   dependencies:
-    "@cognite/sdk-core": "npm:^5.0.0-rc.1"
+    "@cognite/sdk-core": "npm:^5.0.0-rc.2"
     "@types/geojson": "npm:^7946.0.14"
     geojson: "npm:^0.5.0"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
We haven't been able to publish release candidates for the new SDK due to a version conflict in NPM as seen [in this failed CD run](https://github.com/cognitedata/cognite-sdk-js/actions/runs/11497972702/job/32002802038).

We manually bump the release candidate from 1 to 2 to resolve the problem.