### PR TITLE
chore: npm publish CI workflow to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -5,21 +5,25 @@ on:
     branches: [master]
     paths: ['packages/*/package.json']
 
+permissions:
+  id-token: write  # Required for OIDC trusted publishing
+  contents: write
+
 jobs:
   build-and-publish:
     if: 'contains(github.event.head_commit.message, ''chore(release): publish new package versions'')'
     runs-on: ubuntu-latest
     environment: CD
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Configure Git
         run: |
@@ -32,13 +36,5 @@ jobs:
       - name: Build packages
         run: yarn build
 
-      - name: Configure NPM
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
       - name: Publish to NPM
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lerna publish from-package --yes --no-git-reset

--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -37,4 +37,7 @@ jobs:
         run: yarn build
 
       - name: Publish to NPM
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lerna publish from-package --yes --no-git-reset


### PR DESCRIPTION
Due to `npm` token deprecation (announced December 9th, 2025), classic tokens have been revoked and temporary granular tokens expired on February 17th, 2026. This change migrates to npm Trusted Publishing which uses OpenID Connect (OIDC) for authentication, eliminating the need for long-lived tokens.