### PR TITLE
feat(records): add sync endpoint and dedicated filter types

### DIFF
--- a/packages/stable/src/__tests__/api/records.int.spec.ts
+++ b/packages/stable/src/__tests__/api/records.int.spec.ts
@@ -146,4 +146,305 @@ describe('records integration test', () => {
       testValue
     );
   });
+
+  test('filter with range', async () => {
+    const testName = `range_test_${randomInt()}`;
+    const testValue = 75.0;
+
+    await client.records.ingest(immutableStreamId, [
+      {
+        space: testSpaceId,
+        externalId: `range_record_${randomInt()}`,
+        sources: [
+          {
+            source: {
+              type: 'container',
+              space: testSpaceId,
+              externalId: testContainerId,
+            },
+            properties: {
+              name: testName,
+              value: testValue,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ]);
+
+    const result = await vi.waitFor(
+      async () => {
+        const records = await client.records.filter(immutableStreamId, {
+          lastUpdatedTime: {
+            gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+          },
+          sources: [
+            {
+              source: {
+                type: 'container',
+                space: testSpaceId,
+                externalId: testContainerId,
+              },
+              properties: ['*'],
+            },
+          ],
+          filter: {
+            and: [
+              {
+                equals: {
+                  property: [testSpaceId, testContainerId, 'name'],
+                  value: testName,
+                },
+              },
+              {
+                range: {
+                  property: [testSpaceId, testContainerId, 'value'],
+                  gte: 50,
+                  lte: 100,
+                },
+              },
+            ],
+          },
+        });
+        expect(records.length).toBe(1);
+        return records;
+      },
+      { timeout: 5_000, interval: 200 }
+    );
+
+    expect(result[0].properties[testSpaceId][testContainerId].value).toBe(
+      testValue
+    );
+  });
+
+  test('filter with prefix', async () => {
+    const uniquePrefix = `prefix_${randomInt()}`;
+    const testName = `${uniquePrefix}_record`;
+
+    await client.records.ingest(immutableStreamId, [
+      {
+        space: testSpaceId,
+        externalId: `prefix_record_${randomInt()}`,
+        sources: [
+          {
+            source: {
+              type: 'container',
+              space: testSpaceId,
+              externalId: testContainerId,
+            },
+            properties: {
+              name: testName,
+              value: 10,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ]);
+
+    const result = await vi.waitFor(
+      async () => {
+        const records = await client.records.filter(immutableStreamId, {
+          lastUpdatedTime: {
+            gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+          },
+          sources: [
+            {
+              source: {
+                type: 'container',
+                space: testSpaceId,
+                externalId: testContainerId,
+              },
+              properties: ['*'],
+            },
+          ],
+          filter: {
+            prefix: {
+              property: [testSpaceId, testContainerId, 'name'],
+              value: uniquePrefix,
+            },
+          },
+        });
+        expect(records.length).toBe(1);
+        return records;
+      },
+      { timeout: 5_000, interval: 200 }
+    );
+
+    expect(result[0].properties[testSpaceId][testContainerId].name).toBe(
+      testName
+    );
+  });
+
+  test('sync records', async () => {
+    const testName = `sync_test_${randomInt()}`;
+
+    await client.records.ingest(immutableStreamId, [
+      {
+        space: testSpaceId,
+        externalId: `sync_record_${randomInt()}`,
+        sources: [
+          {
+            source: {
+              type: 'container',
+              space: testSpaceId,
+              externalId: testContainerId,
+            },
+            properties: {
+              name: testName,
+              value: 99,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ]);
+
+    const result = await vi.waitFor(
+      async () => {
+        const response = await client.records.sync(immutableStreamId, {
+          initializeCursor: '1d-ago',
+          sources: [
+            {
+              source: {
+                type: 'container',
+                space: testSpaceId,
+                externalId: testContainerId,
+              },
+              properties: ['*'],
+            },
+          ],
+          filter: {
+            equals: {
+              property: [testSpaceId, testContainerId, 'name'],
+              value: testName,
+            },
+          },
+          limit: 10,
+        });
+        expect(response.items.length).toBe(1);
+        return response;
+      },
+      { timeout: 5_000, interval: 200 }
+    );
+
+    // The next() function will be defined if nextCursor is present
+    expect(typeof result.next === 'function' || result.next === undefined).toBe(
+      true
+    );
+    const record = result.items[0];
+    expect(record.space).toBe(testSpaceId);
+    expect(record.status).toBe('created');
+    expect(record.createdTime).toBeInstanceOf(Date);
+    expect(record.lastUpdatedTime).toBeInstanceOf(Date);
+    expect(record.properties?.[testSpaceId][testContainerId].name).toBe(
+      testName
+    );
+  });
+
+  test('sync records with autoPagingToArray', async () => {
+    const testName = `autopaging_test_${randomInt()}`;
+
+    // Ingest 3 records to test pagination across multiple pages
+    await client.records.ingest(immutableStreamId, [
+      {
+        space: testSpaceId,
+        externalId: `autopaging_record_1_${randomInt()}`,
+        sources: [
+          {
+            source: {
+              type: 'container',
+              space: testSpaceId,
+              externalId: testContainerId,
+            },
+            properties: {
+              name: testName,
+              value: 1,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+      {
+        space: testSpaceId,
+        externalId: `autopaging_record_2_${randomInt()}`,
+        sources: [
+          {
+            source: {
+              type: 'container',
+              space: testSpaceId,
+              externalId: testContainerId,
+            },
+            properties: {
+              name: testName,
+              value: 2,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+      {
+        space: testSpaceId,
+        externalId: `autopaging_record_3_${randomInt()}`,
+        sources: [
+          {
+            source: {
+              type: 'container',
+              space: testSpaceId,
+              externalId: testContainerId,
+            },
+            properties: {
+              name: testName,
+              value: 3,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ]);
+
+    const records = await vi.waitFor(
+      async () => {
+        // Use limit: 1 to force multiple pages and verify cursor exhaustion
+        const items = await client.records
+          .sync(immutableStreamId, {
+            initializeCursor: '1d-ago',
+            sources: [
+              {
+                source: {
+                  type: 'container',
+                  space: testSpaceId,
+                  externalId: testContainerId,
+                },
+                properties: ['*'],
+              },
+            ],
+            filter: {
+              equals: {
+                property: [testSpaceId, testContainerId, 'name'],
+                value: testName,
+              },
+            },
+            limit: 1,
+          })
+          .autoPagingToArray({ limit: 100 });
+        expect(items.length).toBe(3);
+        return items;
+      },
+      { timeout: 5_000, interval: 200 }
+    );
+
+    expect(records.length).toBe(3);
+    expect(records.every((r) => r.status === 'created')).toBe(true);
+    expect(
+      records.every(
+        (r) => r.properties?.[testSpaceId][testContainerId].name === testName
+      )
+    ).toBe(true);
+    // Verify we got all 3 different values
+    const values = records
+      .map((r) => r.properties?.[testSpaceId][testContainerId].value)
+      .sort();
+    expect(values).toEqual([1, 2, 3]);
+  });
 });

--- a/packages/stable/src/api/records/recordsApi.ts
+++ b/packages/stable/src/api/records/recordsApi.ts
@@ -1,11 +1,15 @@
 // Copyright 2025 Cognite AS
 
+import type { CursorAndAsyncIterator } from '@cognite/sdk-core';
 import { BaseResourceAPI } from '@cognite/sdk-core';
 import type {
   RecordFilterRequest,
   RecordFilterResponse,
   RecordItem,
+  RecordSyncRequest,
+  RecordSyncResponse,
   RecordWrite,
+  SyncRecordItem,
 } from './types';
 
 export class RecordsAPI extends BaseResourceAPI<RecordItem> {
@@ -78,5 +82,55 @@ export class RecordsAPI extends BaseResourceAPI<RecordItem> {
       data: request,
     });
     return this.addToMapAndReturn(response.data.items, response);
+  };
+
+  /**
+   * [Sync records from a stream](https://developer.cognite.com/api#tag/Records/operation/syncRecords)
+   *
+   * Sync records from a stream using a cursor-based approach. Supports auto-pagination.
+   *
+   * ```js
+   * // Get first page
+   * const response = await client.records.sync('my_stream', {
+   *   initializeCursor: '1d-ago',
+   *   sources: [{ source: { type: 'container', space: 'mySpace', externalId: 'myContainer' }, properties: ['*'] }],
+   * });
+   *
+   * // Auto-paginate to array
+   * const allRecords = await client.records
+   *   .sync('my_stream', { initializeCursor: '1d-ago', sources: [...] })
+   *   .autoPagingToArray({ limit: 10000 });
+   *
+   * // Iterate with for-await
+   * for await (const record of client.records.sync('my_stream', { initializeCursor: '1d-ago' })) {
+   *   console.log(record);
+   * }
+   * ```
+   */
+  public sync = (
+    streamExternalId: string,
+    request: RecordSyncRequest
+  ): CursorAndAsyncIterator<SyncRecordItem> => {
+    const path = this.url(`${streamExternalId}/records/sync`);
+
+    const callSyncEndpoint = async (params?: RecordSyncRequest) => {
+      const response = await this.post<RecordSyncResponse>(path, {
+        data: params,
+      });
+      const items = this.addToMapAndReturn(
+        response.data.items,
+        response
+      ) as SyncRecordItem[];
+      // Map hasNext to nextCursor for the pagination mechanism
+      const nextCursor = response.data.hasNext
+        ? response.data.nextCursor
+        : undefined;
+      return { ...response, data: { items, nextCursor } };
+    };
+
+    return this.cursorBasedEndpoint<RecordSyncRequest, SyncRecordItem>(
+      callSyncEndpoint,
+      request
+    );
   };
 }

--- a/packages/stable/src/api/records/recordsApi.ts
+++ b/packages/stable/src/api/records/recordsApi.ts
@@ -98,7 +98,7 @@ export class RecordsAPI extends BaseResourceAPI<RecordItem> {
    *
    * // Auto-paginate to array
    * const allRecords = await client.records
-   *   .sync('my_stream', { initializeCursor: '1d-ago', sources: [...] })
+   *   .sync('my_stream', { initializeCursor: '1d-ago', sources: [{ source: { type: 'container', space: 'mySpace', externalId: 'myContainer' }, properties: ['*'] }] })
    *   .autoPagingToArray({ limit: 10000 });
    *
    * // Iterate with for-await

--- a/packages/stable/src/api/records/recordsApi.ts
+++ b/packages/stable/src/api/records/recordsApi.ts
@@ -117,10 +117,7 @@ export class RecordsAPI extends BaseResourceAPI<RecordItem> {
       const response = await this.post<RecordSyncResponse>(path, {
         data: params,
       });
-      const items = this.addToMapAndReturn(
-        response.data.items,
-        response
-      ) as SyncRecordItem[];
+      const items = this.addToMapAndReturn(response.data.items, response);
       // Map hasNext to nextCursor for the pagination mechanism
       const nextCursor = response.data.hasNext
         ? response.data.nextCursor


### PR DESCRIPTION
This PR builds on top of https://github.com/cognitedata/cognite-sdk-js/pull/1341 and adds:
- Sync endpoint (`client.records.sync()`) with auto-pagination support for cursor-based synchronization of records from a stream
- Dedicated filter types (`RecordFilter`, `BoolFilter`, `LeafFilter`) replacing the generic `Record<string, unknown>` type