### PR TITLE
feat(simint-alpha): add simulatorExternalIds filter support for routines

### DIFF
--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.spec.ts
@@ -112,6 +112,39 @@ describeIf('simulator routines api', () => {
     expect(routineFound?.externalId).toBe(routineExternalId);
   });
 
+  test('list routines with simulatorExternalIds filter', async () => {
+    const listFilterResponse = await client.simulators.listRoutines({
+      filter: { simulatorExternalIds: [simulatorExternalId] },
+    });
+    expect(listFilterResponse.items.length).toBeGreaterThan(0);
+    const routineFound = listFilterResponse.items.find(
+      (item) => item.externalId === routineExternalId
+    );
+    expect(routineFound?.externalId).toBe(routineExternalId);
+  });
+
+  test('list routines with non-existent simulatorExternalId', async () => {
+    const listFilterResponse = await client.simulators.listRoutines({
+      filter: { simulatorExternalIds: ['non-existent-simulator'] },
+    });
+    expect(listFilterResponse.items.length).toBe(0);
+  });
+
+  test('list routines with all filters combined', async () => {
+    const listFilterResponse = await client.simulators.listRoutines({
+      filter: {
+        simulatorExternalIds: [simulatorExternalId],
+        simulatorIntegrationExternalIds: [simulatorIntegrationExternalId],
+        modelExternalIds: [modelExternalId],
+      },
+    });
+    expect(listFilterResponse.items.length).toBeGreaterThan(0);
+    const routineFound = listFilterResponse.items.find(
+      (item) => item.externalId === routineExternalId
+    );
+    expect(routineFound?.externalId).toBe(routineExternalId);
+  });
+
   test('create routine revision', async () => {
     const response = await client.simulators.createRoutineRevisions([
       {

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.spec.ts
@@ -112,24 +112,6 @@ describeIf('simulator routines api', () => {
     expect(routineFound?.externalId).toBe(routineExternalId);
   });
 
-  test('list routines with simulatorExternalIds filter', async () => {
-    const listFilterResponse = await client.simulators.listRoutines({
-      filter: { simulatorExternalIds: [simulatorExternalId] },
-    });
-    expect(listFilterResponse.items.length).toBeGreaterThan(0);
-    const routineFound = listFilterResponse.items.find(
-      (item) => item.externalId === routineExternalId
-    );
-    expect(routineFound?.externalId).toBe(routineExternalId);
-  });
-
-  test('list routines with non-existent simulatorExternalId', async () => {
-    const listFilterResponse = await client.simulators.listRoutines({
-      filter: { simulatorExternalIds: ['non-existent-simulator'] },
-    });
-    expect(listFilterResponse.items.length).toBe(0);
-  });
-
   test('list routines with all filters combined', async () => {
     const listFilterResponse = await client.simulators.listRoutines({
       filter: {

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
@@ -1,0 +1,119 @@
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import CogniteClientAlpha from '../../cogniteClient';
+
+const mockBaseUrl = 'https://example.com';
+
+function setupMockableClient() {
+  return new CogniteClientAlpha({
+    appId: 'JS SDK unit tests (alpha)',
+    project: process.env.COGNITE_PROJECT as string,
+    baseUrl: mockBaseUrl,
+    oidcTokenProvider: () => Promise.resolve('test accessToken'),
+  });
+}
+
+describe('Simulator Routines API unit tests', () => {
+  let client: CogniteClientAlpha;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    client = setupMockableClient();
+  });
+
+  test('list routines with simulatorExternalIds filter', async () => {
+    const filter = {
+      simulatorExternalIds: ['simulator-1', 'simulator-2'],
+    };
+    const response = {
+      items: [
+        {
+          id: 1,
+          externalId: 'routine-1',
+          name: 'Test Routine 1',
+          modelExternalId: 'model-1',
+          simulatorIntegrationExternalId: 'integration-1',
+        },
+        {
+          id: 2,
+          externalId: 'routine-2',
+          name: 'Test Routine 2',
+          modelExternalId: 'model-2',
+          simulatorIntegrationExternalId: 'integration-2',
+        },
+      ],
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
+        filter: {
+          simulatorExternalIds: ['simulator-1', 'simulator-2'],
+        },
+      })
+      .reply(200, response);
+
+    const result = await client.simulators.listRoutines({
+      filter,
+    });
+    expect(result.items).toEqual(response.items);
+    expect(result.items.length).toBe(2);
+  });
+
+  test('list routines with all filters combined', async () => {
+    const filter = {
+      simulatorExternalIds: ['simulator-1'],
+      simulatorIntegrationExternalIds: ['integration-1'],
+      modelExternalIds: ['model-1'],
+    };
+    const response = {
+      items: [
+        {
+          id: 1,
+          externalId: 'routine-1',
+          name: 'Test Routine 1',
+          modelExternalId: 'model-1',
+          simulatorIntegrationExternalId: 'integration-1',
+        },
+      ],
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
+        filter: {
+          simulatorExternalIds: ['simulator-1'],
+          simulatorIntegrationExternalIds: ['integration-1'],
+          modelExternalIds: ['model-1'],
+        },
+      })
+      .reply(200, response);
+
+    const result = await client.simulators.listRoutines({
+      filter,
+    });
+    expect(result.items).toEqual(response.items);
+    expect(result.items.length).toBe(1);
+  });
+
+  test('list routines with simulatorExternalIds filter - empty result', async () => {
+    const filter = {
+      simulatorExternalIds: ['non-existent-simulator'],
+    };
+    const response = {
+      items: [],
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
+        filter: {
+          simulatorExternalIds: ['non-existent-simulator'],
+        },
+      })
+      .reply(200, response);
+
+    const result = await client.simulators.listRoutines({
+      filter,
+    });
+    expect(result.items).toEqual([]);
+    expect(result.items.length).toBe(0);
+  });
+});

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
@@ -1,17 +1,8 @@
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
-import CogniteClientAlpha from '../../cogniteClient';
-
-const mockBaseUrl = 'https://example.com';
-
-function setupMockableClient() {
-  return new CogniteClientAlpha({
-    appId: 'JS SDK unit tests (alpha)',
-    project: process.env.COGNITE_PROJECT as string,
-    baseUrl: mockBaseUrl,
-    oidcTokenProvider: () => Promise.resolve('test accessToken'),
-  });
-}
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
 
 describe('Simulator Routines API unit tests', () => {
   let client: CogniteClientAlpha;
@@ -46,9 +37,7 @@ describe('Simulator Routines API unit tests', () => {
 
     nock(mockBaseUrl)
       .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
-        filter: {
-          simulatorExternalIds: ['simulator-1', 'simulator-2'],
-        },
+        filter,
       })
       .reply(200, response);
 
@@ -79,11 +68,7 @@ describe('Simulator Routines API unit tests', () => {
 
     nock(mockBaseUrl)
       .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
-        filter: {
-          simulatorExternalIds: ['simulator-1'],
-          simulatorIntegrationExternalIds: ['integration-1'],
-          modelExternalIds: ['model-1'],
-        },
+        filter,
       })
       .reply(200, response);
 
@@ -104,9 +89,7 @@ describe('Simulator Routines API unit tests', () => {
 
     nock(mockBaseUrl)
       .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
-        filter: {
-          simulatorExternalIds: ['non-existent-simulator'],
-        },
+        filter,
       })
       .reply(200, response);
 

--- a/packages/alpha/src/__tests__/testUtils.ts
+++ b/packages/alpha/src/__tests__/testUtils.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 Cognite AS
 
+import { mockBaseUrl } from '../../../core/src/__tests__/testUtils';
 import CogniteClientAlpha from '../cogniteClient';
 import { login } from './login';
 
@@ -12,5 +13,14 @@ export function setupLoggedInClient() {
       login().then((account) => {
         return account.access_token;
       }),
+  });
+}
+
+export function setupMockableClient() {
+  return new CogniteClientAlpha({
+    appId: 'JS SDK unit tests (alpha)',
+    project: process.env.COGNITE_PROJECT || 'unit-test',
+    baseUrl: mockBaseUrl,
+    oidcTokenProvider: () => Promise.resolve('test accessToken'),
   });
 }

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -468,6 +468,7 @@ export interface SimulatorRoutineCreate {
 export interface SimulatorRoutineFilter {
   simulatorIntegrationExternalIds?: CogniteExternalId[];
   modelExternalIds?: CogniteExternalId[];
+  simulatorExternalIds?: CogniteExternalId[];
 }
 
 export interface SimulatorRoutineFilterQuery extends FilterQuery {


### PR DESCRIPTION
This PR is to add support for filtering routines by `simulatorExternalIds` in the SDK package. This allows to filter simulator routines using simulator external IDs alongside existing filters like `modelExternalIds` and `simulatorIntegrationExternalIds`.
