### PR TITLE
feat(alpha): add support for Limit-service

### DIFF
--- a/packages/alpha/src/__tests__/api/limitsApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/limitsApi.unit.spec.ts
@@ -1,0 +1,263 @@
+// Copyright 2025 Cognite AS
+
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+describe('Limits API unit tests', () => {
+  let client: CogniteClientAlpha;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    client = setupMockableClient();
+  });
+
+  describe('retrieveByLimitId', () => {
+    test('should retrieve a single limit by ID', async () => {
+      const limitId = 'streams.properties';
+      const mockedResponse = {
+        limitId: 'streams.properties',
+        value: 1000,
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/limits\/values\/streams\.properties/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.retrieveByLimitId(limitId);
+      expect(result.limitId).toEqual(mockedResponse.limitId);
+      expect(result.value).toEqual(mockedResponse.value);
+    });
+
+    test('should handle URL encoding for special characters in limitId', async () => {
+      const limitId = 'streams.properties/special';
+      const mockedResponse = {
+        limitId: 'streams.properties/special',
+        value: 500,
+      };
+
+      nock(mockBaseUrl)
+        .get(
+          /\/api\/v1\/projects\/.*\/limits\/values\/streams\.properties%2Fspecial$/
+        )
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.retrieveByLimitId(limitId);
+      expect(result.limitId).toEqual(mockedResponse.limitId);
+      expect(result.value).toEqual(mockedResponse.value);
+    });
+
+    test('should handle 404 error when limit not found', async () => {
+      const limitId = 'non-existent-limit';
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/limits\/values\/non-existent-limit$/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(404, { error: { message: 'Limit not found', code: 404 } });
+
+      await expect(client.limits.retrieveByLimitId(limitId)).rejects.toThrow();
+    });
+  });
+
+  describe('retrieveByAdvancedFilter', () => {
+    test('should retrieve limits with filter', async () => {
+      const filter = {
+        filter: {
+          limitIds: ['streams.properties', 'events.max'],
+        },
+        limit: 100,
+      };
+      const mockedResponse = {
+        items: [
+          {
+            limitId: 'streams.properties',
+            value: 1000,
+          },
+          {
+            limitId: 'events.max',
+            value: 5000,
+          },
+        ],
+        nextCursor: 'cursor-123',
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, filter)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.retrieveByAdvancedFilter(filter);
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.nextCursor).toBe('cursor-123');
+      expect(result.items.length).toBe(2);
+    });
+
+    test('should retrieve limits with empty filter', async () => {
+      const filter = {};
+      const mockedResponse = {
+        items: [
+          {
+            limitId: 'streams.properties',
+            value: 1000,
+          },
+        ],
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, filter)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.retrieveByAdvancedFilter(filter);
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.items.length).toBe(1);
+    });
+
+    test('should handle empty results', async () => {
+      const filter = {
+        filter: {
+          limitIds: ['non-existent'],
+        },
+      };
+      const mockedResponse = {
+        items: [],
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, filter)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.retrieveByAdvancedFilter(filter);
+      expect(result.items).toEqual([]);
+      expect(result.items.length).toBe(0);
+    });
+
+    test('should handle pagination with cursor', async () => {
+      const filter = {
+        filter: {},
+        cursor: 'cursor-123',
+        limit: 50,
+      };
+      const mockedResponse = {
+        items: [
+          {
+            limitId: 'streams.properties',
+            value: 1000,
+          },
+        ],
+        nextCursor: 'cursor-456',
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, filter)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.retrieveByAdvancedFilter(filter);
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.nextCursor).toBe('cursor-456');
+    });
+  });
+
+  describe('getAllLimits', () => {
+    test('should retrieve all limits without query params', async () => {
+      const mockedResponse = {
+        items: [
+          {
+            limitId: 'streams.properties',
+            value: 1000,
+          },
+          {
+            limitId: 'events.max',
+            value: 5000,
+          },
+          {
+            limitId: 'assets.max',
+            value: 10000,
+          },
+        ],
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/limits\/values/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.getAllLimits({});
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.items.length).toBe(3);
+    });
+
+    test('should retrieve all limits with query params', async () => {
+      const queryParams = {
+        limit: 100,
+        cursor: 'initial-cursor',
+      };
+      const mockedResponse = {
+        items: [
+          {
+            limitId: 'streams.properties',
+            value: 1000,
+          },
+        ],
+        nextCursor: 'next-cursor',
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/limits\/values/)
+        .query(queryParams)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.getAllLimits(queryParams);
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.nextCursor).toBe('next-cursor');
+    });
+
+    test('should handle empty results', async () => {
+      const mockedResponse = {
+        items: [],
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/limits\/values/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.limits.getAllLimits({});
+      expect(result.items).toEqual([]);
+      expect(result.items.length).toBe(0);
+    });
+
+    test('should handle error responses', async () => {
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/limits\/values/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(500, { error: { message: 'Internal server error', code: 500 } });
+
+      await expect(client.limits.getAllLimits({})).rejects.toThrow();
+    });
+  });
+
+  describe('headers', () => {
+    test('should include cdf-version header in all requests', async () => {
+      const limitId = 'streams.properties';
+      const mockedResponse = {
+        limitId: 'streams.properties',
+        value: 1000,
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/limits\/values\/streams\.properties/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      await client.limits.retrieveByLimitId(limitId);
+    });
+  });
+});

--- a/packages/alpha/src/__tests__/api/limitsApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/limitsApi.unit.spec.ts
@@ -1,5 +1,6 @@
 // Copyright 2025 Cognite AS
 
+import type { LimitAdvanceFilter } from 'alpha/src/types';
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
@@ -65,9 +66,12 @@ describe('Limits API unit tests', () => {
 
   describe('retrieveByAdvancedFilter', () => {
     test('should retrieve limits with filter', async () => {
-      const filter = {
+      const filter: LimitAdvanceFilter = {
         filter: {
-          limitIds: ['streams.properties', 'events.max'],
+          prefix: {
+            property: ['limitId'],
+            value: 'streams.properties',
+          },
         },
         limit: 100,
       };
@@ -86,7 +90,13 @@ describe('Limits API unit tests', () => {
       };
 
       nock(mockBaseUrl)
-        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, filter)
+        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, (body) => {
+          return (
+            body.filter?.prefix?.property?.includes('limitId') &&
+            body.filter?.prefix?.value === 'streams.properties' &&
+            body.limit === 100
+          );
+        })
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
@@ -118,9 +128,12 @@ describe('Limits API unit tests', () => {
     });
 
     test('should handle empty results', async () => {
-      const filter = {
+      const filter: LimitAdvanceFilter = {
         filter: {
-          limitIds: ['non-existent'],
+          prefix: {
+            property: ['limitId'],
+            value: 'unexistent',
+          },
         },
       };
       const mockedResponse = {
@@ -128,7 +141,12 @@ describe('Limits API unit tests', () => {
       };
 
       nock(mockBaseUrl)
-        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, filter)
+        .post(/\/api\/v1\/projects\/.*\/limits\/values\/list/, (body) => {
+          return (
+            body.filter?.prefix?.property?.includes('limitId') &&
+            body.filter?.prefix?.value === 'unexistent'
+          );
+        })
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 

--- a/packages/alpha/src/api/limits/limitsApi.ts
+++ b/packages/alpha/src/api/limits/limitsApi.ts
@@ -1,0 +1,88 @@
+import {
+  BaseResourceAPI,
+  type CursorResponse,
+  type FilterQuery,
+} from '@cognite/sdk-core';
+import type {
+  CursorAndAsyncIterator,
+  LimitAdvanceFilter,
+  LimitsValue,
+} from '../../types';
+
+export class LimitsAPI extends BaseResourceAPI<LimitsValue> {
+  private header = {
+    'cdf-version': '20230101-alpha',
+  };
+
+  /**
+   * [Retrieve a single limit by ID](https://api-docs.cognite.com/20230101-alpha/tag/Limits/operation/fetchLimitById)
+   *
+   * @param limitId - The ID of the limit to retrieve.
+   * @returns The limit value.
+   */
+  public retrieveByLimitId = async (limitId: string): Promise<LimitsValue> => {
+    const path = this.url(`values/${encodeURIComponent(limitId)}`);
+    const response = await this.get<LimitsValue>(path, {
+      headers: this.header,
+    });
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [Retrieve a list of limits with advanced filter](https://api-docs.cognite.com/20230101-alpha/tag/Limits/operation/listLimitsAdvanced)
+   *
+   * @param filter - The filter to apply to the limits.
+   * @returns The list of limits.
+   */
+  public retrieveByAdvancedFilter = (
+    filter?: LimitAdvanceFilter
+  ): CursorAndAsyncIterator<LimitsValue> => {
+    const path = this.url('values/list');
+
+    const endpointCaller = async (query?: LimitAdvanceFilter) => {
+      const requestBody = query || filter || {};
+      const response = await this.post<CursorResponse<LimitsValue[]>>(path, {
+        data: requestBody,
+        headers: this.header,
+      });
+      return {
+        ...response,
+        data: {
+          items: response.data.items || [],
+          nextCursor: response.data?.nextCursor,
+        },
+      };
+    };
+
+    return this.listEndpoint(endpointCaller, filter);
+  };
+
+  /**
+   * [Retrieve a list of all limits](https://api-docs.cognite.com/20230101-alpha/tag/Limits/operation/listLimits)
+   *
+   * @param queryparams - The query parameters to apply to the limits.
+   * @returns The list of limits.
+   */
+  public getAllLimits = (
+    queryparams?: FilterQuery
+  ): CursorAndAsyncIterator<LimitsValue> => {
+    const path = this.url('values');
+
+    const endpointCaller = async (query?: FilterQuery) => {
+      const queryParams = query || queryparams || {};
+      const response = await this.get<CursorResponse<LimitsValue[]>>(path, {
+        params: queryParams,
+        headers: this.header,
+      });
+      return {
+        ...response,
+        data: {
+          items: response.data.items || [],
+          nextCursor: response.data?.nextCursor,
+        },
+      };
+    };
+
+    return this.listEndpoint(endpointCaller, queryparams);
+  };
+}

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -2,10 +2,16 @@
 import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
 import { accessApi } from '@cognite/sdk-core';
 import { version } from '../package.json';
+import { LimitsAPI } from './api/limits/limitsApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
 
 export default class CogniteClientAlpha extends CogniteClientStable {
   private simulatorsApi?: SimulatorsAPI;
+  private limitsApi?: LimitsAPI;
+
+  public get limits() {
+    return accessApi(this.limitsApi);
+  }
 
   public get simulators() {
     return accessApi(this.simulatorsApi);
@@ -17,6 +23,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     this.httpClient.setDefaultHeader('cdf-version', 'alpha');
 
     this.simulatorsApi = this.apiFactory(SimulatorsAPI, 'simulators');
+    this.limitsApi = this.apiFactory(LimitsAPI, 'limits');
   }
 
   protected get version() {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -615,3 +615,12 @@ export interface SimulatorRoutineRevisionsFilterQuery extends FilterQuery {
   sort?: SortItem[];
   includeAllFields?: boolean;
 }
+
+export interface LimitsValue {
+  limitId: string;
+  value: number;
+}
+
+export interface LimitAdvanceFilter extends FilterQuery {
+  filter?: object;
+}

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -622,5 +622,12 @@ export interface LimitsValue {
 }
 
 export interface LimitAdvanceFilter extends FilterQuery {
-  filter?: object;
+  filter?: FilterObject;
+}
+
+export interface FilterObject {
+  prefix?: {
+    property: string[];
+    value: string;
+  };
 }


### PR DESCRIPTION
## Description
MUT-1116 : This PR adds SDK support for the limits service API in the alpha package with three endpoints:
- retrieveByLimitId: Retrieve a single limit by ID (GET `/limits/values/{limitId}`)
- retrieveByAdvancedFilter: List limits with advanced filtering (POST `/limits/values/list`)
- getAllLimits: Retrieve all limits with optional query parameters (GET `/limits/values`)

`retrieveByAdvancedFilter` and `getAllLimits` endpoints support pagination via `listEndpoint` and include proper metadata tracking.

## Changes:
- Add LimitsAPI class extending BaseResourceAPI
- Add Typescript types: LimitsValue, LimitAdvanceFilter, FilterObject
- Integrate LimitsAPI into CogniteClient alpha.
- Add comprehensive unit tests for all endpoints


