### PR TITLE
feat(alpha): multiple updates for simint APIs

### DIFF
--- a/packages/alpha/src/__tests__/api/seed.ts
+++ b/packages/alpha/src/__tests__/api/seed.ts
@@ -114,7 +114,6 @@ export const routineRevisionConfiguration: SimulatorRoutineRevisionConfiguration
     schedule: { enabled: false },
     dataSampling: {
       enabled: true,
-      validationWindow: 0,
       samplingWindow: 0,
       granularity: 0,
     },

--- a/packages/alpha/src/__tests__/api/simulationRunsApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunsApi.int.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Cognite AS
 
 import { describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
 import {
   fileExtensionTypes,
@@ -68,7 +69,6 @@ describeIf('simulator runs api', () => {
         name: 'Test Simulator Model',
         description: 'Test Simulator Model Desc',
         dataSetId: 97552494921583,
-        labels: [{ externalId: 'air-quality-po-1' }],
         type: 'WaterWell',
       },
     ]);

--- a/packages/alpha/src/__tests__/api/simulatorIntegrationsApi.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorIntegrationsApi.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Cognite AS
 
 import { describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
 import {
   fileExtensionTypes,

--- a/packages/alpha/src/__tests__/api/simulatorLogsApi.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorLogsApi.spec.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 Cognite AS
 import { describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
 
 const SHOULD_RUN_TESTS = process.env.RUN_SDK_SIMINT_TESTS === 'true';

--- a/packages/alpha/src/__tests__/api/simulatorModelsApi.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorModelsApi.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Cognite AS
 
 import { describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
 import {
   fileExtensionTypes,
@@ -46,7 +47,6 @@ describeIf('simulator models api', () => {
         name: 'Test Simulator Model',
         description: 'Test Simulator Model Desc',
         dataSetId: 97552494921583,
-        labels: [{ externalId: 'air-quality-po-1' }],
         type: 'WaterWell',
       },
     ]);

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.spec.ts
@@ -1,6 +1,8 @@
 // Copyright 2023 Cognite AS
 
 import { describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
+import type { SimulatorRoutineRevision } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 import {
   fileExtensionTypes,
@@ -68,7 +70,6 @@ describeIf('simulator routines api', () => {
         name: 'Test Simulator Model',
         description: 'Test Simulator Model Desc',
         dataSetId: 97552494921583,
-        labels: [{ externalId: 'air-quality-po-1' }],
         type: 'WaterWell',
       },
     ]);
@@ -158,10 +159,45 @@ describeIf('simulator routines api', () => {
   });
 
   test('list routine revision', async () => {
-    const listResponse = await client.simulators.listRoutineRevisions();
+    const listResponse = await client.simulators.listRoutineRevisions({
+      sort: [
+        {
+          property: 'createdTime',
+          order: 'desc',
+        },
+      ],
+    });
     expect(listResponse.items.length).toBeGreaterThan(0);
-    const routineRevisionFound = listResponse.items.find(
+    const routineRevisionFound = listResponse.items.filter(
+      (item) => item.routineExternalId === routineExternalId
+    );
+    expect(routineRevisionFound.length).toBe(1);
+    expect(routineRevisionFound[0].externalId).toBe(
+      `${routineRevisionExternalId}_2`
+    );
+  });
+
+  test('list routine revision include all fields', async () => {
+    const listResponse = await client.simulators
+      .listRoutineRevisions<SimulatorRoutineRevision>({
+        filter: { allVersions: true },
+        includeAllFields: true,
+        sort: [
+          {
+            property: 'createdTime',
+            order: 'desc',
+          },
+        ],
+      })
+      .autoPagingToArray();
+    expect(listResponse.length).toBeGreaterThan(0);
+    const routineRevisionFound = listResponse.find(
       (item) => item.externalId === routineRevisionExternalId
+    );
+    expect(routineRevisionFound).toBeDefined();
+    expect(routineRevisionFound?.script).toEqual(routineRevisionScript);
+    expect(routineRevisionFound?.configuration).toEqual(
+      routineRevisionConfiguration
     );
     expect(routineRevisionFound?.externalId).toBe(routineRevisionExternalId);
   });

--- a/packages/alpha/src/__tests__/api/simulatorsApi.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorsApi.int.spec.ts
@@ -1,6 +1,8 @@
 // Copyright 2023 Cognite AS
 
 import { describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
+import type { SimulatorPatch } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 import {
   fileExtensionTypes,

--- a/packages/alpha/src/api/simulators/integrationsApi.ts
+++ b/packages/alpha/src/api/simulators/integrationsApi.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../types';
 
 export class IntegrationsAPI extends BaseResourceAPI<SimulatorIntegration> {
-  public create = async (items: SimulatorIntegrationCreate[]) => {
+  public create = (items: SimulatorIntegrationCreate[]) => {
     return this.createEndpoint(items);
   };
 
@@ -19,7 +19,7 @@ export class IntegrationsAPI extends BaseResourceAPI<SimulatorIntegration> {
     );
   };
 
-  public delete = async (ids: IdEither[]) => {
+  public delete = (ids: IdEither[]) => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/simulators/integrationsApi.ts
+++ b/packages/alpha/src/api/simulators/integrationsApi.ts
@@ -12,7 +12,7 @@ export class IntegrationsAPI extends BaseResourceAPI<SimulatorIntegration> {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: SimulatorIntegrationFilterQuery) => {
+  public list = (filter?: SimulatorIntegrationFilterQuery) => {
     return this.listEndpoint<SimulatorIntegrationFilterQuery>(
       this.callListEndpointWithPost,
       filter

--- a/packages/alpha/src/api/simulators/modelRevisionsApi.ts
+++ b/packages/alpha/src/api/simulators/modelRevisionsApi.ts
@@ -16,7 +16,7 @@ export class ModelRevisionsAPI extends BaseResourceAPI<SimulatorModelRevision> {
     return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
   }
 
-  public create = async (items: SimulatorModelRevisionCreate[]) => {
+  public create = (items: SimulatorModelRevisionCreate[]) => {
     return this.createEndpoint(items);
   };
 
@@ -31,11 +31,11 @@ export class ModelRevisionsAPI extends BaseResourceAPI<SimulatorModelRevision> {
     return this.retrieveEndpoint(items);
   }
 
-  public update = async (changes: SimulatorModelRevisionChange[]) => {
+  public update = (changes: SimulatorModelRevisionChange[]) => {
     return this.updateEndpoint(changes);
   };
 
-  public delete = async (ids: IdEither[]) => {
+  public delete = (ids: IdEither[]) => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/simulators/modelRevisionsApi.ts
+++ b/packages/alpha/src/api/simulators/modelRevisionsApi.ts
@@ -20,7 +20,7 @@ export class ModelRevisionsAPI extends BaseResourceAPI<SimulatorModelRevision> {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: SimulatorModelRevisionFilterQuery) => {
+  public list = (filter?: SimulatorModelRevisionFilterQuery) => {
     return this.listEndpoint<SimulatorModelRevisionFilterQuery>(
       this.callListEndpointWithPost,
       filter

--- a/packages/alpha/src/api/simulators/modelsApi.ts
+++ b/packages/alpha/src/api/simulators/modelsApi.ts
@@ -25,7 +25,7 @@ export class ModelsAPI extends BaseResourceAPI<SimulatorModel> {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: SimulatorModelFilterQuery) => {
+  public list = (filter?: SimulatorModelFilterQuery) => {
     return this.listEndpoint<SimulatorModelFilterQuery>(
       this.callListEndpointWithPost,
       filter

--- a/packages/alpha/src/api/simulators/modelsApi.ts
+++ b/packages/alpha/src/api/simulators/modelsApi.ts
@@ -21,7 +21,7 @@ export class ModelsAPI extends BaseResourceAPI<SimulatorModel> {
     return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
   }
 
-  public create = async (items: SimulatorModelCreate[]) => {
+  public create = (items: SimulatorModelCreate[]) => {
     return this.createEndpoint(items);
   };
 
@@ -36,11 +36,11 @@ export class ModelsAPI extends BaseResourceAPI<SimulatorModel> {
     return this.retrieveEndpoint(items);
   }
 
-  public update = async (changes: SimulatorModelChange[]) => {
+  public update = (changes: SimulatorModelChange[]) => {
     return this.updateEndpoint(changes);
   };
 
-  public delete = async (ids: IdEither[]) => {
+  public delete = (ids: IdEither[]) => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/simulators/routinesApi.ts
+++ b/packages/alpha/src/api/simulators/routinesApi.ts
@@ -15,7 +15,7 @@ export class RoutinesAPI extends BaseResourceAPI<SimulatorRoutine> {
     return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
   }
 
-  public create = async (items: SimulatorRoutineCreate[]) => {
+  public create = (items: SimulatorRoutineCreate[]) => {
     return this.createEndpoint(items);
   };
 
@@ -26,7 +26,7 @@ export class RoutinesAPI extends BaseResourceAPI<SimulatorRoutine> {
     );
   };
 
-  public delete = async (ids: IdEither[]) => {
+  public delete = (ids: IdEither[]) => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/simulators/routinesApi.ts
+++ b/packages/alpha/src/api/simulators/routinesApi.ts
@@ -1,11 +1,6 @@
 // Copyright 2024 Cognite AS
 
-import {
-  BaseResourceAPI,
-  type CDFHttpClient,
-  type IdEither,
-  type MetadataMap,
-} from '@cognite/sdk-core';
+import { BaseResourceAPI, type IdEither } from '@cognite/sdk-core';
 import type {
   SimulatorRoutine,
   SimulatorRoutineCreate,
@@ -24,7 +19,7 @@ export class RoutinesAPI extends BaseResourceAPI<SimulatorRoutine> {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: SimulatorRoutineFilterQuery) => {
+  public list = (filter?: SimulatorRoutineFilterQuery) => {
     return this.listEndpoint<SimulatorRoutineFilterQuery>(
       this.callListEndpointWithPost,
       filter

--- a/packages/alpha/src/api/simulators/routinesRevisionsAPI.ts
+++ b/packages/alpha/src/api/simulators/routinesRevisionsAPI.ts
@@ -2,8 +2,13 @@
 
 import { BaseResourceAPI, type IdEither } from '@cognite/sdk-core';
 import type {
+  CursorAndAsyncIterator,
+  CursorResponse,
+  HttpResponse,
   SimulatorRoutineRevision,
+  SimulatorRoutineRevisionBase,
   SimulatorRoutineRevisionCreate,
+  SimulatorRoutineRevisionView,
   SimulatorRoutineRevisionsFilterQuery,
 } from '../../types';
 
@@ -12,18 +17,37 @@ export class RoutineRevisionsAPI extends BaseResourceAPI<SimulatorRoutineRevisio
    * @hidden
    */
   protected getDateProps() {
-    return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
+    return this.pickDateProps(['items'], ['createdTime']);
   }
 
   public create = async (items: SimulatorRoutineRevisionCreate[]) => {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: SimulatorRoutineRevisionsFilterQuery) => {
-    return this.listEndpoint<SimulatorRoutineRevisionsFilterQuery>(
-      this.callListEndpointWithPost,
-      filter
+  private callRevisionListEndpoint = async <
+    RevisionResponseType extends SimulatorRoutineRevisionBase,
+  >(
+    query?: SimulatorRoutineRevisionsFilterQuery
+  ): Promise<HttpResponse<CursorResponse<RevisionResponseType[]>>> => {
+    const response = await this.post<CursorResponse<RevisionResponseType[]>>(
+      this.listPostUrl,
+      {
+        data: query || {},
+      }
     );
+    return response;
+  };
+
+  public list = <
+    RevisionResponseType extends
+      SimulatorRoutineRevisionBase = SimulatorRoutineRevisionView,
+  >(
+    query?: SimulatorRoutineRevisionsFilterQuery
+  ): CursorAndAsyncIterator<RevisionResponseType> => {
+    return this.cursorBasedEndpoint<
+      SimulatorRoutineRevisionsFilterQuery,
+      RevisionResponseType
+    >(this.callRevisionListEndpoint, query);
   };
 
   public retrieve(items: IdEither[]) {

--- a/packages/alpha/src/api/simulators/routinesRevisionsAPI.ts
+++ b/packages/alpha/src/api/simulators/routinesRevisionsAPI.ts
@@ -2,7 +2,6 @@
 
 import { BaseResourceAPI, type IdEither } from '@cognite/sdk-core';
 import type {
-  CursorAndAsyncIterator,
   CursorResponse,
   HttpResponse,
   SimulatorRoutineRevision,
@@ -20,7 +19,7 @@ export class RoutineRevisionsAPI extends BaseResourceAPI<SimulatorRoutineRevisio
     return this.pickDateProps(['items'], ['createdTime']);
   }
 
-  public create = async (items: SimulatorRoutineRevisionCreate[]) => {
+  public create = (items: SimulatorRoutineRevisionCreate[]) => {
     return this.createEndpoint(items);
   };
 
@@ -43,7 +42,7 @@ export class RoutineRevisionsAPI extends BaseResourceAPI<SimulatorRoutineRevisio
       SimulatorRoutineRevisionBase = SimulatorRoutineRevisionView,
   >(
     query?: SimulatorRoutineRevisionsFilterQuery
-  ): CursorAndAsyncIterator<RevisionResponseType> => {
+  ) => {
     return this.cursorBasedEndpoint<
       SimulatorRoutineRevisionsFilterQuery,
       RevisionResponseType
@@ -54,7 +53,7 @@ export class RoutineRevisionsAPI extends BaseResourceAPI<SimulatorRoutineRevisio
     return this.retrieveEndpoint(items);
   }
 
-  public delete = async (ids: IdEither[]) => {
+  public delete = (ids: IdEither[]) => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/simulators/simulationRunDataApi.ts
+++ b/packages/alpha/src/api/simulators/simulationRunDataApi.ts
@@ -4,7 +4,7 @@ import { BaseResourceAPI } from '@cognite/sdk-core';
 import type { SimulationRunData, SimulationRunId } from '../../types';
 
 export class SimulationRunDataAPI extends BaseResourceAPI<SimulationRunData> {
-  public retrieve = async (ids: SimulationRunId[]) => {
+  public retrieve = (ids: SimulationRunId[]) => {
     const path = this.url('list');
 
     return this.retrieveEndpoint(ids, {}, path);

--- a/packages/alpha/src/api/simulators/simulationRunsApi.ts
+++ b/packages/alpha/src/api/simulators/simulationRunsApi.ts
@@ -28,7 +28,7 @@ export class SimulationRunsAPI extends BaseResourceAPI<SimulationRun> {
     return this.createEndpoint(items, runUrl);
   };
 
-  public list = async (filter?: SimulationRunFilterQuery) => {
+  public list = (filter?: SimulationRunFilterQuery) => {
     return this.listEndpoint<SimulationRunFilterQuery>(
       this.callListEndpointWithPost,
       filter

--- a/packages/alpha/src/api/simulators/simulationRunsApi.ts
+++ b/packages/alpha/src/api/simulators/simulationRunsApi.ts
@@ -1,11 +1,6 @@
 // Copyright 2023 Cognite AS
 
-import {
-  BaseResourceAPI,
-  type CDFHttpClient,
-  type CogniteInternalId,
-  type MetadataMap,
-} from '@cognite/sdk-core';
+import { BaseResourceAPI, type CogniteInternalId } from '@cognite/sdk-core';
 import type {
   SimulationRun,
   SimulationRunCreate,
@@ -23,7 +18,7 @@ export class SimulationRunsAPI extends BaseResourceAPI<SimulationRun> {
     );
   }
 
-  public run = async (items: SimulationRunCreate[]) => {
+  public run = (items: SimulationRunCreate[]) => {
     const runUrl = this.url().slice(0, -2); // `/run` instead of `/runs`
     return this.createEndpoint(items, runUrl);
   };
@@ -35,7 +30,7 @@ export class SimulationRunsAPI extends BaseResourceAPI<SimulationRun> {
     );
   };
 
-  public retrieve = async (ids: CogniteInternalId[]) => {
+  public retrieve = (ids: CogniteInternalId[]) => {
     const items = ids.map((id) => ({ id }));
     return this.retrieveEndpoint(items);
   };

--- a/packages/alpha/src/api/simulators/simulatorsApi.ts
+++ b/packages/alpha/src/api/simulators/simulatorsApi.ts
@@ -23,7 +23,9 @@ import type {
   SimulatorModelRevisionFilterQuery,
   SimulatorRoutineCreate,
   SimulatorRoutineFilterQuery,
+  SimulatorRoutineRevisionBase,
   SimulatorRoutineRevisionCreate,
+  SimulatorRoutineRevisionView,
   SimulatorRoutineRevisionsFilterQuery,
 } from '../../types';
 import { IntegrationsAPI } from './integrationsApi';
@@ -102,127 +104,120 @@ export class SimulatorsAPI extends BaseResourceAPI<Simulator> {
     this.logsApi = new LogsAPI(`${resourcePath}/logs`, client, metadataMap);
   }
 
-  public create = async (items: SimulatorCreate[]) => {
+  public create = (items: SimulatorCreate[]) => {
     return this.createEndpoint(items);
   };
 
-  public list = async (filter?: SimulatorFilterQuery) => {
+  public list = (filter?: SimulatorFilterQuery) => {
     return this.listEndpoint(this.callListEndpointWithPost, filter);
   };
 
-  public update = async (changes: SimulatorChange[]) => {
+  public update = (changes: SimulatorChange[]) => {
     return this.updateEndpoint(changes);
   };
 
-  public delete = async (ids: IdEither[]) => {
+  public delete = (ids: IdEither[]) => {
     return this.deleteEndpoint(ids);
   };
 
-  public listIntegrations = async (
-    filter?: SimulatorIntegrationFilterQuery
-  ) => {
+  public listIntegrations = (filter?: SimulatorIntegrationFilterQuery) => {
     return this.integrationsApi.list(filter);
   };
 
-  public createIntegrations = async (items: SimulatorIntegrationCreate[]) => {
+  public createIntegrations = (items: SimulatorIntegrationCreate[]) => {
     return this.integrationsApi.create(items);
   };
 
-  public deleteIntegrations = async (ids: IdEither[]) => {
+  public deleteIntegrations = (ids: IdEither[]) => {
     return this.integrationsApi.delete(ids);
   };
 
-  public listRuns = async (filter?: SimulationRunFilterQuery) => {
+  public listRuns = (filter?: SimulationRunFilterQuery) => {
     return this.runsApi.list(filter);
   };
 
-  public listRunData = async (ids: SimulationRunId[]) => {
+  public listRunData = (ids: SimulationRunId[]) => {
     return this.runDataApi.retrieve(ids);
   };
 
-  public runSimulation = async (items: SimulationRunCreate[]) => {
+  public runSimulation = (items: SimulationRunCreate[]) => {
     return this.runsApi.run(items);
   };
 
-  public retrieveRuns = async (ids: CogniteInternalId[]) => {
+  public retrieveRuns = (ids: CogniteInternalId[]) => {
     return this.runsApi.retrieve(ids);
   };
 
-  public listModels = async (filter?: SimulatorModelFilterQuery) => {
+  public listModels = (filter?: SimulatorModelFilterQuery) => {
     return this.modelsApi.list(filter);
   };
 
-  public retrieveModels = async (items: IdEither[]) => {
+  public retrieveModels = (items: IdEither[]) => {
     return this.modelsApi.retrieve(items);
   };
 
-  public createModels = async (items: SimulatorModelCreate[]) => {
+  public createModels = (items: SimulatorModelCreate[]) => {
     return this.modelsApi.create(items);
   };
 
-  public deleteModels = async (ids: IdEither[]) => {
+  public deleteModels = (ids: IdEither[]) => {
     return this.modelsApi.delete(ids);
   };
 
-  public updateModels = async (changes: SimulatorModelChange[]) => {
+  public updateModels = (changes: SimulatorModelChange[]) => {
     return this.modelsApi.update(changes);
   };
 
-  public listModelRevisions = async (
-    filter?: SimulatorModelRevisionFilterQuery
-  ) => {
+  public listModelRevisions = (filter?: SimulatorModelRevisionFilterQuery) => {
     return this.modelRevisionsApi.list(filter);
   };
 
-  public retrieveModelRevisions = async (items: IdEither[]) => {
+  public retrieveModelRevisions = (items: IdEither[]) => {
     return this.modelRevisionsApi.retrieve(items);
   };
 
-  public createModelRevisions = async (
-    items: SimulatorModelRevisionCreate[]
-  ) => {
+  public createModelRevisions = (items: SimulatorModelRevisionCreate[]) => {
     return this.modelRevisionsApi.create(items);
   };
 
-  public deleteModelRevisions = async (ids: IdEither[]) => {
+  public deleteModelRevisions = (ids: IdEither[]) => {
     return this.modelRevisionsApi.delete(ids);
   };
 
-  public updateModelRevisions = async (
-    changes: SimulatorModelRevisionChange[]
-  ) => {
+  public updateModelRevisions = (changes: SimulatorModelRevisionChange[]) => {
     return this.modelRevisionsApi.update(changes);
   };
 
-  public listRoutines = async (filter?: SimulatorRoutineFilterQuery) => {
+  public listRoutines = (filter?: SimulatorRoutineFilterQuery) => {
     return this.routinesApi.list(filter);
   };
 
-  public createRoutines = async (items: SimulatorRoutineCreate[]) => {
+  public createRoutines = (items: SimulatorRoutineCreate[]) => {
     return this.routinesApi.create(items);
   };
 
-  public deleteRoutines = async (ids: IdEither[]) => {
+  public deleteRoutines = (ids: IdEither[]) => {
     return this.routinesApi.delete(ids);
   };
 
-  public listRoutineRevisions = async (
+  public listRoutineRevisions = <
+    RevisionResponseType extends
+      SimulatorRoutineRevisionBase = SimulatorRoutineRevisionView,
+  >(
     filter?: SimulatorRoutineRevisionsFilterQuery
   ) => {
-    return this.routineRevisionsApi.list(filter);
+    return this.routineRevisionsApi.list<RevisionResponseType>(filter);
   };
 
-  public retrieveRoutineRevisions = async (items: IdEither[]) => {
+  public retrieveRoutineRevisions = (items: IdEither[]) => {
     return this.routineRevisionsApi.retrieve(items);
   };
 
-  public createRoutineRevisions = async (
-    items: SimulatorRoutineRevisionCreate[]
-  ) => {
+  public createRoutineRevisions = (items: SimulatorRoutineRevisionCreate[]) => {
     return this.routineRevisionsApi.create(items);
   };
 
-  public retrieveLogs = async (items: InternalId[]) => {
+  public retrieveLogs = (items: InternalId[]) => {
     return this.logsApi.retrieve(items);
   };
 }

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -557,19 +557,8 @@ export interface SimulatorRoutineRevisionView
 }
 
 export interface SimulatorRoutineRevision extends SimulatorRoutineRevisionBase {
-  id: CogniteInternalId;
-  externalId: CogniteExternalId;
-  simulatorExternalId: CogniteExternalId;
-  routineExternalId: CogniteExternalId;
-  simulatorIntegrationExternalId: CogniteExternalId;
-  modelExternalId: CogniteExternalId;
-  dataSetId: CogniteInternalId;
-  createdByUserId: string;
-  createdTime: Date;
-  versionNumber: number;
-
   configuration: SimulatorRoutineRevisionConfiguration;
-  script?: SimulatorRoutineScript[];
+  script: SimulatorRoutineScript[];
 }
 
 export interface SimulatorRoutineRevisionCreate {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -322,6 +322,7 @@ export interface SimulatorModelCreate {
 
 export interface SimulatorModelFilter {
   simulatorExternalIds?: CogniteExternalId[];
+  simulatorIntegrationExternalIds?: CogniteExternalId[];
 }
 
 export interface SimulatorModelFilterQuery extends FilterQuery {
@@ -452,7 +453,7 @@ export interface SimulatorRoutineFilterQuery extends FilterQuery {
 
 export interface SimulatorRoutineDataSampling {
   enabled: true;
-  validationWindow: number;
+  validationWindow?: number;
   samplingWindow: number;
   granularity: number;
 }
@@ -523,16 +524,21 @@ export interface SimulatorRoutineScript {
   description?: string;
   steps: SimulatorRoutineScriptStep[];
 }
-export interface SimulatorRoutineRevisionConfiguration {
+
+export interface SimulatorRoutineRevisionConfigurationBase {
   dataSampling: SimulatorRoutineConfigDisabled | SimulatorRoutineDataSampling;
   schedule: SimulatorRoutineConfigDisabled | SimulatorRoutineSchedule;
   steadyStateDetection: SimulatorRoutineSteadyStateDetection[];
   logicalCheck: SimulatorRoutineLogicalCheck[];
+}
 
+export interface SimulatorRoutineRevisionConfiguration
+  extends SimulatorRoutineRevisionConfigurationBase {
   inputs: SimulatorRoutineInput[];
   outputs: SimulatorRoutineOutput[];
 }
-export interface SimulatorRoutineRevision {
+
+export interface SimulatorRoutineRevisionBase {
   id: CogniteInternalId;
   externalId: CogniteExternalId;
   simulatorExternalId: CogniteExternalId;
@@ -542,9 +548,28 @@ export interface SimulatorRoutineRevision {
   dataSetId: CogniteInternalId;
   createdByUserId: string;
   createdTime: Date;
-  configuration: SimulatorRoutineRevisionConfiguration;
-  script: SimulatorRoutineScript[];
   versionNumber: number;
+}
+
+export interface SimulatorRoutineRevisionView
+  extends SimulatorRoutineRevisionBase {
+  configuration: SimulatorRoutineRevisionConfigurationBase;
+}
+
+export interface SimulatorRoutineRevision extends SimulatorRoutineRevisionBase {
+  id: CogniteInternalId;
+  externalId: CogniteExternalId;
+  simulatorExternalId: CogniteExternalId;
+  routineExternalId: CogniteExternalId;
+  simulatorIntegrationExternalId: CogniteExternalId;
+  modelExternalId: CogniteExternalId;
+  dataSetId: CogniteInternalId;
+  createdByUserId: string;
+  createdTime: Date;
+  versionNumber: number;
+
+  configuration: SimulatorRoutineRevisionConfiguration;
+  script?: SimulatorRoutineScript[];
 }
 
 export interface SimulatorRoutineRevisionCreate {
@@ -554,7 +579,7 @@ export interface SimulatorRoutineRevisionCreate {
   script: SimulatorRoutineScript[];
 }
 
-export interface SimulatorRoutineRevisionslFilter {
+export interface SimulatorRoutineRevisionsFilter {
   routineExternalIds?: CogniteExternalId[];
   allVersions?: boolean;
   modelExternalIds?: CogniteExternalId[];
@@ -564,6 +589,7 @@ export interface SimulatorRoutineRevisionslFilter {
 }
 
 export interface SimulatorRoutineRevisionsFilterQuery extends FilterQuery {
-  filter?: SimulatorRoutineRevisionslFilter;
+  filter?: SimulatorRoutineRevisionsFilter;
   sort?: SortItem[];
+  includeAllFields?: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,7 +3313,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-alpha@workspace:packages/alpha"
   dependencies:
-    "@cognite/sdk": "npm:^9.16.0"
+    "@cognite/sdk": "npm:^9.16.1"
     "@cognite/sdk-core": "npm:^4.10.6"
   languageName: unknown
   linkType: soft
@@ -3322,7 +3322,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-beta@workspace:packages/beta"
   dependencies:
-    "@cognite/sdk": "npm:^9.16.0"
+    "@cognite/sdk": "npm:^9.16.1"
     "@cognite/sdk-core": "npm:^4.10.6"
   languageName: unknown
   linkType: soft
@@ -3383,7 +3383,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-playground@workspace:packages/playground"
   dependencies:
-    "@cognite/sdk": "npm:^9.16.0"
+    "@cognite/sdk": "npm:^9.16.1"
     "@cognite/sdk-core": "npm:^4.10.6"
   languageName: unknown
   linkType: soft
@@ -3397,7 +3397,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk@npm:^9, @cognite/sdk@npm:^9.16.0, @cognite/sdk@workspace:packages/stable":
+"@cognite/sdk@npm:^9, @cognite/sdk@npm:^9.16.1, @cognite/sdk@workspace:packages/stable":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk@workspace:packages/stable"
   dependencies:


### PR DESCRIPTION
- removed labels
- support for `includeAllFields` on revision list endpoint. added `SimulatorRoutineRevisionView` type for the object that is returned when boolean flag is disabled
- removed redundant `async` as we lose the original type due to it (e.g. CursorAndAsyncIterator in some cases)
- fixed tests, typo