### PR TITLE
ci: run with node 22, remove 18

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: configure node js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Cache node_modules
         id: cache-modules

--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Configure Git
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Cache node_modules
         id: cache-modules
@@ -50,7 +50,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Cache node_modules
         id: cache-modules
@@ -79,7 +79,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Cache node_modules
         id: cache-modules
@@ -103,7 +103,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
 
     env:
       COGNITE_PROJECT: cognitesdk-js


### PR DESCRIPTION
Node 18 is deprecated and node 20 is going to in 2026, we have to switch to LTS

Changes:

- set node 22 by default for most jobs
- run tests with node 20 + 22