### PR TITLE
fix(docs): restore documentation deployment and add missing API exports

### DIFF
--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -42,3 +42,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lerna publish from-package --yes --no-git-reset
+
+      - name: Build documentation
+        run: yarn docs:bundle
+
+      - name: Publish documentation
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: docs

--- a/packages/stable/src/index.ts
+++ b/packages/stable/src/index.ts
@@ -45,4 +45,19 @@ export { SyntheticTimeSeriesAPI } from './api/timeSeries/syntheticTimeSeriesApi'
 export { TimeSeriesAPI } from './api/timeSeries/timeSeriesApi';
 export * from './api/templates';
 
+export { AnnotationsAPI } from './api/annotations/annotationsApi';
+export { ContainersAPI } from './api/containers/containersApi';
+export { DocumentsAPI } from './api/documents/documentsApi';
+export { GeospatialAPI } from './api/geospatial/geospatialAPI';
+export { InstancesAPI } from './api/instances/instancesApi';
+export { DataModelsAPI } from './api/models/datamodelsApi';
+export { RecordsAPI } from './api/records/recordsApi';
+export { SessionsApi } from './api/sessions/sessionsApi';
+export { SpacesAPI } from './api/spaces/spacesApi';
+export { StreamsAPI } from './api/streams/streamsApi';
+export { UnitsAPI } from './api/units/unitsApi';
+export { ProfilesAPI } from './api/userProfiles/profilesApi';
+export { ViewsAPI } from './api/views/viewsApi';
+export { VisionAPI } from './api/vision/visionApi';
+
 export * from './types';


### PR DESCRIPTION
Fixes the SDK documentation not being deployed to GitHub Pages since February 2025.