### PR TITLE
fix: revert to using Capital A in AUTHORIZATION_HEADER

### DIFF
--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -243,7 +243,7 @@ describe('CogniteClient', () => {
           .reply(function () {
             expect(
               this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
-            ).toStrictEqual(['Bearer·test-token0']);
+            ).toStrictEqual(['Bearer test-token0']);
             return [401];
           });
         nock(mockBaseUrl)
@@ -251,7 +251,7 @@ describe('CogniteClient', () => {
           .reply(function () {
             expect(
               this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
-            ).toStrictEqual(['Bearer·test-token1']);
+            ).toStrictEqual(['Bearer test-token1']);
             return [401];
           });
         nock(mockBaseUrl)
@@ -259,7 +259,7 @@ describe('CogniteClient', () => {
           .reply(function () {
             expect(
               this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
-            ).toStrictEqual(['Bearer·test-token2']);
+            ).toStrictEqual(['Bearer test-token2']);
             return [200];
           });
 

--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -243,9 +243,7 @@ describe('CogniteClient', () => {
           .reply(function () {
             expect(
               this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
-            ).toStrictEqual([
-              'Bearer test-token0',
-            ]);
+            ).toStrictEqual(['Bearer·test-token0']);
             return [401];
           });
         nock(mockBaseUrl)
@@ -253,9 +251,7 @@ describe('CogniteClient', () => {
           .reply(function () {
             expect(
               this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
-            ).toStrictEqual([
-              'Bearer test-token1',
-            ]);
+            ).toStrictEqual(['Bearer·test-token1']);
             return [401];
           });
         nock(mockBaseUrl)
@@ -263,9 +259,7 @@ describe('CogniteClient', () => {
           .reply(function () {
             expect(
               this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
-          ).toStrictEqual([
-              'Bearer test-token2',
-            ]);
+            ).toStrictEqual(['Bearer·test-token2']);
             return [200];
           });
 

--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -241,7 +241,7 @@ describe('CogniteClient', () => {
         nock(mockBaseUrl)
           .get('/test')
           .reply(function () {
-            expect(this.req.headers[AUTHORIZATION_HEADER]).toStrictEqual([
+            expect(this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]).toStrictEqual([
               'Bearer test-token0',
             ]);
             return [401];
@@ -249,7 +249,7 @@ describe('CogniteClient', () => {
         nock(mockBaseUrl)
           .get('/test')
           .reply(function () {
-            expect(this.req.headers[AUTHORIZATION_HEADER]).toStrictEqual([
+            expect(this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]).toStrictEqual([
               'Bearer test-token1',
             ]);
             return [401];
@@ -257,7 +257,7 @@ describe('CogniteClient', () => {
         nock(mockBaseUrl)
           .get('/test')
           .reply(function () {
-            expect(this.req.headers[AUTHORIZATION_HEADER]).toStrictEqual([
+            expect(this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]).toStrictEqual([
               'Bearer test-token2',
             ]);
             return [200];

--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -241,7 +241,9 @@ describe('CogniteClient', () => {
         nock(mockBaseUrl)
           .get('/test')
           .reply(function () {
-            expect(this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]).toStrictEqual([
+            expect(
+              this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
+            ).toStrictEqual([
               'Bearer test-token0',
             ]);
             return [401];
@@ -249,7 +251,9 @@ describe('CogniteClient', () => {
         nock(mockBaseUrl)
           .get('/test')
           .reply(function () {
-            expect(this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]).toStrictEqual([
+            expect(
+              this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
+            ).toStrictEqual([
               'Bearer test-token1',
             ]);
             return [401];
@@ -257,7 +261,9 @@ describe('CogniteClient', () => {
         nock(mockBaseUrl)
           .get('/test')
           .reply(function () {
-            expect(this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]).toStrictEqual([
+            expect(
+              this.req.headers[AUTHORIZATION_HEADER.toLowerCase()]
+          ).toStrictEqual([
               'Bearer test-token2',
             ]);
             return [200];

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_DOMAIN = 'cognitedata.com';
 export const BASE_URL = `https://${DEFAULT_CLUSTER}.${DEFAULT_DOMAIN}`;
 
 /** @hidden */
-export const AUTHORIZATION_HEADER = 'authorization';
+export const AUTHORIZATION_HEADER = 'Authorization';
 /** @hidden */
 export const X_CDF_APP_HEADER = 'x-cdp-app';
 /** @hidden */


### PR DESCRIPTION
Fix: revert to using Capital A in AUTHORIZATION_HEADER #1182
