### PR TITLE
fix(vite): adding common js as fallback [release]

### DIFF
--- a/packages/alpha/package.json
+++ b/packages/alpha/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
-  "types": "dist/index",
+  "types": "dist/index.d.ts",
   "exports": {
     "import": "./dist/index.js",
     "require": "./dist/index.cjs",

--- a/packages/alpha/package.json
+++ b/packages/alpha/package.json
@@ -3,7 +3,14 @@
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "types": "dist/src/index.d.ts",
   "version": "1.0.0-rc.4",
   "type": "module",

--- a/packages/alpha/package.json
+++ b/packages/alpha/package.json
@@ -5,13 +5,12 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
+  "types": "dist/index",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
-  "types": "dist/src/index.d.ts",
   "version": "1.0.0-rc.4",
   "type": "module",
   "scripts": {

--- a/packages/alpha/vite.config.js
+++ b/packages/alpha/vite.config.js
@@ -16,12 +16,12 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es'],
+      formats: ['es','cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: 'index',
+      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/alpha/vite.config.js
+++ b/packages/alpha/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es','cjs'],
+      formats: ['es', 'cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',

--- a/packages/alpha/vite.config.js
+++ b/packages/alpha/vite.config.js
@@ -7,9 +7,10 @@ const externals = ['@cognite/sdk', '@cognite/sdk-core'];
 export default defineConfig({
   plugins: [
     dts({
-      exclude: ['**/__tests__/**/*'],
+      exclude: ['**/__tests__/**/*', '**/*.spec.ts'],
       entryRoot: '.',
       aliasesExclude: externals,
+      insertTypesEntry: true,
     }),
   ],
   build: {

--- a/packages/alpha/vite.config.js
+++ b/packages/alpha/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
+      fileName: 'index',
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/beta/package.json
+++ b/packages/beta/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
-  "types": "dist/index",
+  "types": "dist/index.d.ts",
   "exports": {
     "import": "./dist/index.js",
     "require": "./dist/index.cjs",

--- a/packages/beta/package.json
+++ b/packages/beta/package.json
@@ -3,7 +3,14 @@
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "types": "dist/src/index.d.ts",
   "type": "module",
   "version": "6.0.0-rc.4",

--- a/packages/beta/package.json
+++ b/packages/beta/package.json
@@ -5,13 +5,12 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
+  "types": "dist/index",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
-  "types": "dist/src/index.d.ts",
   "type": "module",
   "version": "6.0.0-rc.4",
   "scripts": {

--- a/packages/beta/vite.config.js
+++ b/packages/beta/vite.config.js
@@ -16,12 +16,12 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es'],
+      formats: ['es','cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: 'index',
+      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/beta/vite.config.js
+++ b/packages/beta/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es','cjs'],
+      formats: ['es', 'cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',

--- a/packages/beta/vite.config.js
+++ b/packages/beta/vite.config.js
@@ -7,9 +7,10 @@ const externals = ['@cognite/sdk', '@cognite/sdk-core'];
 export default defineConfig({
   plugins: [
     dts({
-      exclude: ['**/__tests__/**/*'],
+      exclude: ['**/__tests__/**/*', '**/*.spec.ts'],
       entryRoot: '.',
       aliasesExclude: externals,
+      insertTypesEntry: true,
     }),
   ],
   build: {

--- a/packages/beta/vite.config.js
+++ b/packages/beta/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
+      fileName: 'index',
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,14 +3,7 @@
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
-  },
+  "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "version": "5.0.0-rc.4",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "version": "5.0.0-rc.4",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,14 @@
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "types": "dist/src/index.d.ts",
   "version": "5.0.0-rc.4",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "version": "5.0.0-rc.4",
   "type": "module",
   "scripts": {

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es'],
+      formats: ['es', 'cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -7,9 +7,10 @@ const externals = ['cross-fetch', 'lodash'];
 export default defineConfig({
   plugins: [
     dts({
-      exclude: ['**/__tests__/**/*'],
+      exclude: ['**/__tests__/**/*', '**/*.spec.ts'],
       entryRoot: '.',
       aliasesExclude: externals,
+      insertTypesEntry: true,
     }),
   ],
   build: {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -5,13 +5,12 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
+  "types": "dist/index",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
-  "types": "dist/src/index.d.ts",
   "type": "module",
   "version": "8.0.0-rc.4",
   "scripts": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
-  "types": "dist/index",
+  "types": "dist/index.d.ts",
   "exports": {
     "import": "./dist/index.js",
     "require": "./dist/index.cjs",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -3,7 +3,14 @@
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "types": "dist/src/index.d.ts",
   "type": "module",
   "version": "8.0.0-rc.4",

--- a/packages/playground/vite.config.js
+++ b/packages/playground/vite.config.js
@@ -16,12 +16,12 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es'],
+      formats: ['es','cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: 'index',
+      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/playground/vite.config.js
+++ b/packages/playground/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es','cjs'],
+      formats: ['es', 'cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',

--- a/packages/playground/vite.config.js
+++ b/packages/playground/vite.config.js
@@ -7,9 +7,10 @@ const externals = ['@cognite/sdk', '@cognite/sdk-core'];
 export default defineConfig({
   plugins: [
     dts({
-      exclude: ['**/__tests__/**/*'],
+      exclude: ['**/__tests__/**/*', '**/*.spec.ts'],
       entryRoot: '.',
       aliasesExclude: externals,
+      insertTypesEntry: true,
     }),
   ],
   build: {

--- a/packages/playground/vite.config.js
+++ b/packages/playground/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
+      fileName: 'index',
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
-  "types": "dist/index",
+  "types": "dist/index.d.ts",
   "exports": {
     "import": "./dist/index.js",
     "require": "./dist/index.cjs",

--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -5,13 +5,12 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
+  "types": "dist/index",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
-  "types": "dist/src/index.d.ts",
   "version": "10.0.0-rc.4",
   "type": "module",
   "scripts": {

--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -3,7 +3,14 @@
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "types": "dist/src/index.d.ts",
   "version": "10.0.0-rc.4",
   "type": "module",

--- a/packages/stable/vite.config.js
+++ b/packages/stable/vite.config.js
@@ -16,12 +16,12 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es'],
+      formats: ['es','cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: 'index',
+      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/stable/vite.config.js
+++ b/packages/stable/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es','cjs'],
+      formats: ['es', 'cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',

--- a/packages/stable/vite.config.js
+++ b/packages/stable/vite.config.js
@@ -7,9 +7,10 @@ const externals = ['@cognite/sdk-core', 'geojson', 'lodash'];
 export default defineConfig({
   plugins: [
     dts({
-      exclude: ['**/__tests__/**/*'],
+      exclude: ['**/__tests__/**/*', '**/*.spec.ts'],
       entryRoot: '.',
       aliasesExclude: externals,
+      insertTypesEntry: true,
     }),
   ],
   build: {

--- a/packages/stable/vite.config.js
+++ b/packages/stable/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
+      fileName: 'index',
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -4,7 +4,14 @@
   "license": "Apache-2.0",
   "repository": "cognitedata/cognite-sdk-js",
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "types": "dist/src/index.d.ts",
   "type": "module",
   "version": "0.0.0",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -6,13 +6,12 @@
   "homepage": "https://github.com/cognitedata/cognite-sdk-js#readme",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
+  "types": "dist/index",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
-  "types": "dist/src/index.d.ts",
   "type": "module",
   "version": "0.0.0",
   "scripts": {

--- a/packages/template/vite.config.js
+++ b/packages/template/vite.config.js
@@ -16,12 +16,12 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es'],
+      formats: ['es','cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: 'index',
+      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/packages/template/vite.config.js
+++ b/packages/template/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     sourcemap: true,
     target: 'es6',
     lib: {
-      formats: ['es','cjs'],
+      formats: ['es', 'cjs'],
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',

--- a/packages/template/vite.config.js
+++ b/packages/template/vite.config.js
@@ -7,9 +7,10 @@ const externals = ['@cognite/sdk', '@cognite/sdk-core'];
 export default defineConfig({
   plugins: [
     dts({
-      exclude: ['**/__tests__/**/*'],
+      exclude: ['**/__tests__/**/*', '**/*.spec.ts'],
       entryRoot: '.',
       aliasesExclude: externals,
+      insertTypesEntry: true,
     }),
   ],
   build: {

--- a/packages/template/vite.config.js
+++ b/packages/template/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
       // the proper extensions will be added
-      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'), // Output files for different formats
+      fileName: 'index',
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
Update : 
- adding cjs
- update exports 

Reminder 
Now we use the default common plugin 
if issues we could use 
const commonjs = require('vite-plugin-commonjs'); // Import CommonJS plugin

