### PR TITLE
feat(datapoints-latest): add automatic chunking [release]

### DIFF
--- a/packages/stable/src/__tests__/api/containers.int.spec.ts
+++ b/packages/stable/src/__tests__/api/containers.int.spec.ts
@@ -36,13 +36,23 @@ describe('Containers integration test', () => {
   beforeAll(async () => {
     client = setupLoggedInClient();
     await deleteOldSpaces(client);
-    await client.spaces.upsert([
+
+    // Eventual consistency
+    await vi.waitFor(
+      async () =>
+        client.spaces.upsert([
+          {
+            space: TEST_SPACE_NAME,
+            name: TEST_SPACE_NAME,
+            description:
+              'Instance space used for containers integration tests.',
+          },
+        ]),
       {
-        space: TEST_SPACE_NAME,
-        name: TEST_SPACE_NAME,
-        description: 'Instance space used for containers integration tests.',
-      },
-    ]);
+        timeout: 25 * 1000,
+        interval: 1000,
+      }
+    );
   }, 25_000);
   afterAll(async () => {
     client = setupLoggedInClient();

--- a/packages/stable/src/__tests__/api/timeseries.int.spec.ts
+++ b/packages/stable/src/__tests__/api/timeseries.int.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Cognite AS
 
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
 import type { Asset, NodeWrite, Timeseries } from '../../types';
 import {
@@ -20,11 +20,19 @@ describe('Timeseries integration test', () => {
         externalId: `external_${randomInt()}`,
       },
     ]);
-    await client.spaces.upsert([testSpace]);
-    await client.instances.upsert({
-      items: [timeseriesCdmInstance],
-    });
-  });
+    await vi.waitFor(
+      async () => {
+        await client.spaces.upsert([testSpace]);
+        await client.instances.upsert({
+          items: [timeseriesCdmInstance],
+        });
+      },
+      {
+        timeout: 25 * 1000,
+        interval: 1000,
+      }
+    );
+  }, 25_000);
 
   afterAll(async () => {
     await client.assets.delete([{ id: asset.id }]);

--- a/packages/stable/src/__tests__/api/views.int.spec.ts
+++ b/packages/stable/src/__tests__/api/views.int.spec.ts
@@ -47,8 +47,8 @@ describe('Views integration test', () => {
   };
 
   beforeAll(async () => {
-    vi.setConfig({ testTimeout: 30 * 1000 });
     client = setupLoggedInClient();
+    vi.setConfig({ testTimeout: 30 * 1000 });
     await deleteOldSpaces(client);
     await client.spaces.upsert([
       {

--- a/packages/stable/src/__tests__/api/visionApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/visionApi.int.spec.ts
@@ -28,9 +28,9 @@ describe('Vision API', () => {
   let extractBetaJob: VisionExtractPostResponse;
 
   beforeAll(async () => {
-    vi.setConfig({ testTimeout: 3 * 60 * 1000 }); // timeout after 3 minutes
     consoleSpy = vi.spyOn(console, 'warn').mockImplementation(noop);
     client = setupLoggedInClient();
+    vi.setConfig({ testTimeout: 3 * 60 * 1000 }); // timeout after 3 minutes
 
     const testFileExternalId = 'vision_extract_test_image';
     const files = await client.files.retrieve(

--- a/packages/stable/src/__tests__/testUtils.ts
+++ b/packages/stable/src/__tests__/testUtils.ts
@@ -2,6 +2,7 @@
 
 import { createReadStream, readFileSync, statSync } from 'node:fs';
 import { PassThrough } from 'node:stream';
+import { vi } from 'vitest';
 import { mockBaseUrl, randomInt } from '../../../core/src/__tests__/testUtils';
 import CogniteClient from '../cogniteClient';
 import type { ExternalFileInfo, NodeOrEdge } from '../types';
@@ -17,6 +18,9 @@ function setupClient(baseUrl: string = process.env.COGNITE_BASE_URL as string) {
 }
 
 function setupLoggedInClient() {
+  vi.setConfig({
+    testTimeout: 25 * 1000,
+  });
   const client = new CogniteClient({
     appId: 'JS SDK integration tests',
     baseUrl: process.env.COGNITE_BASE_URL,

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -183,12 +183,16 @@ export class DataPointsAPI extends BaseResourceAPI<
   private async retrieveLatestEndpoint(
     items: LatestDataBeforeRequest[],
     params: LatestDataParams
-  ) {
+  ): Promise<Datapoints[]> {
     const path = this.url('latest');
-    const response = await this.post<ItemsWrapper<Datapoints[]>>(path, {
-      data: { items, ...params },
-    });
-    return this.addToMapAndReturn(response.data.items, response);
+    return this.callEndpointWithMergeAndTransform(items, (request) =>
+      this.postInParallelWithAutomaticChunking({
+        items: request,
+        params,
+        path,
+        chunkSize: 100,
+      })
+    ) as Promise<Datapoints[]>;
   }
 
   private async deleteDatapointsEndpoint(items: DatapointsDeleteRequest[]) {


### PR DESCRIPTION
added automatic chunking to datapointsLatest datapoint, so that when there are more than 100 ids multiple requests would be fired.

inspired from customer request

NOTE: a bunch of tests were enpowered by retries to accomodate for eventually consistent dms