### PR TITLE
feat(FUN-462): add lastCalled field to CogniteFunction type

### DIFF
--- a/packages/stable/src/__tests__/api/functions.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/functions.unit.spec.ts
@@ -82,6 +82,7 @@ describe('Functions unit test', () => {
     const func = await client.functions.retrieve([{ id: 123 }]);
     expect(func[0].id).toBe(mockFunction.id);
     expect(func[0].name).toBe(mockFunction.name);
+    expect(func[0].lastCalled).toBeInstanceOf(Date);
   });
 
   test('delete', async () => {

--- a/packages/stable/src/__tests__/api/functions.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/functions.unit.spec.ts
@@ -22,6 +22,7 @@ describe('Functions unit test', () => {
     description: externalFunction.description,
     status: 'Ready',
     createdTime: Date.now(),
+    lastCalled: Date.now() - 1000,
   };
 
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('Functions unit test', () => {
     const createdFunctions = await client.functions.create([externalFunction]);
     expect(createdFunctions[0].id).toBe(mockFunction.id);
     expect(createdFunctions[0].name).toBe(externalFunction.name);
+    expect(createdFunctions[0].lastCalled).toBeInstanceOf(Date);
   });
 
   test('list', async () => {
@@ -64,6 +66,7 @@ describe('Functions unit test', () => {
     });
     expect(functions.length).toBe(1);
     expect(functions[0].id).toBe(mockFunction.id);
+    expect(functions[0].lastCalled).toBeInstanceOf(Date);
   });
 
   test('retrieve by id', async () => {

--- a/packages/stable/src/api/functions/functionsApi.ts
+++ b/packages/stable/src/api/functions/functionsApi.ts
@@ -16,7 +16,7 @@ export class FunctionsAPI extends BaseResourceAPI<CogniteFunction> {
    * @hidden
    */
   protected getDateProps() {
-    return this.pickDateProps(['items'], ['createdTime']);
+    return this.pickDateProps(['items'], ['createdTime', 'lastCalled']);
   }
 
   /**

--- a/packages/stable/src/api/functions/types.ts
+++ b/packages/stable/src/api/functions/types.ts
@@ -118,6 +118,10 @@ export interface CogniteFunction extends ExternalCogniteFunction {
    * Error that occurred during function build.
    */
   error?: FunctionBuildError;
+  /**
+   * The last time the function was called. Not present if the function has never been called.
+   */
+  lastCalled?: Date;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `lastCalled?: Date` to the `CogniteFunction` interface in `types.ts`
- Adds `'lastCalled'` to `pickDateProps` in `functionsApi.ts` so the SDK converts the raw ms integer from the API into a `Date` object, consistent with `createdTime`
- The field is absent when the function has never been called