### PR TITLE
feat(stable): add 3d asset mappings with core dm support in API

### DIFF
--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -407,7 +407,7 @@ export interface AssetMappings3DListFilter extends FilterQuery {
    */
   intersectsBoundingBox?: BoundingBox3D;
   /**
-   * If true, the response will include the mappings with assetInstanceId values, for DMS based assets.
+   * If true, the response will include the mappings with assetInstanceId values, for DM based assets.
    */
   getDmsInstances?: boolean;
 }

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -393,6 +393,10 @@ export interface AssetMapping3DBase {
    * The ID of the associated asset (Cognite's Assets API).
    */
   assetId: CogniteInternalId;
+  /**
+   * The ID of the associated Cognite Asset instance from Core Data Model.
+   */
+  assetInstanceId?: UnitDMSUniqueIdentifier,
 }
 
 export interface AssetMappings3DListFilter extends FilterQuery {
@@ -402,6 +406,10 @@ export interface AssetMappings3DListFilter extends FilterQuery {
    * If given, only return asset mappings for assets whose bounding box intersects the given bounding box.
    */
   intersectsBoundingBox?: BoundingBox3D;
+  /**
+   * if is true, the response will include the mappings associated with the Cognite Asset Data Model instances.
+   */
+  getDmsInstances?: boolean;
 }
 
 export interface AssetMappings3DAssetFilter {
@@ -3268,6 +3276,11 @@ export interface UnitSystem {
   name: string;
   quantities: UnitSystemQuantity[];
 }
+
+export interface UnitDMSUniqueIdentifier {
+  space: string;
+  externalId: string;
+};
 
 export type {
   AggregatedHistogramValue,

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -407,7 +407,7 @@ export interface AssetMappings3DListFilter extends FilterQuery {
    */
   intersectsBoundingBox?: BoundingBox3D;
   /**
-   * if is true, the response will include the mappings associated with the Cognite Asset Data Model instances.
+   * If true, the response will include the mappings with assetInstanceId values, for DMS based assets.
    */
   getDmsInstances?: boolean;
 }

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -396,7 +396,7 @@ export interface AssetMapping3DBase {
   /**
    * The ID of the associated Cognite Asset instance from Core Data Model.
    */
-  assetInstanceId?: UnitDMSUniqueIdentifier,
+  assetInstanceId?: UnitDMSUniqueIdentifier;
 }
 
 export interface AssetMappings3DListFilter extends FilterQuery {
@@ -3280,7 +3280,7 @@ export interface UnitSystem {
 export interface UnitDMSUniqueIdentifier {
   space: string;
   externalId: string;
-};
+}
 
 export type {
   AggregatedHistogramValue,


### PR DESCRIPTION
Adding support for 3d asset mappings with Cognite Asset (Core DM) within the Asset Mappings type definition and including flag support for requesting asset mappings via Cognite Asset (Core DM).

Following the 3d API (the doc updates not merged yet, it seems. But the API is already updated):

https://pr-2743.specs.preview.cogniteapp.com/20230101.json.html#tag/3D-Asset-Mapping/operation/get3DMappings
https://pr-2743.specs.preview.cogniteapp.com/20230101.json.html#tag/3D-Asset-Mapping/operation/filter3DAssetMappings