### PR TITLE
test(templates): skip tests for deprecated API

### DIFF
--- a/packages/stable/src/__tests__/api/documentsApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/documentsApi.int.spec.ts
@@ -56,7 +56,7 @@ const getFileId = async (
   );
 };
 
-describe('Documents integration test', () => {
+describe('Documents integration test', { timeout: 3 * 60_000 }, () => {
   let client: CogniteClient;
   let fileId: number;
 
@@ -155,7 +155,7 @@ describe('Documents integration test', () => {
     expect(aggregate.groups[0].group[0].property).toStrictEqual(['labels']);
   });
 
-  describe('document preview', () => {
+  describe('document preview', { timeout: 3 * 60_000 }, () => {
     let documents: DocumentSearchResponse;
 
     beforeAll(async () => {
@@ -193,7 +193,7 @@ describe('Documents integration test', () => {
         const match = Buffer.from(frontSlice, 0).equals(Buffer.from(pdfPrefix));
         expect(match).toBe(true);
       },
-      30 * 1000
+      60 * 1000
     );
 
     test('fetch temporary link', async () => {

--- a/packages/stable/src/__tests__/api/templateGroupVersions.int.spec.ts
+++ b/packages/stable/src/__tests__/api/templateGroupVersions.int.spec.ts
@@ -6,7 +6,7 @@ import type CogniteClient from '../../cogniteClient';
 import { ConflictMode } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
-describe('template group versions test', () => {
+describe.skip('template group versions test', () => {
   let client: CogniteClient;
 
   const externalId = `VersionTest ${randomInt()}`;

--- a/packages/stable/src/__tests__/api/templateGroups.int.spec.ts
+++ b/packages/stable/src/__tests__/api/templateGroups.int.spec.ts
@@ -6,7 +6,7 @@ import type CogniteClient from '../../cogniteClient';
 import type { ExternalTemplateGroup, TemplateGroup } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
-describe('template group test', () => {
+describe.skip('template group test', () => {
   let client: CogniteClient;
 
   const templateGroups = [

--- a/packages/stable/src/__tests__/api/templateInstances.int.spec.ts
+++ b/packages/stable/src/__tests__/api/templateInstances.int.spec.ts
@@ -17,7 +17,7 @@ import type CogniteClient from '../../cogniteClient';
 import type { ExternalTemplateInstance, TemplateInstance } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
-describe('template instances test', () => {
+describe.skip('template instances test', () => {
   let client: CogniteClient;
 
   const externalId = `TemplateInstanceTest ${randomInt()}`;

--- a/packages/stable/src/__tests__/api/viewApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/viewApi.int.spec.ts
@@ -6,7 +6,7 @@ import type CogniteClient from '../../cogniteClient';
 import type { ExternalView, View } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
-describe('template view test', () => {
+describe.skip('template view test', () => {
   let client: CogniteClient;
 
   const externalId = `ViewInstanceTest ${randomInt()}`;


### PR DESCRIPTION
this API has been already shutdown, will remove in the next release