### PR TITLE
chore(cd): do not version private packages

### DIFF
--- a/scripts/create-release-pr.js
+++ b/scripts/create-release-pr.js
@@ -63,7 +63,7 @@ async function createReleasePR() {
     // Calculate versions without pushing (now on the release branch)
     console.log('Calculating version changes...');
     execSync(
-      'lerna version --conventional-commits --no-push --no-git-tag-version --yes',
+      'lerna version --conventional-commits --no-push --no-git-tag-version --no-private --yes',
       { stdio: 'inherit' }
     );
 


### PR DESCRIPTION
Currently there is an issue with codegen being version bumped as a part of release script.
Example: https://github.com/cognitedata/cognite-sdk-js/blob/81362e7ac3e394e5061d5c063a73027f452cf86d/packages/codegen/CHANGELOG.md

This fixes the issue by excluding any private package from `lerna version` command (e.g. templates, codegen, etc)