### PR TITLE
feat(simint): make simulatorIntegrationExternalId optional for routines, revisions and runs

### DIFF
--- a/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
@@ -2,7 +2,6 @@ import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
 import type CogniteClientAlpha from '../../cogniteClient';
-import type { SimulationRun } from '../../types';
 import { setupMockableClient } from '../testUtils';
 
 describe('Simulator Runs API unit tests', () => {
@@ -24,17 +23,17 @@ describe('Simulator Runs API unit tests', () => {
           routineExternalId: 'routine-1',
           routineRevisionExternalId: 'routine-revision-1',
           status: 'success',
-          runTime: new Date(),
-          simulationTime: new Date(),
+          runTime: 1765203279461,
+          simulationTime: 1765203279461,
           statusMessage: 'Test Status Message',
           dataSetId: 1,
           eventId: 1,
           runType: 'external',
           logId: 1,
-          createdTime: new Date(),
-          lastUpdatedTime: new Date(),
+          createdTime: 1765203279461,
+          lastUpdatedTime: 1765203279461,
           modelRevisionExternalId: 'model-revision-1',
-        } as SimulationRun,
+        },
       ],
     };
 
@@ -44,6 +43,14 @@ describe('Simulator Runs API unit tests', () => {
 
     const result = await client.simulators.listRuns();
     expect(result.items.length).toBe(1);
+    const mockedResponse = response.items.map((item) => ({
+      ...item,
+      createdTime: new Date(item.createdTime),
+      lastUpdatedTime: new Date(item.lastUpdatedTime),
+      runTime: new Date(item.runTime),
+      simulationTime: new Date(item.simulationTime),
+    }));
+    expect(result.items).toEqual(mockedResponse);
     expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
   });
 });

--- a/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
@@ -13,7 +13,7 @@ describe('Simulator Runs API unit tests', () => {
   });
 
   test('list simulation runs with undefined simulatorIntegrationExternalId', async () => {
-    const response = {
+    const mockedResponse = {
       items: [
         {
           id: 1,
@@ -39,18 +39,18 @@ describe('Simulator Runs API unit tests', () => {
 
     nock(mockBaseUrl)
       .post(/\/api\/v1\/projects\/.*\/simulators\/runs\/list/, {})
-      .reply(200, response);
+      .reply(200, mockedResponse);
 
     const result = await client.simulators.listRuns();
     expect(result.items.length).toBe(1);
-    const mockedResponse = response.items.map((item) => ({
+    const expectedResponse = mockedResponse.items.map((item) => ({
       ...item,
       createdTime: new Date(item.createdTime),
       lastUpdatedTime: new Date(item.lastUpdatedTime),
       runTime: new Date(item.runTime),
       simulationTime: new Date(item.simulationTime),
     }));
-    expect(result.items).toEqual(mockedResponse);
+    expect(result.items).toEqual(expectedResponse);
     expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
   });
 });

--- a/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
@@ -2,6 +2,7 @@ import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
 import type CogniteClientAlpha from '../../cogniteClient';
+import type { SimulationRun } from '../../types';
 import { setupMockableClient } from '../testUtils';
 
 describe('Simulator Runs API unit tests', () => {
@@ -29,7 +30,11 @@ describe('Simulator Runs API unit tests', () => {
           dataSetId: 1,
           eventId: 1,
           runType: 'external',
-        },
+          logId: 1,
+          createdTime: new Date(),
+          lastUpdatedTime: new Date(),
+          modelRevisionExternalId: 'model-revision-1',
+        } as SimulationRun,
       ],
     };
 

--- a/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulationRunsApi.unit.spec.ts
@@ -1,0 +1,44 @@
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+describe('Simulator Runs API unit tests', () => {
+  let client: CogniteClientAlpha;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    client = setupMockableClient();
+  });
+
+  test('list simulation runs with undefined simulatorIntegrationExternalId', async () => {
+    const response = {
+      items: [
+        {
+          id: 1,
+          simulatorExternalId: 'simulator-1',
+          simulatorIntegrationExternalId: undefined,
+          modelExternalId: 'model-1',
+          routineExternalId: 'routine-1',
+          routineRevisionExternalId: 'routine-revision-1',
+          status: 'success',
+          runTime: new Date(),
+          simulationTime: new Date(),
+          statusMessage: 'Test Status Message',
+          dataSetId: 1,
+          eventId: 1,
+          runType: 'external',
+        },
+      ],
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/api\/v1\/projects\/.*\/simulators\/runs\/list/, {})
+      .reply(200, response);
+
+    const result = await client.simulators.listRuns();
+    expect(result.items.length).toBe(1);
+    expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
+  });
+});

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
@@ -17,7 +17,7 @@ describe('Simulator Routines API unit tests', () => {
     const filter = {
       simulatorExternalIds: ['simulator-1', 'simulator-2'],
     };
-    const response = {
+    const mockedResponse = {
       items: [
         {
           id: 1,
@@ -48,17 +48,17 @@ describe('Simulator Routines API unit tests', () => {
       .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
         filter,
       })
-      .reply(200, response);
+      .reply(200, mockedResponse);
 
     const result = await client.simulators.listRoutines({
       filter,
     });
-    const mockedResponse = response.items.map((item) => ({
+    const expectedResponse = mockedResponse.items.map((item) => ({
       ...item,
       createdTime: new Date(item.createdTime),
       lastUpdatedTime: new Date(item.lastUpdatedTime),
     }));
-    expect(result.items).toEqual(mockedResponse);
+    expect(result.items).toEqual(expectedResponse);
     expect(result.items.length).toBe(2);
   });
 
@@ -68,7 +68,7 @@ describe('Simulator Routines API unit tests', () => {
       simulatorIntegrationExternalIds: ['integration-1'],
       modelExternalIds: ['model-1'],
     };
-    const response = {
+    const mockedResponse = {
       items: [
         {
           id: 1,
@@ -88,17 +88,17 @@ describe('Simulator Routines API unit tests', () => {
       .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {
         filter,
       })
-      .reply(200, response);
+      .reply(200, mockedResponse);
 
     const result = await client.simulators.listRoutines({
       filter,
     });
-    const mockedResponse = response.items.map((item) => ({
+    const expectedResponse = mockedResponse.items.map((item) => ({
       ...item,
       createdTime: new Date(item.createdTime),
       lastUpdatedTime: new Date(item.lastUpdatedTime),
     }));
-    expect(result.items).toEqual(mockedResponse);
+    expect(result.items).toEqual(expectedResponse);
     expect(result.items.length).toBe(1);
   });
 
@@ -124,7 +124,7 @@ describe('Simulator Routines API unit tests', () => {
   });
 
   test('list simulator routines with undefined simulatorIntegrationExternalId', async () => {
-    const response = {
+    const mockedResponse = {
       items: [
         {
           id: 1,
@@ -142,20 +142,20 @@ describe('Simulator Routines API unit tests', () => {
 
     nock(mockBaseUrl)
       .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {})
-      .reply(200, response);
+      .reply(200, mockedResponse);
 
     const result = await client.simulators.listRoutines();
     expect(result.items.length).toBe(1);
-    const mockedResponse = response.items.map((item) => ({
+    const expectedResponse = mockedResponse.items.map((item) => ({
       ...item,
       createdTime: new Date(item.createdTime),
       lastUpdatedTime: new Date(item.lastUpdatedTime),
     }));
-    expect(result.items).toEqual(mockedResponse);
+    expect(result.items).toEqual(expectedResponse);
   });
 
   test('list simulator routine revisions with undefined simulatorIntegrationExternalId', async () => {
-    const response = {
+    const mockedResponse = {
       items: [
         {
           id: 1,
@@ -179,14 +179,14 @@ describe('Simulator Routines API unit tests', () => {
         /\/api\/v1\/projects\/.*\/simulators\/routines\/revisions\/list/,
         {}
       )
-      .reply(200, response);
+      .reply(200, mockedResponse);
 
     const result = await client.simulators.listRoutineRevisions();
     expect(result.items.length).toBe(1);
-    const mockedResponse = response.items.map((item) => ({
+    const expectedResponse = mockedResponse.items.map((item) => ({
       ...item,
       createdTime: new Date(item.createdTime),
     }));
-    expect(result.items).toEqual(mockedResponse);
+    expect(result.items).toEqual(expectedResponse);
   });
 });

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
@@ -1,13 +1,9 @@
-import type {
-  SimulatorRoutine,
-  SimulatorRoutineRevision,
-} from 'alpha/src/types';
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
 import type CogniteClientAlpha from '../../cogniteClient';
 import { setupMockableClient } from '../testUtils';
-import { routineRevisionConfiguration } from './seed';
+import { routineRevisionConfiguration, routineRevisionScript } from './seed';
 
 describe('Simulator Routines API unit tests', () => {
   let client: CogniteClientAlpha;
@@ -25,27 +21,27 @@ describe('Simulator Routines API unit tests', () => {
       items: [
         {
           id: 1,
-          externalId: 'routine-1',
+          externalId: 'test_sim_routine_1',
+          simulatorExternalId: 'test_sim_1',
+          modelExternalId: 'test_model_1',
+          simulatorIntegrationExternalId: 'test_sim_integration_1',
           name: 'Test Routine 1',
-          modelExternalId: 'model-1',
-          simulatorIntegrationExternalId: 'integration-1',
           dataSetId: 1,
-          createdTime: new Date(),
-          lastUpdatedTime: new Date(),
-          simulatorExternalId: 'simulator-1',
+          createdTime: 1765203279461,
+          lastUpdatedTime: 1765203279461,
         },
         {
-          id: 2,
-          externalId: 'routine-2',
+          id: 1,
+          externalId: 'test_sim_routine_2',
+          simulatorExternalId: 'test_sim_1',
+          modelExternalId: 'test_model_1',
+          simulatorIntegrationExternalId: 'test_sim_integration_1',
           name: 'Test Routine 2',
-          modelExternalId: 'model-2',
-          simulatorIntegrationExternalId: 'integration-2',
-          dataSetId: 2,
-          createdTime: new Date(),
-          lastUpdatedTime: new Date(),
-          simulatorExternalId: 'simulator-2',
+          dataSetId: 1,
+          createdTime: 1765203279461,
+          lastUpdatedTime: 1765203279461,
         },
-      ] as SimulatorRoutine[],
+      ],
     };
 
     nock(mockBaseUrl)
@@ -57,7 +53,12 @@ describe('Simulator Routines API unit tests', () => {
     const result = await client.simulators.listRoutines({
       filter,
     });
-    expect(result.items).toEqual(response.items);
+    const mockedResponse = response.items.map((item) => ({
+      ...item,
+      createdTime: new Date(item.createdTime),
+      lastUpdatedTime: new Date(item.lastUpdatedTime),
+    }));
+    expect(result.items).toEqual(mockedResponse);
     expect(result.items.length).toBe(2);
   });
 
@@ -71,11 +72,15 @@ describe('Simulator Routines API unit tests', () => {
       items: [
         {
           id: 1,
-          externalId: 'routine-1',
+          externalId: 'test_sim_routine_1',
+          simulatorExternalId: 'test_sim_1',
+          modelExternalId: 'test_model_1',
+          simulatorIntegrationExternalId: 'test_sim_integration_1',
           name: 'Test Routine 1',
-          modelExternalId: 'model-1',
-          simulatorIntegrationExternalId: 'integration-1',
-        } as SimulatorRoutine,
+          dataSetId: 1,
+          createdTime: 1765203279461,
+          lastUpdatedTime: 1765203279461,
+        },
       ],
     };
 
@@ -88,7 +93,12 @@ describe('Simulator Routines API unit tests', () => {
     const result = await client.simulators.listRoutines({
       filter,
     });
-    expect(result.items).toEqual(response.items);
+    const mockedResponse = response.items.map((item) => ({
+      ...item,
+      createdTime: new Date(item.createdTime),
+      lastUpdatedTime: new Date(item.lastUpdatedTime),
+    }));
+    expect(result.items).toEqual(mockedResponse);
     expect(result.items.length).toBe(1);
   });
 
@@ -118,16 +128,15 @@ describe('Simulator Routines API unit tests', () => {
       items: [
         {
           id: 1,
-          externalId: 'routine-1',
+          externalId: 'test_sim_routine_1',
+          simulatorExternalId: 'test_sim_1',
+          modelExternalId: 'test_model_1',
+          simulatorIntegrationExternalId: 'test_sim_integration_1',
           name: 'Test Routine 1',
-          modelExternalId: 'model-1',
-          simulatorIntegrationExternalId: undefined,
-          simulatorExternalId: 'simulator-1',
           dataSetId: 1,
-          createdByUserId: 'user-1',
-          createdTime: new Date(),
-          lastUpdatedTime: new Date(),
-        } as SimulatorRoutine,
+          createdTime: 1765203279461,
+          lastUpdatedTime: 1765203279461,
+        },
       ],
     };
 
@@ -137,7 +146,12 @@ describe('Simulator Routines API unit tests', () => {
 
     const result = await client.simulators.listRoutines();
     expect(result.items.length).toBe(1);
-    expect(result.items).toEqual(response.items);
+    const mockedResponse = response.items.map((item) => ({
+      ...item,
+      createdTime: new Date(item.createdTime),
+      lastUpdatedTime: new Date(item.lastUpdatedTime),
+    }));
+    expect(result.items).toEqual(mockedResponse);
   });
 
   test('list simulator routine revisions with undefined simulatorIntegrationExternalId', async () => {
@@ -145,18 +159,18 @@ describe('Simulator Routines API unit tests', () => {
       items: [
         {
           id: 1,
-          externalId: 'routine-revision-1',
-          routineExternalId: 'routine-1',
-          modelExternalId: 'model-1',
-          simulatorIntegrationExternalId: undefined,
+          externalId: 'test_sim_routine_revision_1',
+          routineExternalId: 'test_sim_routine_1',
+          modelExternalId: 'test_model_1',
+          simulatorIntegrationExternalId: 'test_sim_integration_1',
           configuration: routineRevisionConfiguration,
-          script: [],
+          script: routineRevisionScript,
+          simulatorExternalId: 'test_sim_1',
           dataSetId: 1,
-          createdByUserId: 'user-1',
-          createdTime: new Date(),
+          createdByUserId: 'test_user_1',
+          createdTime: 1765203279461,
           versionNumber: 1,
-          simulatorExternalId: 'simulator-1',
-        } as SimulatorRoutineRevision,
+        },
       ],
     };
 
@@ -169,6 +183,10 @@ describe('Simulator Routines API unit tests', () => {
 
     const result = await client.simulators.listRoutineRevisions();
     expect(result.items.length).toBe(1);
-    expect(result.items).toEqual(response.items);
+    const mockedResponse = response.items.map((item) => ({
+      ...item,
+      createdTime: new Date(item.createdTime),
+    }));
+    expect(result.items).toEqual(mockedResponse);
   });
 });

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
 import type CogniteClientAlpha from '../../cogniteClient';
 import { setupMockableClient } from '../testUtils';
+import { routineRevisionConfiguration } from './seed';
 
 describe('Simulator Routines API unit tests', () => {
   let client: CogniteClientAlpha;
@@ -46,6 +47,12 @@ describe('Simulator Routines API unit tests', () => {
     });
     expect(result.items).toEqual(response.items);
     expect(result.items.length).toBe(2);
+    expect(result.items[0].simulatorIntegrationExternalId).toBe(
+      'integration-1'
+    );
+    expect(result.items[1].simulatorIntegrationExternalId).toBe(
+      'integration-2'
+    );
   });
 
   test('list routines with all filters combined', async () => {
@@ -98,5 +105,54 @@ describe('Simulator Routines API unit tests', () => {
     });
     expect(result.items).toEqual([]);
     expect(result.items.length).toBe(0);
+  });
+
+  test('list simulator routines with undefined simulatorIntegrationExternalId', async () => {
+    const response = {
+      items: [
+        {
+          id: 1,
+          externalId: 'routine-1',
+          name: 'Test Routine 1',
+          modelExternalId: 'model-1',
+          simulatorIntegrationExternalId: undefined,
+        },
+      ],
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/api\/v1\/projects\/.*\/simulators\/routines\/list/, {})
+      .reply(200, response);
+
+    const result = await client.simulators.listRoutines();
+    expect(result.items.length).toBe(1);
+    expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
+  });
+
+  test('list simulator routine revisions with undefined simulatorIntegrationExternalId', async () => {
+    const response = {
+      items: [
+        {
+          id: 1,
+          externalId: 'routine-revision-1',
+          routineExternalId: 'routine-1',
+          modelExternalId: 'model-1',
+          simulatorIntegrationExternalId: undefined,
+          configuration: routineRevisionConfiguration,
+          script: [],
+        },
+      ],
+    };
+
+    nock(mockBaseUrl)
+      .post(
+        /\/api\/v1\/projects\/.*\/simulators\/routines\/revisions\/list/,
+        {}
+      )
+      .reply(200, response);
+
+    const result = await client.simulators.listRoutineRevisions();
+    expect(result.items.length).toBe(1);
+    expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
   });
 });

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
@@ -1,3 +1,7 @@
+import type {
+  SimulatorRoutine,
+  SimulatorRoutineRevision,
+} from 'alpha/src/types';
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
@@ -25,6 +29,10 @@ describe('Simulator Routines API unit tests', () => {
           name: 'Test Routine 1',
           modelExternalId: 'model-1',
           simulatorIntegrationExternalId: 'integration-1',
+          dataSetId: 1,
+          createdTime: new Date(),
+          lastUpdatedTime: new Date(),
+          simulatorExternalId: 'simulator-1',
         },
         {
           id: 2,
@@ -32,8 +40,12 @@ describe('Simulator Routines API unit tests', () => {
           name: 'Test Routine 2',
           modelExternalId: 'model-2',
           simulatorIntegrationExternalId: 'integration-2',
+          dataSetId: 2,
+          createdTime: new Date(),
+          lastUpdatedTime: new Date(),
+          simulatorExternalId: 'simulator-2',
         },
-      ],
+      ] as SimulatorRoutine[],
     };
 
     nock(mockBaseUrl)
@@ -47,12 +59,6 @@ describe('Simulator Routines API unit tests', () => {
     });
     expect(result.items).toEqual(response.items);
     expect(result.items.length).toBe(2);
-    expect(result.items[0].simulatorIntegrationExternalId).toBe(
-      'integration-1'
-    );
-    expect(result.items[1].simulatorIntegrationExternalId).toBe(
-      'integration-2'
-    );
   });
 
   test('list routines with all filters combined', async () => {
@@ -69,7 +75,7 @@ describe('Simulator Routines API unit tests', () => {
           name: 'Test Routine 1',
           modelExternalId: 'model-1',
           simulatorIntegrationExternalId: 'integration-1',
-        },
+        } as SimulatorRoutine,
       ],
     };
 
@@ -116,7 +122,12 @@ describe('Simulator Routines API unit tests', () => {
           name: 'Test Routine 1',
           modelExternalId: 'model-1',
           simulatorIntegrationExternalId: undefined,
-        },
+          simulatorExternalId: 'simulator-1',
+          dataSetId: 1,
+          createdByUserId: 'user-1',
+          createdTime: new Date(),
+          lastUpdatedTime: new Date(),
+        } as SimulatorRoutine,
       ],
     };
 
@@ -126,7 +137,7 @@ describe('Simulator Routines API unit tests', () => {
 
     const result = await client.simulators.listRoutines();
     expect(result.items.length).toBe(1);
-    expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
+    expect(result.items).toEqual(response.items);
   });
 
   test('list simulator routine revisions with undefined simulatorIntegrationExternalId', async () => {
@@ -140,7 +151,12 @@ describe('Simulator Routines API unit tests', () => {
           simulatorIntegrationExternalId: undefined,
           configuration: routineRevisionConfiguration,
           script: [],
-        },
+          dataSetId: 1,
+          createdByUserId: 'user-1',
+          createdTime: new Date(),
+          versionNumber: 1,
+          simulatorExternalId: 'simulator-1',
+        } as SimulatorRoutineRevision,
       ],
     };
 
@@ -153,6 +169,6 @@ describe('Simulator Routines API unit tests', () => {
 
     const result = await client.simulators.listRoutineRevisions();
     expect(result.items.length).toBe(1);
-    expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
+    expect(result.items).toEqual(response.items);
   });
 });

--- a/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/simulatorRoutinesApi.unit.spec.ts
@@ -31,7 +31,7 @@ describe('Simulator Routines API unit tests', () => {
           lastUpdatedTime: 1765203279461,
         },
         {
-          id: 1,
+          id: 2,
           externalId: 'test_sim_routine_2',
           simulatorExternalId: 'test_sim_1',
           modelExternalId: 'test_model_1',
@@ -131,7 +131,7 @@ describe('Simulator Routines API unit tests', () => {
           externalId: 'test_sim_routine_1',
           simulatorExternalId: 'test_sim_1',
           modelExternalId: 'test_model_1',
-          simulatorIntegrationExternalId: 'test_sim_integration_1',
+          simulatorIntegrationExternalId: undefined,
           name: 'Test Routine 1',
           dataSetId: 1,
           createdTime: 1765203279461,
@@ -152,6 +152,7 @@ describe('Simulator Routines API unit tests', () => {
       lastUpdatedTime: new Date(item.lastUpdatedTime),
     }));
     expect(result.items).toEqual(expectedResponse);
+    expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
   });
 
   test('list simulator routine revisions with undefined simulatorIntegrationExternalId', async () => {
@@ -162,7 +163,7 @@ describe('Simulator Routines API unit tests', () => {
           externalId: 'test_sim_routine_revision_1',
           routineExternalId: 'test_sim_routine_1',
           modelExternalId: 'test_model_1',
-          simulatorIntegrationExternalId: 'test_sim_integration_1',
+          simulatorIntegrationExternalId: undefined,
           configuration: routineRevisionConfiguration,
           script: routineRevisionScript,
           simulatorExternalId: 'test_sim_1',
@@ -188,5 +189,6 @@ describe('Simulator Routines API unit tests', () => {
       createdTime: new Date(item.createdTime),
     }));
     expect(result.items).toEqual(expectedResponse);
+    expect(result.items[0].simulatorIntegrationExternalId).toBeUndefined();
   });
 });

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -200,7 +200,7 @@ export interface SimulationRun {
   id: CogniteInternalId;
 
   simulatorExternalId: CogniteExternalId;
-  simulatorIntegrationExternalId: CogniteExternalId;
+  simulatorIntegrationExternalId?: CogniteExternalId;
   modelExternalId: CogniteExternalId;
   modelRevisionExternalId: CogniteExternalId;
   routineExternalId: CogniteExternalId;
@@ -450,7 +450,7 @@ export interface SimulatorRoutine {
   externalId: CogniteExternalId;
   simulatorExternalId: CogniteExternalId;
   modelExternalId: CogniteExternalId;
-  simulatorIntegrationExternalId: CogniteExternalId;
+  simulatorIntegrationExternalId?: CogniteExternalId;
   name: string;
   dataSetId: number;
   description?: string;
@@ -461,7 +461,7 @@ export interface SimulatorRoutine {
 export interface SimulatorRoutineCreate {
   externalId: CogniteExternalId;
   modelExternalId: CogniteExternalId;
-  simulatorIntegrationExternalId: CogniteExternalId;
+  simulatorIntegrationExternalId?: CogniteExternalId;
   name: string;
 }
 
@@ -576,7 +576,7 @@ export interface SimulatorRoutineRevisionBase {
   externalId: CogniteExternalId;
   simulatorExternalId: CogniteExternalId;
   routineExternalId: CogniteExternalId;
-  simulatorIntegrationExternalId: CogniteExternalId;
+  simulatorIntegrationExternalId?: CogniteExternalId;
   modelExternalId: CogniteExternalId;
   dataSetId: CogniteInternalId;
   createdByUserId: string;


### PR DESCRIPTION
`simulatorIntegrationExternalId` is a required field at the moment, which means that it has to be associated with a connector since the creation of the resource, to make it flexible to decide after creation which connector can pick it up, we're making that field optional in this PR.

Ref: https://github.com/cognitedata/cognite-sdk-python/pull/2420