### PR TITLE
chore(release): fix broken release workflow

### DIFF
--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-and-publish:
+    if: "contains(github.event.head_commit.message, 'chore(release): publish new package versions')"
     runs-on: ubuntu-latest
     environment: CD
 
@@ -28,7 +29,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Publish to NPM
-        if: contains(github.event.head_commit.message, 'chore(release): publish new package versions')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lerna publish from-package --yes --no-git-reset

--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-publish:
-    if: "contains(github.event.head_commit.message, 'chore(release): publish new package versions')"
+    if: 'contains(github.event.head_commit.message, ''chore(release): publish new package versions'')'
     runs-on: ubuntu-latest
     environment: CD
 


### PR DESCRIPTION
* Fix : in if condition not being escaped, which caused the file to not parse
* Move if condition to job level because there is no point performing the other actions of "build-and-publish" job currently without the publish step being performed