### PR TITLE
feat(records): add aggregate endpoint support

### DIFF
--- a/packages/stable/src/__tests__/api/records.int.spec.ts
+++ b/packages/stable/src/__tests__/api/records.int.spec.ts
@@ -450,63 +450,176 @@ describe('records integration test', () => {
 
   test('aggregate records with metric aggregates', async () => {
     const testName = `aggregate_metrics_${randomInt()}`;
-    const source = { type: 'container' as const, space: testSpaceId, externalId: testContainerId };
+    const source = {
+      type: 'container' as const,
+      space: testSpaceId,
+      externalId: testContainerId,
+    };
 
     await client.records.ingest(immutableStreamId, [
-      { space: testSpaceId, externalId: `agg_1_${randomInt()}`, sources: [{ source, properties: { name: testName, value: 100, timestamp: '2025-01-01T00:00:00.000Z' } }] },
-      { space: testSpaceId, externalId: `agg_2_${randomInt()}`, sources: [{ source, properties: { name: testName, value: 200, timestamp: '2025-01-01T00:00:00.000Z' } }] },
+      {
+        space: testSpaceId,
+        externalId: `agg_1_${randomInt()}`,
+        sources: [
+          {
+            source,
+            properties: {
+              name: testName,
+              value: 100,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+      {
+        space: testSpaceId,
+        externalId: `agg_2_${randomInt()}`,
+        sources: [
+          {
+            source,
+            properties: {
+              name: testName,
+              value: 200,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
     ]);
 
-    await vi.waitFor(async () => {
-      const prop = [testSpaceId, testContainerId, 'value'] as [string, string, string];
-      const aggregates = await client.records.aggregate(immutableStreamId, {
-        lastUpdatedTime: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() },
-        filter: { equals: { property: [testSpaceId, testContainerId, 'name'], value: testName } },
-        aggregates: {
-          total_count: { count: {} },
-          total_sum: { sum: { property: prop } },
-          avg_value: { avg: { property: prop } },
-          min_value: { min: { property: prop } },
-          max_value: { max: { property: prop } },
-        },
-      });
-      expect((aggregates.total_count as { count: number }).count).toBe(2);
-      expect((aggregates.total_sum as { sum: number }).sum).toBe(300);
-      expect((aggregates.avg_value as { avg: number }).avg).toBe(150);
-      expect((aggregates.min_value as { min: number }).min).toBe(100);
-      expect((aggregates.max_value as { max: number }).max).toBe(200);
-    }, { timeout: 5_000, interval: 200 });
+    await vi.waitFor(
+      async () => {
+        const prop = [testSpaceId, testContainerId, 'value'] as [
+          string,
+          string,
+          string,
+        ];
+        const aggregates = await client.records.aggregate(immutableStreamId, {
+          lastUpdatedTime: {
+            gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+          },
+          filter: {
+            equals: {
+              property: [testSpaceId, testContainerId, 'name'],
+              value: testName,
+            },
+          },
+          aggregates: {
+            total_count: { count: {} },
+            total_sum: { sum: { property: prop } },
+            avg_value: { avg: { property: prop } },
+            min_value: { min: { property: prop } },
+            max_value: { max: { property: prop } },
+          },
+        });
+        expect((aggregates.total_count as { count: number }).count).toBe(2);
+        expect((aggregates.total_sum as { sum: number }).sum).toBe(300);
+        expect((aggregates.avg_value as { avg: number }).avg).toBe(150);
+        expect((aggregates.min_value as { min: number }).min).toBe(100);
+        expect((aggregates.max_value as { max: number }).max).toBe(200);
+      },
+      { timeout: 5_000, interval: 200 }
+    );
   });
 
   test('aggregate records with uniqueValues bucket', async () => {
     const testPrefix = `agg_bucket_${randomInt()}`;
-    const cat1 = `${testPrefix}_cat1`, cat2 = `${testPrefix}_cat2`;
-    const source = { type: 'container' as const, space: testSpaceId, externalId: testContainerId };
+    const cat1 = `${testPrefix}_cat1`;
+    const cat2 = `${testPrefix}_cat2`;
+    const source = {
+      type: 'container' as const,
+      space: testSpaceId,
+      externalId: testContainerId,
+    };
 
     await client.records.ingest(immutableStreamId, [
-      { space: testSpaceId, externalId: `agg_b1_${randomInt()}`, sources: [{ source, properties: { name: cat1, value: 10, timestamp: '2025-01-01T00:00:00.000Z' } }] },
-      { space: testSpaceId, externalId: `agg_b2_${randomInt()}`, sources: [{ source, properties: { name: cat1, value: 20, timestamp: '2025-01-01T00:00:00.000Z' } }] },
-      { space: testSpaceId, externalId: `agg_b3_${randomInt()}`, sources: [{ source, properties: { name: cat2, value: 30, timestamp: '2025-01-01T00:00:00.000Z' } }] },
+      {
+        space: testSpaceId,
+        externalId: `agg_b1_${randomInt()}`,
+        sources: [
+          {
+            source,
+            properties: {
+              name: cat1,
+              value: 10,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+      {
+        space: testSpaceId,
+        externalId: `agg_b2_${randomInt()}`,
+        sources: [
+          {
+            source,
+            properties: {
+              name: cat1,
+              value: 20,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+      {
+        space: testSpaceId,
+        externalId: `agg_b3_${randomInt()}`,
+        sources: [
+          {
+            source,
+            properties: {
+              name: cat2,
+              value: 30,
+              timestamp: '2025-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
     ]);
 
-    type BucketResult = { uniqueValueBuckets: Array<{ count: number; value: string; aggregates?: { cat_sum: { sum: number } } }> };
+    type BucketResult = {
+      uniqueValueBuckets: Array<{
+        count: number;
+        value: string;
+        aggregates?: { cat_sum: { sum: number } };
+      }>;
+    };
 
-    await vi.waitFor(async () => {
-      const aggregates = await client.records.aggregate(immutableStreamId, {
-        lastUpdatedTime: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() },
-        filter: { prefix: { property: [testSpaceId, testContainerId, 'name'], value: testPrefix } },
-        aggregates: {
-          by_cat: { uniqueValues: { property: [testSpaceId, testContainerId, 'name'], aggregates: { cat_sum: { sum: { property: [testSpaceId, testContainerId, 'value'] } } } } },
-        },
-      });
-      const result = aggregates.by_cat as BucketResult;
-      expect(result.uniqueValueBuckets.length).toBe(2);
-      const b1 = result.uniqueValueBuckets.find((b) => b.value === cat1);
-      const b2 = result.uniqueValueBuckets.find((b) => b.value === cat2);
-      expect(b1?.count).toBe(2);
-      expect(b1?.aggregates?.cat_sum.sum).toBe(30);
-      expect(b2?.count).toBe(1);
-      expect(b2?.aggregates?.cat_sum.sum).toBe(30);
-    }, { timeout: 10_000, interval: 500 });
+    await vi.waitFor(
+      async () => {
+        const aggregates = await client.records.aggregate(immutableStreamId, {
+          lastUpdatedTime: {
+            gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+          },
+          filter: {
+            prefix: {
+              property: [testSpaceId, testContainerId, 'name'],
+              value: testPrefix,
+            },
+          },
+          aggregates: {
+            by_cat: {
+              uniqueValues: {
+                property: [testSpaceId, testContainerId, 'name'],
+                aggregates: {
+                  cat_sum: {
+                    sum: { property: [testSpaceId, testContainerId, 'value'] },
+                  },
+                },
+              },
+            },
+          },
+        });
+        const result = aggregates.by_cat as BucketResult;
+        expect(result.uniqueValueBuckets.length).toBe(2);
+        const b1 = result.uniqueValueBuckets.find((b) => b.value === cat1);
+        const b2 = result.uniqueValueBuckets.find((b) => b.value === cat2);
+        expect(b1?.count).toBe(2);
+        expect(b1?.aggregates?.cat_sum.sum).toBe(30);
+        expect(b2?.count).toBe(1);
+        expect(b2?.aggregates?.cat_sum.sum).toBe(30);
+      },
+      { timeout: 10_000, interval: 500 }
+    );
   });
 });

--- a/packages/stable/src/__tests__/api/records.int.spec.ts
+++ b/packages/stable/src/__tests__/api/records.int.spec.ts
@@ -447,4 +447,66 @@ describe('records integration test', () => {
       .sort();
     expect(values).toEqual([1, 2, 3]);
   });
+
+  test('aggregate records with metric aggregates', async () => {
+    const testName = `aggregate_metrics_${randomInt()}`;
+    const source = { type: 'container' as const, space: testSpaceId, externalId: testContainerId };
+
+    await client.records.ingest(immutableStreamId, [
+      { space: testSpaceId, externalId: `agg_1_${randomInt()}`, sources: [{ source, properties: { name: testName, value: 100, timestamp: '2025-01-01T00:00:00.000Z' } }] },
+      { space: testSpaceId, externalId: `agg_2_${randomInt()}`, sources: [{ source, properties: { name: testName, value: 200, timestamp: '2025-01-01T00:00:00.000Z' } }] },
+    ]);
+
+    await vi.waitFor(async () => {
+      const prop = [testSpaceId, testContainerId, 'value'] as [string, string, string];
+      const aggregates = await client.records.aggregate(immutableStreamId, {
+        lastUpdatedTime: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() },
+        filter: { equals: { property: [testSpaceId, testContainerId, 'name'], value: testName } },
+        aggregates: {
+          total_count: { count: {} },
+          total_sum: { sum: { property: prop } },
+          avg_value: { avg: { property: prop } },
+          min_value: { min: { property: prop } },
+          max_value: { max: { property: prop } },
+        },
+      });
+      expect((aggregates.total_count as { count: number }).count).toBe(2);
+      expect((aggregates.total_sum as { sum: number }).sum).toBe(300);
+      expect((aggregates.avg_value as { avg: number }).avg).toBe(150);
+      expect((aggregates.min_value as { min: number }).min).toBe(100);
+      expect((aggregates.max_value as { max: number }).max).toBe(200);
+    }, { timeout: 5_000, interval: 200 });
+  });
+
+  test('aggregate records with uniqueValues bucket', async () => {
+    const testPrefix = `agg_bucket_${randomInt()}`;
+    const cat1 = `${testPrefix}_cat1`, cat2 = `${testPrefix}_cat2`;
+    const source = { type: 'container' as const, space: testSpaceId, externalId: testContainerId };
+
+    await client.records.ingest(immutableStreamId, [
+      { space: testSpaceId, externalId: `agg_b1_${randomInt()}`, sources: [{ source, properties: { name: cat1, value: 10, timestamp: '2025-01-01T00:00:00.000Z' } }] },
+      { space: testSpaceId, externalId: `agg_b2_${randomInt()}`, sources: [{ source, properties: { name: cat1, value: 20, timestamp: '2025-01-01T00:00:00.000Z' } }] },
+      { space: testSpaceId, externalId: `agg_b3_${randomInt()}`, sources: [{ source, properties: { name: cat2, value: 30, timestamp: '2025-01-01T00:00:00.000Z' } }] },
+    ]);
+
+    type BucketResult = { uniqueValueBuckets: Array<{ count: number; value: string; aggregates?: { cat_sum: { sum: number } } }> };
+
+    await vi.waitFor(async () => {
+      const aggregates = await client.records.aggregate(immutableStreamId, {
+        lastUpdatedTime: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() },
+        filter: { prefix: { property: [testSpaceId, testContainerId, 'name'], value: testPrefix } },
+        aggregates: {
+          by_cat: { uniqueValues: { property: [testSpaceId, testContainerId, 'name'], aggregates: { cat_sum: { sum: { property: [testSpaceId, testContainerId, 'value'] } } } } },
+        },
+      });
+      const result = aggregates.by_cat as BucketResult;
+      expect(result.uniqueValueBuckets.length).toBe(2);
+      const b1 = result.uniqueValueBuckets.find((b) => b.value === cat1);
+      const b2 = result.uniqueValueBuckets.find((b) => b.value === cat2);
+      expect(b1?.count).toBe(2);
+      expect(b1?.aggregates?.cat_sum.sum).toBe(30);
+      expect(b2?.count).toBe(1);
+      expect(b2?.aggregates?.cat_sum.sum).toBe(30);
+    }, { timeout: 10_000, interval: 500 });
+  });
 });

--- a/packages/stable/src/api/records/recordsApi.ts
+++ b/packages/stable/src/api/records/recordsApi.ts
@@ -3,6 +3,9 @@
 import type { CursorAndAsyncIterator } from '@cognite/sdk-core';
 import { BaseResourceAPI } from '@cognite/sdk-core';
 import type {
+  RecordAggregateRequest,
+  RecordAggregateResponse,
+  RecordAggregateResults,
   RecordFilterRequest,
   RecordFilterResponse,
   RecordItem,
@@ -129,5 +132,35 @@ export class RecordsAPI extends BaseResourceAPI<RecordItem> {
       callSyncEndpoint,
       request
     );
+  };
+
+  /**
+   * [Aggregate records from a stream](https://developer.cognite.com/api#tag/Records/operation/aggregateRecords)
+   *
+   * Aggregate data for records from a stream.
+   *
+   * ```js
+   * const response = await client.records.aggregate('my_stream', {
+   *   aggregates: {
+   *     total_count: { count: {} },
+   *     by_category: {
+   *       uniqueValues: {
+   *         property: ['mySpace', 'myContainer', 'category'],
+   *         aggregates: { total: { sum: { property: ['mySpace', 'myContainer', 'amount'] } } }
+   *       }
+   *     }
+   *   }
+   * });
+   * ```
+   */
+  public aggregate = async (
+    streamExternalId: string,
+    request: RecordAggregateRequest
+  ): Promise<RecordAggregateResults> => {
+    const path = this.url(`${streamExternalId}/records/aggregate`);
+    const response = await this.post<RecordAggregateResponse>(path, {
+      data: request,
+    });
+    return response.data.aggregates;
   };
 }

--- a/packages/stable/src/api/records/types.ts
+++ b/packages/stable/src/api/records/types.ts
@@ -310,7 +310,15 @@ export type MovingFunctionType =
   | 'MovingFunctions.linearWeightedAvg';
 
 /** Calendar interval for time histogram aggregation */
-export type CalendarInterval = '1s' | '1m' | '1h' | '1d' | '1w' | '1M' | '1q' | '1y';
+export type CalendarInterval =
+  | '1s'
+  | '1m'
+  | '1h'
+  | '1d'
+  | '1w'
+  | '1M'
+  | '1q'
+  | '1y';
 
 /** Hard bounds for histogram aggregates */
 export interface HistogramHardBounds {
@@ -320,17 +328,32 @@ export interface HistogramHardBounds {
 
 // Metric aggregates
 /** Calculates the average from the data stored by the specified property */
-export interface AvgAggregate { avg: { property: AggregateProperty } }
+export interface AvgAggregate {
+  avg: { property: AggregateProperty };
+}
 /** Counts the number of items (or non-null values when property is specified) */
-export interface CountAggregate { count: { property?: AggregateProperty } }
+export interface CountAggregate {
+  count: { property?: AggregateProperty };
+}
 /** Calculates the lowest value for the property */
-export interface MinAggregate { min: { property: AggregateProperty } }
+export interface MinAggregate {
+  min: { property: AggregateProperty };
+}
 /** Calculates the highest value for the property */
-export interface MaxAggregate { max: { property: AggregateProperty } }
+export interface MaxAggregate {
+  max: { property: AggregateProperty };
+}
 /** Calculates the sum from the values of the specified property */
-export interface SumAggregate { sum: { property: AggregateProperty } }
+export interface SumAggregate {
+  sum: { property: AggregateProperty };
+}
 
-export type MetricAggregate = AvgAggregate | CountAggregate | MinAggregate | MaxAggregate | SumAggregate;
+export type MetricAggregate =
+  | AvgAggregate
+  | CountAggregate
+  | MinAggregate
+  | MaxAggregate
+  | SumAggregate;
 
 // Bucket aggregates
 /** Groups records by unique property values */
@@ -404,7 +427,10 @@ export interface MovingFunctionAggregate {
 export type PipelineAggregate = MovingFunctionAggregate;
 
 /** All aggregate types */
-export type RecordAggregate = MetricAggregate | BucketAggregate | PipelineAggregate;
+export type RecordAggregate =
+  | MetricAggregate
+  | BucketAggregate
+  | PipelineAggregate;
 
 /** Dictionary of aggregates with client-defined identifiers (max 5 per level, max depth 5) */
 export type RecordAggregates = Record<string, RecordAggregate>;
@@ -420,12 +446,24 @@ export interface RecordAggregateRequest {
 }
 
 // Aggregate result types
-export interface AvgAggregateResult { avg: number }
-export interface CountAggregateResult { count: number }
-export interface MinAggregateResult { min: number }
-export interface MaxAggregateResult { max: number }
-export interface SumAggregateResult { sum: number }
-export interface MovingFunctionAggregateResult { fnValue: number }
+export interface AvgAggregateResult {
+  avg: number;
+}
+export interface CountAggregateResult {
+  count: number;
+}
+export interface MinAggregateResult {
+  min: number;
+}
+export interface MaxAggregateResult {
+  max: number;
+}
+export interface SumAggregateResult {
+  sum: number;
+}
+export interface MovingFunctionAggregateResult {
+  fnValue: number;
+}
 
 export type MetricAggregateResult =
   | AvgAggregateResult
@@ -484,7 +522,9 @@ export type BucketAggregateResult =
   | TimeHistogramAggregateResult
   | FiltersAggregateResult;
 
-export type RecordAggregateResult = MetricAggregateResult | BucketAggregateResult;
+export type RecordAggregateResult =
+  | MetricAggregateResult
+  | BucketAggregateResult;
 
 /** Dictionary of aggregate results with identifiers matching the request */
 export type RecordAggregateResults = Record<string, RecordAggregateResult>;


### PR DESCRIPTION
This PR adds support for the Aggregate endpoint for records with full type definitions for requests and responses.