### PR TITLE
feat(instances): implement support for explicitly setting search operator

### DIFF
--- a/packages/stable/src/__tests__/api/instances.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/instances.unit.spec.ts
@@ -1,0 +1,60 @@
+// Copyright 2020 Cognite AS
+
+import type { ViewReference } from '@cognite/sdk-stable';
+import nock from 'nock';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+import { mockBaseUrl, setupMockableClient } from '../testUtils';
+
+describe('instances unit tests', () => {
+  const view: ViewReference = {
+    externalId: 'Describable',
+    space: 'cdf_core',
+    type: 'view',
+    version: 'v1',
+  };
+
+  beforeAll(async () => {
+    nock.cleanAll();
+  });
+
+  test('search operator warning should be logged the first time making a search request with default operator', async () => {
+    const freshClient = setupMockableClient();
+    const warnMock = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    nock(mockBaseUrl)
+      .persist()
+      .post(/\/models\/instances\/search/)
+      .reply(200, { items: [] });
+    await freshClient.instances.search({
+      view,
+      limit: 1,
+    });
+    await freshClient.instances.search({
+      view,
+      limit: 1,
+    });
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('search operator warning should not be logged if explicitly setting operator', async () => {
+    const freshClient = setupMockableClient();
+    const warnMock = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    nock(mockBaseUrl)
+      .persist()
+      .post(/\/models\/instances\/search/)
+      .reply(200, { items: [] });
+    await freshClient.instances.search({
+      view,
+      operator: 'OR',
+      limit: 1,
+    });
+
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -21,6 +21,8 @@ import type {
 } from './types.gen';
 
 export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
+  private searchOperatorChangeWarningDisplayed = false;
+
   /**
    * [Search instances](https://developer.cognite.com/api#tag/Instances/operation/searchInstances)
    *
@@ -46,6 +48,17 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
   public search = async (
     params: NodeOrEdgeSearchRequest
   ): Promise<ByIdsResponse> => {
+    if (
+      params.operator === undefined &&
+      !this.searchOperatorChangeWarningDisplayed
+    ) {
+      console.warn(
+        "The default operator for instance search will change from 'OR' to 'AND' sometime in Q1 2027. In the " +
+          "next major version release (v11), the default will be changed to 'AND', which is the recommended " +
+          'setting for most use cases. Please explicitly pass the operator to avoid this warning.'
+      );
+      this.searchOperatorChangeWarningDisplayed = true;
+    }
     const response = await this.post<ByIdsResponse>(this.searchUrl, {
       data: params,
     });

--- a/packages/stable/src/api/instances/types.gen.ts
+++ b/packages/stable/src/api/instances/types.gen.ts
@@ -115,6 +115,15 @@ export interface CommonAggregationRequest {
    * @max 1000
    */
   limit?: number;
+  /**
+   * Controls how multiple search terms are combined when matching documents.
+   * - **OR** (default): A document matches if it contains *any* of the query terms
+   *   in the searchable fields. This typically returns more results but with lower precision.
+   *
+   * - **AND**: A document matches only if it contains *all* of the query terms
+   *   across the searchable fields. This typically returns fewer results but with higher relevance.
+   */
+  operator?: SearchOperator;
   /** Optional list (array) of properties you want to apply the query above to. If you do not list any properties, you search through text fields by default. */
   properties?: string[];
   /** Optional query string.  The API will parse the query string, and use it to match the text properties on elements to use for the aggregate(s). */
@@ -860,6 +869,15 @@ export type RawPropertyValueV3 =
 export interface ReferencedPropertyValueV3 {
   property: string[];
 }
+/**
+* Controls how multiple search terms are combined when matching documents.
+- **OR** (default): A document matches if it contains *any* of the query terms
+  in the searchable fields. This typically returns more results but with lower precision.
+
+- **AND**: A document matches only if it contains *all* of the query terms
+  across the searchable fields. This typically returns fewer results but with higher relevance.
+*/
+export type SearchOperator = 'AND' | 'OR';
 export type SearchRequestV3 = {
   view: ViewReference;
   query?: string;
@@ -869,6 +887,7 @@ export type SearchRequestV3 = {
   filter?: FilterDefinition;
   includeTyping?: IncludeTyping;
   sort?: SearchSort[];
+  operator?: SearchOperator;
 } & LimitWithDefault1000;
 export interface SearchResponse {
   /** List of nodes and edges */

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -3493,6 +3493,7 @@ export type {
   ViewOrContainer,
   ViewPropertyReference,
   ViewReference,
+  SearchOperator,
 } from './api/instances/types.gen';
 
 export type {


### PR DESCRIPTION
Currently it is only possible to use OR as search operator (API default) with this the user can set it manually.

Also added a warning that the default operator will change in the next major version.