### PR TITLE
fix: handle casing in merge of headers

### DIFF
--- a/packages/core/src/httpClient/basicHttpClient.ts
+++ b/packages/core/src/httpClient/basicHttpClient.ts
@@ -5,6 +5,7 @@ import { DEFAULT_DOMAIN } from '../constants';
 import { isJson } from '../utils';
 import { HttpError, type HttpErrorData } from './httpError';
 import type { HttpHeaders } from './httpHeaders';
+import { mapKeys } from 'lodash';
 
 /**
  * The `BasicHttpClient` class provides a simplified HTTP client for making
@@ -114,7 +115,7 @@ export class BasicHttpClient {
    *
    * @param baseUrl
    */
-  constructor(protected baseUrl: string) {}
+  constructor(protected baseUrl: string) { }
 
   public setDefaultHeader(name: string, value: string) {
     this.defaultHeaders[name] = value;
@@ -199,9 +200,13 @@ export class BasicHttpClient {
   }
 
   protected populateDefaultHeaders(headers: HttpHeaders = {}) {
+    const mapFn = (_: unknown, key: string) => {
+      const lcKey = key.toLowerCase();
+      return lcKey === 'authorization' ? 'Authorization' : lcKey;
+    };
     return {
-      ...this.defaultHeaders,
-      ...headers,
+      ...mapKeys(this.defaultHeaders, mapFn),
+      ...mapKeys(headers, mapFn),
     };
   }
 


### PR DESCRIPTION
If you want to override default header values in requests with the SDK, you need to specify the right casing for the key to make it work.

If the header key you specify differs in casing from a default one, they appear to be merged when they are sent, which causes issues.

Example:

```typescript
  const response = await sdk.post<TData>(
    `${resolveUrl(url, queryParams, pathParameters)}`,
    {
      headers: {
        'Cdf-Version': 'beta',
      },
      data: body,
    }
  );

```

Result:

<img width="378" alt="image" src="https://github.com/user-attachments/assets/4c61c302-eeca-4a1e-90c3-e5c8f6e896cd" />



Or if specifying authorization with a lower case:


```
{
        authorization: 'my token',
}
```


<img width="378" alt="image" src="https://github.com/user-attachments/assets/2d0c43d5-3723-4aab-ae32-f5353f6ae3ab" />


The changes here make the sdk fix the merging of default headers and user provided headers after converting the keys to lowercase, before the request is sent. Apart from the case of `"Authorization"`, the header keys are sent in lower case.
