### PR TITLE
chore(release): publish new package versions

### DIFF
--- a/packages/alpha/CHANGELOG.md
+++ b/packages/alpha/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.38.1](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk-alpha@0.38.0...@cognite/sdk-alpha@0.38.1) (2025-11-27)
+
+**Note:** Version bump only for package @cognite/sdk-alpha
+
+
+
+
+
 # [0.38.0](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk-alpha@0.37.0...@cognite/sdk-alpha@0.38.0) (2025-11-04)
 
 

--- a/packages/alpha/package.json
+++ b/packages/alpha/package.json
@@ -11,7 +11,7 @@
     "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts"
   },
-  "version": "0.38.0",
+  "version": "0.38.1",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",
@@ -30,8 +30,8 @@
     "test-snippets": ""
   },
   "dependencies": {
-    "@cognite/sdk": "^10.3.0",
-    "@cognite/sdk-core": "^5.1.2"
+    "@cognite/sdk": "^10.4.0",
+    "@cognite/sdk-core": "^5.1.3"
   },
   "files": [
     "dist"

--- a/packages/beta/CHANGELOG.md
+++ b/packages/beta/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.8](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk-beta@6.0.7...@cognite/sdk-beta@6.0.8) (2025-11-27)
+
+**Note:** Version bump only for package @cognite/sdk-beta
+
+
+
+
+
 ## [6.0.7](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk-beta@6.0.6...@cognite/sdk-beta@6.0.7) (2025-11-04)
 
 **Note:** Version bump only for package @cognite/sdk-beta

--- a/packages/beta/package.json
+++ b/packages/beta/package.json
@@ -12,7 +12,7 @@
     "types": "./dist/index.d.ts"
   },
   "type": "module",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",
     "test": "yarn g:vitest run",
@@ -29,8 +29,8 @@
     "test-snippets": "yarn extract-snippets && yarn g:tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/sdk": "^10.3.0",
-    "@cognite/sdk-core": "^5.1.2"
+    "@cognite/sdk": "^10.4.0",
+    "@cognite/sdk-core": "^5.1.3"
   },
   "files": [
     "dist"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.1.3](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk-core@5.1.2...@cognite/sdk-core@5.1.3) (2025-11-27)
+
+**Note:** Version bump only for package @cognite/sdk-core
+
+
+
+
+
 ## [5.1.2](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk-core@5.1.1...@cognite/sdk-core@5.1.2) (2025-11-04)
 
 **Note:** Version bump only for package @cognite/sdk-core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts"
   },
-  "version": "5.1.2",
+  "version": "5.1.3",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/",

--- a/packages/stable/CHANGELOG.md
+++ b/packages/stable/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.4.0](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk@10.3.0...@cognite/sdk@10.4.0) (2025-11-27)
+
+
+### Features
+
+* **streams:** add support for Streams API ([#1338](https://github.com/cognitedata/cognite-sdk-js/issues/1338)) ([683d581](https://github.com/cognitedata/cognite-sdk-js/commit/683d581f24))
+
+
+
+
+
 # [10.3.0](https://github.com/cognitedata/cognite-sdk-js/compare/@cognite/sdk@10.2.0...@cognite/sdk@10.3.0) (2025-11-04)
 
 

--- a/packages/stable/package.json
+++ b/packages/stable/package.json
@@ -11,7 +11,7 @@
     "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts"
   },
-  "version": "10.3.0",
+  "version": "10.4.0",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",
@@ -29,7 +29,7 @@
     "test-snippets": "yarn extract-snippets && yarn g:tsc -p codeSnippets/tsconfig.build.json"
   },
   "dependencies": {
-    "@cognite/sdk-core": "^5.1.2",
+    "@cognite/sdk-core": "^5.1.3",
     "@types/geojson": "^7946.0.14",
     "geojson": "^0.5.0",
     "lodash": "^4.17.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,8 +182,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-alpha@workspace:packages/alpha"
   dependencies:
-    "@cognite/sdk": "npm:^10.3.0"
-    "@cognite/sdk-core": "npm:^5.1.2"
+    "@cognite/sdk": "npm:^10.4.0"
+    "@cognite/sdk-core": "npm:^5.1.3"
   languageName: unknown
   linkType: soft
 
@@ -191,8 +191,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-beta@workspace:packages/beta"
   dependencies:
-    "@cognite/sdk": "npm:^10.3.0"
-    "@cognite/sdk-core": "npm:^5.1.2"
+    "@cognite/sdk": "npm:^10.4.0"
+    "@cognite/sdk-core": "npm:^5.1.3"
   languageName: unknown
   linkType: soft
 
@@ -212,7 +212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cognite/sdk-core@npm:^5.1.2, @cognite/sdk-core@workspace:packages/core":
+"@cognite/sdk-core@npm:^5.1.3, @cognite/sdk-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk-core@workspace:packages/core"
   dependencies:
@@ -264,11 +264,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk@npm:^10.3.0, @cognite/sdk@workspace:packages/stable":
+"@cognite/sdk@npm:^10.4.0, @cognite/sdk@workspace:packages/stable":
   version: 0.0.0-use.local
   resolution: "@cognite/sdk@workspace:packages/stable"
   dependencies:
-    "@cognite/sdk-core": "npm:^5.1.2"
+    "@cognite/sdk-core": "npm:^5.1.3"
     "@types/geojson": "npm:^7946.0.14"
     geojson: "npm:^0.5.0"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
## Summary
- Publishes `@cognite/sdk@10.4.0` with Streams API support
- Manually corrected version bump from patch to minor (feature release)
- Added missing changelog entry for #1338 (commits were not squashed)

## Packages
- `@cognite/sdk`: 10.3.0 → 10.4.0
- `@cognite/sdk-beta`: 6.0.7 → 6.0.8
- `@cognite/sdk-alpha`: 0.38.0 → 0.38.1
- `@cognite/sdk-core`: 5.1.2 → 5.1.3

## Note
PR #1338 was merged without squashing, so the changelog entry was added manually.