### PR TITLE
feat(records): add support for ingesting/filtering immutable records

### DIFF
--- a/packages/codegen/src/__tests__/.cognite-openapi-snapshot.json
+++ b/packages/codegen/src/__tests__/.cognite-openapi-snapshot.json
@@ -23489,7 +23489,7 @@
       "UsedFor": {
         "type": "string",
         "description": "Should this operation apply to nodes, edges or both.",
-        "enum": ["node", "edge", "all"],
+        "enum": ["node", "edge", "all", "record"],
         "default": "node"
       },
       "DMSFilterProperty": {

--- a/packages/stable/src/.cognite-openapi-snapshot.json
+++ b/packages/stable/src/.cognite-openapi-snapshot.json
@@ -1239,6 +1239,9 @@
           },
           {
             "$ref": "#/components/parameters/IncludeGlobal"
+          },
+          {
+            "$ref": "#/components/parameters/UsedFor"
           }
         ],
         "x-capability": [
@@ -88964,6 +88967,21 @@
           "type": "boolean",
           "default": false
         }
+      },
+      "UsedFor": {
+        "name": "usedFor",
+        "in": "query",
+        "description": "Only include containers that have been marked as used for the specified purposes. Defaults to [node, edge, all].",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["node", "edge", "all", "record"]
+          },
+          "default": ["node", "edge", "all"]
+        },
+        "style": "form",
+        "explode": true
       },
       "StreamId": {
         "name": "streamId",

--- a/packages/stable/src/.cognite-openapi-snapshot.json
+++ b/packages/stable/src/.cognite-openapi-snapshot.json
@@ -35955,7 +35955,8 @@
         "enum": [
           "node",
           "edge",
-          "all"
+          "all",
+          "record"
         ],
         "default": "node"
       },

--- a/packages/stable/src/__tests__/api/records.int.spec.ts
+++ b/packages/stable/src/__tests__/api/records.int.spec.ts
@@ -1,0 +1,151 @@
+// Copyright 2025 Cognite AS
+
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+import type CogniteClient from '../../cogniteClient';
+import type { ContainerCreateDefinition } from '../../types';
+import { randomInt, setupLoggedInClient } from '../testUtils';
+
+describe('records integration test', () => {
+  let client: CogniteClient;
+
+  // Use the existing test streams from streams.int.spec.ts
+  const immutableStreamId = 'sdk_test_immutable_stream';
+
+  // Unique space and container
+  const testSpaceId = 'sdk_test_records_space';
+  const testContainerId = 'sdk_test_records_container';
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+
+    // Check if stream exists, create if not
+    try {
+      await client.streams.retrieve({ externalId: immutableStreamId });
+    } catch {
+      await client.streams.create({
+        externalId: immutableStreamId,
+        settings: {
+          template: {
+            name: 'ImmutableTestStream',
+          },
+        },
+      });
+    }
+
+    // Create or upsert the test space
+    await vi.waitFor(
+      async () =>
+        client.spaces.upsert([
+          {
+            space: testSpaceId,
+            name: testSpaceId,
+            description: 'Space used for records integration tests.',
+          },
+        ]),
+      {
+        timeout: 25 * 1000,
+        interval: 1000,
+      }
+    );
+
+    // Create or upsert a container for records integration tests
+    const containerDefinition: ContainerCreateDefinition = {
+      externalId: testContainerId,
+      space: testSpaceId,
+      name: 'Test Records Container',
+      description: 'Container used for records integration tests.',
+      usedFor: 'record',
+      properties: {
+        name: {
+          type: { type: 'text' },
+        },
+        value: {
+          type: { type: 'float64' },
+        },
+        timestamp: {
+          type: { type: 'timestamp' },
+        },
+      },
+    };
+
+    await vi.waitFor(
+      async () => client.containers.upsert([containerDefinition]),
+      {
+        timeout: 25 * 1000,
+        interval: 1000,
+      }
+    );
+
+    // Wait for eventual consistency
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }, 60_000);
+
+  test('ingest and filter records', async () => {
+    const testName = `test_record_${randomInt()}`;
+    const testValue = 42.5;
+
+    // Ingest a record
+    await client.records.ingest(immutableStreamId, [
+      {
+        space: testSpaceId,
+        externalId: `test_record_${randomInt()}`,
+        sources: [
+          {
+            source: {
+              type: 'container' as const,
+              space: testSpaceId,
+              externalId: testContainerId,
+            },
+            properties: {
+              name: testName,
+              value: testValue,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ]);
+
+    // Wait for eventual consistency (record should be available at most within 2 seconds)
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Filter records by name property
+    const result = await client.records.filter(immutableStreamId, {
+      lastUpdatedTime: {
+        gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // Last 24 hours
+      },
+      sources: [
+        {
+          source: {
+            type: 'container',
+            space: testSpaceId,
+            externalId: testContainerId,
+          },
+          properties: ['*'],
+        },
+      ],
+      filter: {
+        equals: {
+          property: [testSpaceId, testContainerId, 'name'],
+          value: testName,
+        },
+      },
+      limit: 10,
+    });
+
+    expect(result.length).toBe(1);
+
+    const record = result[0];
+    expect(record.space).toBe(testSpaceId);
+    expect(record.externalId).toBeDefined();
+    expect(record.createdTime).toBeInstanceOf(Date);
+    expect(record.lastUpdatedTime).toBeInstanceOf(Date);
+    expect(record.properties).toBeDefined();
+    expect(record.properties[testSpaceId]).toBeDefined();
+    expect(record.properties[testSpaceId][testContainerId]).toBeDefined();
+    expect(record.properties[testSpaceId][testContainerId].name).toBe(testName);
+    expect(record.properties[testSpaceId][testContainerId].value).toBe(
+      testValue
+    );
+  });
+});

--- a/packages/stable/src/__tests__/api/records.int.spec.ts
+++ b/packages/stable/src/__tests__/api/records.int.spec.ts
@@ -3,7 +3,11 @@
 import { beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
 import type { ContainerCreateDefinition } from '../../types';
-import { RECORDS_TEST_SPACE, randomInt, setupLoggedInClient } from '../testUtils';
+import {
+  RECORDS_TEST_SPACE,
+  randomInt,
+  setupLoggedInClient,
+} from '../testUtils';
 
 describe('records integration test', () => {
   let client: CogniteClient;

--- a/packages/stable/src/__tests__/testUtils.ts
+++ b/packages/stable/src/__tests__/testUtils.ts
@@ -42,6 +42,8 @@ function setupMockableClient() {
   });
 }
 
+const RECORDS_TEST_SPACE = 'sdk_test_records_space'; // Space reserved for records integration tests
+
 const deleteOldSpaces = async (client: CogniteClient) => {
   const fiveMinutesInMs = 5 * 60 * 1000;
   await deleteSpacesNotUpdatedSince(client, Date.now() - fiveMinutesInMs);
@@ -55,7 +57,8 @@ const deleteSpacesNotUpdatedSince = async (
     // Can max delete 100 spaces at a time thus the limit is set to 100
     const spaces = (await client.spaces.list({ limit: 100 })).items;
     const oldSpaces = spaces.filter(
-      (space) => space.lastUpdatedTime < timestamp
+      (space) =>
+        space.lastUpdatedTime < timestamp && space.space !== RECORDS_TEST_SPACE
     );
 
     const spacesList = oldSpaces.map((space) => space.space);
@@ -298,4 +301,5 @@ export {
   setupMockableClient,
   deleteOldSpaces,
   getFileCreateArgs,
+  RECORDS_TEST_SPACE,
 };

--- a/packages/stable/src/api/containers/containersApi.ts
+++ b/packages/stable/src/api/containers/containersApi.ts
@@ -14,7 +14,14 @@ import type {
   ListOfSpaceExternalIdsResponse,
   ReducedLimitQueryParameter,
   SpaceQueryParameter,
+  UsedForQueryParameter,
 } from './types.gen';
+
+type ContainerListParams = IncludeGlobalQueryParameter &
+  CursorQueryParameter &
+  ReducedLimitQueryParameter &
+  SpaceQueryParameter &
+  UsedForQueryParameter;
 
 export class ContainersAPI extends BaseResourceAPI<ContainerDefinition> {
   /**
@@ -82,16 +89,19 @@ export class ContainersAPI extends BaseResourceAPI<ContainerDefinition> {
    *
    * ```js
    *  const response = await client.containers.list({ space: '', includeGlobal: true });
-   *
+   *  // List only record containers
+   *  const recordContainers = await client.containers.list({ usedFor: ['record'] });
+   *  // List all container types including records
+   *  const allContainers = await client.containers.list({ usedFor: ['node', 'edge', 'all', 'record'] });
    * ```
    */
   public list = (
-    params: IncludeGlobalQueryParameter &
-      CursorQueryParameter &
-      ReducedLimitQueryParameter &
-      SpaceQueryParameter = { includeGlobal: false }
+    params: ContainerListParams = { includeGlobal: false }
   ): CursorAndAsyncIterator<ContainerDefinition> => {
-    return super.listEndpoint(this.callListEndpointWithGet, params);
+    return super.listEndpoint(
+      this.callListEndpointWithRepeatedQueryParams,
+      params
+    );
   };
 
   /**

--- a/packages/stable/src/api/containers/types.gen.ts
+++ b/packages/stable/src/api/containers/types.gen.ts
@@ -1157,7 +1157,7 @@ export interface UpsertConflict {
 /**
  * Should this operation apply to nodes, edges or both.
  */
-export type UsedFor = 'node' | 'edge' | 'all';
+export type UsedFor = 'node' | 'edge' | 'all' | 'record';
 /**
  * Reference to a view
  */

--- a/packages/stable/src/api/containers/types.gen.ts
+++ b/packages/stable/src/api/containers/types.gen.ts
@@ -228,6 +228,10 @@ export type EpochTimestamp = number;
 export interface IncludeGlobalQueryParameter {
   includeGlobal?: boolean;
 }
+export interface UsedForQueryParameter {
+  /** Only include containers that have been marked as used for the specified purposes. Defaults to [node, edge, all] */
+  usedFor?: UsedFor[];
+}
 /**
 * You can optimize query performance by defining an index to apply to a container.  You can only create an index across properties belonging to the same container.
 

--- a/packages/stable/src/api/models/types.gen.ts
+++ b/packages/stable/src/api/models/types.gen.ts
@@ -1347,7 +1347,7 @@ export interface UpsertConflict {
 /**
  * Should this operation apply to nodes, edges or both.
  */
-export type UsedFor = 'node' | 'edge' | 'all';
+export type UsedFor = 'node' | 'edge' | 'all' | 'record';
 export interface VersionReferencesCollectionResponse {
   items: {
     externalId: DMSExternalId;

--- a/packages/stable/src/api/records/recordsApi.ts
+++ b/packages/stable/src/api/records/recordsApi.ts
@@ -1,0 +1,82 @@
+// Copyright 2025 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import type {
+  RecordFilterRequest,
+  RecordFilterResponse,
+  RecordItem,
+  RecordWrite,
+} from './types';
+
+export class RecordsAPI extends BaseResourceAPI<RecordItem> {
+  /**
+   * @hidden
+   */
+  protected getDateProps() {
+    return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
+  }
+
+  /**
+   * [Ingest records into a stream](https://developer.cognite.com/api#tag/Records/operation/ingestRecords)
+   *
+   * Ingest records into a stream.
+   *
+   * ```js
+   * await client.records.ingest('my_stream', [
+   *   {
+   *     space: 'mySpace',
+   *     externalId: 'record1',
+   *     sources: [
+   *       {
+   *         source: { type: 'container', space: 'mySpace', externalId: 'myContainer' },
+   *         properties: { temperature: 25.5, timestamp: '2025-01-01T00:00:00Z' }
+   *       }
+   *     ]
+   *   }
+   * ]);
+   * ```
+   */
+  public ingest = async (
+    streamExternalId: string,
+    items: RecordWrite[]
+  ): Promise<void> => {
+    const path = this.url(`${streamExternalId}/records`);
+    await this.post<object>(path, {
+      data: { items },
+    });
+  };
+
+  /**
+   * [Filter records from a stream](https://developer.cognite.com/api#tag/Records/operation/filterRecords)
+   *
+   * Retrieve records from a stream using filters.
+   *
+   * ```js
+   * const response = await client.records.filter('my_stream', {
+   *   sources: [
+   *     {
+   *       source: { type: 'container', space: 'mySpace', externalId: 'myContainer' },
+   *       properties: ['*']
+   *     }
+   *   ],
+   *   filter: {
+   *     equals: {
+   *       property: ['mySpace', 'myContainer', 'status'],
+   *       value: 'active'
+   *     }
+   *   },
+   *   limit: 100
+   * });
+   * ```
+   */
+  public filter = async (
+    streamExternalId: string,
+    request: RecordFilterRequest = {}
+  ): Promise<RecordItem[]> => {
+    const path = this.url(`${streamExternalId}/records/filter`);
+    const response = await this.post<RecordFilterResponse>(path, {
+      data: request,
+    });
+    return this.addToMapAndReturn(response.data.items, response);
+  };
+}

--- a/packages/stable/src/api/records/types.ts
+++ b/packages/stable/src/api/records/types.ts
@@ -1,0 +1,163 @@
+// Copyright 2025 Cognite AS
+
+import type {
+  ContainerReference,
+  PropertyValueGroupV3,
+  RawPropertyValueV3,
+} from '../instances/types.gen';
+
+export type { ContainerReference, PropertyValueGroupV3, RawPropertyValueV3 };
+
+/**
+ * Property values for a container source
+ */
+export interface RecordData {
+  /**
+   * Reference to the container
+   */
+  source: ContainerReference;
+  /**
+   * Property values for the container
+   */
+  properties: PropertyValueGroupV3;
+}
+
+/**
+ * Record to write/ingest into a stream
+ */
+export interface RecordWrite {
+  /**
+   * The space that the record belongs to
+   */
+  space: string;
+  /**
+   * External ID of the record
+   */
+  externalId: string;
+  /**
+   * List of source properties to write
+   */
+  sources: RecordData[];
+}
+
+/**
+ * Source selector for specifying which container properties to return
+ */
+export interface SourceSelector {
+  /**
+   * Reference to the container
+   */
+  source: ContainerReference;
+  /**
+   * Properties to return for the specified container
+   */
+  properties: string[];
+}
+
+/**
+ * Last updated time filter for records
+ */
+export interface LastUpdatedTimeFilter {
+  /**
+   * Greater than or equal to
+   */
+  gte?: string | number;
+  /**
+   * Greater than
+   */
+  gt?: string | number;
+  /**
+   * Less than or equal to
+   */
+  lte?: string | number;
+  /**
+   * Less than
+   */
+  lt?: string | number;
+}
+
+/**
+ * Sort specification for a property
+ */
+export interface RecordSort {
+  /**
+   * Property to sort by
+   */
+  property: string[];
+  /**
+   * Sort direction
+   */
+  direction?: 'ascending' | 'descending';
+}
+
+/**
+ * Filter request for retrieving records from a stream
+ */
+export interface RecordFilterRequest {
+  /**
+   * Filter on last updated time. Required for immutable streams.
+   */
+  lastUpdatedTime?: LastUpdatedTimeFilter;
+  /**
+   * List of containers and their properties to return
+   */
+  sources?: SourceSelector[];
+  /**
+   * Filter specification
+   */
+  filter?: Record<string, unknown>;
+  /**
+   * Sorting specifications
+   */
+  sort?: RecordSort[];
+  /**
+   * Maximum number of results to return (default: 10, max: 1000)
+   */
+  limit?: number;
+}
+
+/**
+ * A record retrieved from a stream
+ */
+export interface RecordItem {
+  /**
+   * The space that the record belongs to
+   */
+  space: string;
+  /**
+   * External ID of the record
+   */
+  externalId: string;
+  /**
+   * When the record was created
+   */
+  createdTime: Date;
+  /**
+   * When the record was last updated
+   */
+  lastUpdatedTime: Date;
+  /**
+   * Properties organized by space -> container -> property
+   */
+  properties: RecordProperties;
+}
+
+/**
+ * Properties structure returned from the API
+ * Organized as: { [spaceId]: { [containerId]: { [propertyId]: value } } }
+ */
+export type RecordProperties = {
+  [space: string]: {
+    [container: string]: PropertyValueGroupV3;
+  };
+};
+
+/**
+ * Response from the filter records endpoint
+ */
+export interface RecordFilterResponse {
+  /**
+   * List of records matching the filter
+   */
+  items: RecordItem[];
+}

--- a/packages/stable/src/api/views/types.gen.ts
+++ b/packages/stable/src/api/views/types.gen.ts
@@ -1308,7 +1308,7 @@ export interface UpsertConflict {
 /**
  * Should this operation apply to nodes, edges or both.
  */
-export type UsedFor = 'node' | 'edge' | 'all';
+export type UsedFor = 'node' | 'edge' | 'all' | 'record';
 export interface VersionReferencesCollectionResponse {
   items: {
     externalId: DMSExternalId;

--- a/packages/stable/src/cogniteClient.ts
+++ b/packages/stable/src/cogniteClient.ts
@@ -27,6 +27,7 @@ import { LabelsAPI } from './api/labels/labelsApi';
 import { DataModelsAPI } from './api/models/datamodelsApi';
 import { ProjectsAPI } from './api/projects/projectsApi';
 import { RawAPI } from './api/raw/rawApi';
+import { RecordsAPI } from './api/records/recordsApi';
 import { RelationshipsApi } from './api/relationships/relationshipsApi';
 import { SecurityCategoriesAPI } from './api/securityCategories/securityCategoriesApi';
 import { SequencesAPI } from './api/sequences/sequencesApi';
@@ -183,6 +184,9 @@ export default class CogniteClient extends BaseCogniteClient {
   public get streams() {
     return accessApi(this.streamsApi);
   }
+  public get records() {
+    return accessApi(this.recordsApi);
+  }
   private assetsApi?: AssetsAPI;
   private timeSeriesApi?: TimeSeriesAPI;
   protected dataPointsApi?: DataPointsAPI;
@@ -215,6 +219,7 @@ export default class CogniteClient extends BaseCogniteClient {
   private dataModelsApi?: DataModelsAPI;
   private sessionsApi?: SessionsApi;
   private streamsApi?: StreamsAPI;
+  private recordsApi?: RecordsAPI;
 
   protected get version() {
     return version;
@@ -272,6 +277,7 @@ export default class CogniteClient extends BaseCogniteClient {
     this.dataModelsApi = this.apiFactory(DataModelsAPI, 'models/datamodels');
     this.sessionsApi = this.apiFactory(SessionsApi, 'sessions');
     this.streamsApi = this.apiFactory(StreamsAPI, 'streams');
+    this.recordsApi = this.apiFactory(RecordsAPI, 'streams');
   }
 
   static urlEncodeExternalId(externalId: string): string {

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -40,6 +40,7 @@ export * from './exports.gen';
 
 export * from './api/geospatial/types';
 export * from './api/streams/types';
+export * from './api/records/types';
 
 export interface Acl<ActionsType, ScopeType> {
   actions: ActionsType[];


### PR DESCRIPTION
This PR add new RecordsAPI with ingest and filter methods for working with immutable stream records. We also update the valid options for usedFor in containers to support record containers, which is needed to test the new feature.