### PR TITLE
refactor(datapoints): move data points types to dedicated module

### DIFF
--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -1,20 +1,18 @@
 // Copyright 2020 Cognite AS
 
 import { BaseResourceAPI } from '@cognite/sdk-core';
+import type { ItemsWrapper } from '@cognite/sdk-core';
 import type {
   DatapointAggregate,
   DatapointAggregates,
-  DatapointInfo,
   Datapoints,
   DatapointsDeleteRequest,
   DatapointsMonthlyGranularityMultiQuery,
   DatapointsMultiQuery,
   ExternalDatapointsQuery,
-  IgnoreUnknownIds,
-  ItemsWrapper,
   LatestDataBeforeRequest,
-  Timestamp,
-} from '../../types';
+} from './types';
+import type { DatapointInfo, IgnoreUnknownIds, Timestamp } from '../../types/common';
 
 export class DataPointsAPI extends BaseResourceAPI<
   DatapointAggregates | Datapoints

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -3,6 +3,11 @@
 import { BaseResourceAPI } from '@cognite/sdk-core';
 import type { ItemsWrapper } from '@cognite/sdk-core';
 import type {
+  DatapointInfo,
+  IgnoreUnknownIds,
+  Timestamp,
+} from '../../types/common';
+import type {
   DatapointAggregate,
   DatapointAggregates,
   Datapoints,
@@ -12,7 +17,6 @@ import type {
   ExternalDatapointsQuery,
   LatestDataBeforeRequest,
 } from './types';
-import type { DatapointInfo, IgnoreUnknownIds, Timestamp } from '../../types/common';
 
 export class DataPointsAPI extends BaseResourceAPI<
   DatapointAggregates | Datapoints

--- a/packages/stable/src/api/dataPoints/types.ts
+++ b/packages/stable/src/api/dataPoints/types.ts
@@ -1,0 +1,285 @@
+// Copyright 2026 Cognite AS
+
+import type {
+  CogniteExternalId,
+  CogniteInstanceId,
+  Cursor,
+  ExternalId,
+  InstanceId,
+  InternalId,
+  Limit,
+} from '@cognite/sdk-core';
+import type {
+  DatapointInfo,
+  IgnoreUnknownIds,
+  Timestamp,
+} from '../../types/common';
+
+// =====================================================
+// Aggregate function type
+// =====================================================
+
+export type Aggregate =
+  | 'average'
+  | 'max'
+  | 'min'
+  | 'count'
+  | 'sum'
+  | 'interpolation'
+  | 'stepInterpolation'
+  | 'totalVariation'
+  | 'continuousVariance'
+  | 'discreteVariance';
+
+// =====================================================
+// Data point value types
+// =====================================================
+
+export interface DatapointAggregate extends DatapointInfo {
+  average?: number;
+  max?: number;
+  min?: number;
+  count?: number;
+  sum?: number;
+  interpolation?: number;
+  stepInterpolation?: number;
+  continuousVariance?: number;
+  discreteVariance?: number;
+  totalVariation?: number;
+}
+
+export interface DoubleDatapoint extends DatapointInfo {
+  value: number;
+}
+
+export interface StringDatapoint extends DatapointInfo {
+  value: string;
+}
+
+export interface ExternalDatapoint {
+  timestamp: Timestamp;
+  value: number | string;
+}
+
+// =====================================================
+// Data points delete types
+// =====================================================
+
+export interface DatapointsDeleteRange {
+  /**
+   * The timestamp of first datapoint to delete
+   */
+  inclusiveBegin: Timestamp;
+  /**
+   * If set, the timestamp of first datapoint after inclusiveBegin to not delete. If not set, only deletes the datapoint at inclusiveBegin.
+   */
+  exclusiveEnd?: Timestamp;
+}
+
+export type DatapointsDeleteRequest =
+  | (InternalId & DatapointsDeleteRange)
+  | (ExternalId & DatapointsDeleteRange)
+  | (InstanceId & DatapointsDeleteRange);
+
+// =====================================================
+// Data points response types
+// =====================================================
+
+export interface NextCursor {
+  nextCursor?: string;
+}
+
+export interface DatapointsMetadata extends InternalId {
+  /**
+   * External id of the timeseries the datapoints belong to.
+   */
+  externalId?: CogniteExternalId;
+
+  /**
+   * Instance id of the timeseries the datapoints belong to in Cognite Data Modeling.
+   */
+  instanceId?: CogniteInstanceId;
+
+  /**
+   * Whether or not the datapoints are string values.
+   */
+  isString: boolean;
+  /**
+   * Name of the physical unit of the time series
+   */
+  unit?: string;
+}
+
+export interface DatapointAggregates extends DatapointsMetadata, NextCursor {
+  isString: false;
+  /**
+   * Whether the timeseries is a step series or not
+   */
+  isStep: boolean;
+  datapoints: DatapointAggregate[];
+  /**
+   * The physical unit of the time series (reference to unit catalog). Replaced with target unit if data points were converted.
+   */
+  unitExternalId?: CogniteExternalId;
+}
+
+export type Datapoints = StringDatapoints | DoubleDatapoints;
+
+export interface DoubleDatapoints extends DatapointsMetadata, NextCursor {
+  isString: false;
+  /**
+   * Whether the timeseries is a step series or not
+   */
+  isStep?: boolean;
+  /**
+   * The list of datapoints
+   */
+  datapoints: DoubleDatapoint[];
+  /**
+   * The physical unit of the time series (reference to unit catalog). Replaced with target unit if data points were converted.
+   */
+  unitExternalId?: CogniteExternalId;
+}
+
+export interface StringDatapoints extends DatapointsMetadata, NextCursor {
+  isString: true;
+  /**
+   * The list of datapoints
+   */
+  datapoints: StringDatapoint[];
+}
+
+// =====================================================
+// External data points (insert) types
+// =====================================================
+
+export interface ExternalDatapoints {
+  datapoints: ExternalDatapoint[];
+}
+
+export type ExternalDatapointsQuery =
+  | ExternalDatapointId
+  | ExternalDatapointExternalId
+  | ExternalDatapointInstanceId;
+
+export interface ExternalDatapointExternalId
+  extends ExternalDatapoints,
+    ExternalId {}
+
+export interface ExternalDatapointInstanceId
+  extends ExternalDatapoints,
+    InstanceId {}
+
+export interface ExternalDatapointId extends ExternalDatapoints, InternalId {}
+
+// =====================================================
+// Data points query types
+// =====================================================
+
+export interface DatapointsMultiQuery extends DatapointsMultiQueryBase {
+  items: DatapointsQuery[];
+}
+
+export interface DatapointsMonthlyGranularityMultiQuery
+  extends Omit<DatapointsMultiQueryBase, 'granularity'> {
+  items: DatapointsQuery[];
+}
+
+export interface DatapointsMultiQueryBase extends Limit, IgnoreUnknownIds {
+  /**
+   * Get datapoints after this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send in a Date object. Note that when using aggregates, the start time will be rounded down to a whole granularity unit (in UTC timezone). For granularity 2d it will be rounded to 0:00 AM on the same day, for 3h it will be rounded to the start of the hour, etc.
+   */
+  start?: string | Timestamp;
+  /**
+   * Get datapoints up to this time. Same format as for start. Note that when using aggregates, the end will be rounded up such that the last aggregate represents a full aggregation interval containing the original end, where the interval is the granularity unit times the granularity multiplier. For granularity 2d, the aggregation interval is 2 days, if end was originally 3 days after the start, it will be rounded to 4 days after the start.
+   */
+  end?: string | Timestamp;
+  /**
+   * The aggregates to be returned. This value overrides top-level default aggregates list when set. Specify all aggregates to be retrieved here. Specify empty array if this sub-query needs to return datapoints without aggregation.
+   */
+  aggregates?: Aggregate[];
+  /**
+   * The time granularity size and unit to aggregate over.
+   */
+  granularity?: string;
+  /**
+   * Whether to include the last datapoint before the requested time period,and the first one after the requested period. This can be useful for interpolating data. Not available for aggregates.
+   */
+  includeOutsidePoints?: boolean;
+  /**
+    * Defaul "UTC" For aggregates of granularity 'hour' and longer, which time zone should we align to. Align to the start of the hour, start of the day or start of the month. For time zones of type Region/Location, the aggregate duration can vary, typically due to daylight saving time. For time zones of type UTC+/-HH:MM, use increments of 15 minutes.
+Note: Time zones with minute offsets (e.g. UTC+05:30 or Asia/Kolkata) may take longer to execute. Historical time zones, with offsets not multiples of 15 minutes, are not supported.
+   */
+  timeZone?: string;
+}
+
+export type DatapointsQuery =
+  | DatapointsQueryId
+  | DatapointsQueryExternalId
+  | DatapointsQueryInstanceId;
+
+export interface DatapointsQueryExternalId
+  extends DatapointsQueryProperties,
+    ExternalId {}
+
+export interface DatapointsQueryId
+  extends DatapointsQueryProperties,
+    InternalId {}
+
+export interface DatapointsQueryInstanceId
+  extends DatapointsQueryProperties,
+    InstanceId {}
+
+export interface DatapointsQueryProperties extends Limit, Cursor {
+  /**
+   * Get datapoints after this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send in Date object. Note that when using aggregates, the start time will be rounded down to a whole granularity unit (in UTC timezone). For granularity 2d it will be rounded to 0:00 AM on the same day, for 3h it will be rounded to the start of the hour, etc.
+   */
+  start?: string | Timestamp;
+  /**
+   * Get datapoints up to this time. Same format as for start. Note that when using aggregates, the end will be rounded up such that the last aggregate represents a full aggregation interval containing the original end, where the interval is the granularity unit times the granularity multiplier. For granularity 2d, the aggregation interval is 2 days, if end was originally 3 days after the start, it will be rounded to 4 days after the start.
+   */
+  end?: string | Timestamp;
+  /**
+   * The aggregates to be returned.  Use default if null. An empty string must be sent to get raw data if the default is a set of aggregates.
+   */
+  aggregates?: Aggregate[];
+  /**
+   * The granularity size and granularity of the aggregates (2h)
+   */
+  granularity?: string;
+  /**
+   * Whether to include the last datapoint before the requested time period,and the first one after the requested period. This can be useful for interpolating data. Not available for aggregates.
+   */
+  includeOutsidePoints?: boolean;
+  /**
+   * The unit externalId of the data points returned.
+   * If the time series does not have a unitExternalId that
+   * can be converted to the targetUnit,
+   * an error will be returned. Cannot be used with targetUnitSystem.
+   */
+  targetUnit?: CogniteExternalId;
+  /**
+   * The unit system of the data points returned. Cannot be used with targetUnit.
+   */
+  targetUnitSystem?: CogniteExternalId;
+  /**
+   * Default: "UTC" Which time zone to align aggregates to. Omit to use top-level value.
+   */
+  timeZone?: string;
+}
+
+// =====================================================
+// Latest data point types
+// =====================================================
+
+export type LatestDataBeforeRequest =
+  | (InternalId & LatestDataPropertyFilter)
+  | (ExternalId & LatestDataPropertyFilter)
+  | (InstanceId & LatestDataPropertyFilter);
+
+export interface LatestDataPropertyFilter {
+  /**
+   * Get first datapoint before this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time as a Date object or number of milliseconds since epoch.
+   */
+  before?: string | Date | number;
+}

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -19,9 +19,9 @@ import type {
   ArrayPatchLong,
   CreatedAndLastUpdatedTime,
   CreatedAndLastUpdatedTimeFilter,
-  DatapointInfo,
   DateRange,
   ExternalIdPrefix,
+  IgnoreUnknownIds,
   Metadata,
   MetadataPatch,
   NullableSinglePatchLong,
@@ -62,6 +62,7 @@ export * from './api/streams/types';
 export * from './api/records/types';
 export * from './api/sessions/types';
 export * from './api/timeSeries/types';
+export * from './api/dataPoints/types';
 export * from './api/functions/types';
 
 export interface Acl<ActionsType, ScopeType> {
@@ -230,18 +231,6 @@ export type AclTimeseries = Acl<AclActionTimeseries, AclScopeTimeseries>;
 export type AclUsers = Acl<AclActionUsers, AclScopeUsers>;
 
 export type AclSessions = Acl<AclActionSessions, AclScopeSessions>;
-
-export type Aggregate =
-  | 'average'
-  | 'max'
-  | 'min'
-  | 'count'
-  | 'sum'
-  | 'interpolation'
-  | 'stepInterpolation'
-  | 'totalVariation'
-  | 'continuousVariance'
-  | 'discreteVariance';
 
 export type ArrayPatchString =
   | { set: string[] }
@@ -679,197 +668,6 @@ export interface DataSetPatch {
  */
 export type DataSetWriteProtected = boolean;
 
-export interface DatapointsDeleteRange {
-  /**
-   * The timestamp of first datapoint to delete
-   */
-  inclusiveBegin: Timestamp;
-  /**
-   * If set, the timestamp of first datapoint after inclusiveBegin to not delete. If not set, only deletes the datapoint at inclusiveBegin.
-   */
-  exclusiveEnd?: Timestamp;
-}
-
-export type DatapointsDeleteRequest =
-  | (InternalId & DatapointsDeleteRange)
-  | (ExternalId & DatapointsDeleteRange)
-  | (InstanceId & DatapointsDeleteRange);
-
-export interface NextCursor {
-  nextCursor?: string;
-}
-
-export interface DatapointAggregates extends DatapointsMetadata, NextCursor {
-  isString: false;
-  /**
-   * Whether the timeseries is a step series or not
-   */
-  isStep: boolean;
-  datapoints: DatapointAggregate[];
-  /**
-   * The physical unit of the time series (reference to unit catalog). Replaced with target unit if data points were converted.
-   */
-  unitExternalId?: CogniteExternalId;
-}
-
-export type Datapoints = StringDatapoints | DoubleDatapoints;
-
-export interface DoubleDatapoints extends DatapointsMetadata, NextCursor {
-  isString: false;
-  /**
-   * Whether the timeseries is a step series or not
-   */
-  isStep?: boolean;
-  /**
-   * The list of datapoints
-   */
-  datapoints: DoubleDatapoint[];
-  /**
-   * The physical unit of the time series (reference to unit catalog). Replaced with target unit if data points were converted.
-   */
-  unitExternalId?: CogniteExternalId;
-}
-
-export interface StringDatapoints extends DatapointsMetadata, NextCursor {
-  isString: true;
-  /**
-   * The list of datapoints
-   */
-  datapoints: StringDatapoint[];
-}
-
-export interface ExternalDatapoints {
-  datapoints: ExternalDatapoint[];
-}
-
-export interface DatapointsMetadata extends InternalId {
-  /**
-   * External id of the timeseries the datapoints belong to.
-   */
-  externalId?: CogniteExternalId;
-
-  /**
-   * Instance id of the timeseries the datapoints belong to in Cognite Data Modeling.
-   */
-  instanceId?: CogniteInstanceId;
-
-  /**
-   * Whether or not the datapoints are string values.
-   */
-  isString: boolean;
-  /**
-   * Name of the physical unit of the time series
-   */
-  unit?: string;
-}
-
-export interface DatapointsMultiQuery extends DatapointsMultiQueryBase {
-  items: DatapointsQuery[];
-}
-
-export interface DatapointsMonthlyGranularityMultiQuery
-  extends Omit<DatapointsMultiQueryBase, 'granularity'> {
-  items: DatapointsQuery[];
-}
-
-export interface DatapointsMultiQueryBase extends Limit, IgnoreUnknownIds {
-  /**
-   * Get datapoints after this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send in a Date object. Note that when using aggregates, the start time will be rounded down to a whole granularity unit (in UTC timezone). For granularity 2d it will be rounded to 0:00 AM on the same day, for 3h it will be rounded to the start of the hour, etc.
-   */
-  start?: string | Timestamp;
-  /**
-   * Get datapoints up to this time. Same format as for start. Note that when using aggregates, the end will be rounded up such that the last aggregate represents a full aggregation interval containing the original end, where the interval is the granularity unit times the granularity multiplier. For granularity 2d, the aggregation interval is 2 days, if end was originally 3 days after the start, it will be rounded to 4 days after the start.
-   */
-  end?: string | Timestamp;
-  /**
-   * The aggregates to be returned. This value overrides top-level default aggregates list when set. Specify all aggregates to be retrieved here. Specify empty array if this sub-query needs to return datapoints without aggregation.
-   */
-  aggregates?: Aggregate[];
-  /**
-   * The time granularity size and unit to aggregate over.
-   */
-  granularity?: string;
-  /**
-   * Whether to include the last datapoint before the requested time period,and the first one after the requested period. This can be useful for interpolating data. Not available for aggregates.
-   */
-  includeOutsidePoints?: boolean;
-  /**
-    * Defaul "UTC" For aggregates of granularity 'hour' and longer, which time zone should we align to. Align to the start of the hour, start of the day or start of the month. For time zones of type Region/Location, the aggregate duration can vary, typically due to daylight saving time. For time zones of type UTC+/-HH:MM, use increments of 15 minutes.
-Note: Time zones with minute offsets (e.g. UTC+05:30 or Asia/Kolkata) may take longer to execute. Historical time zones, with offsets not multiples of 15 minutes, are not supported.
-   */
-  timeZone?: string;
-}
-
-export type ExternalDatapointsQuery =
-  | ExternalDatapointId
-  | ExternalDatapointExternalId
-  | ExternalDatapointInstanceId;
-
-export interface ExternalDatapointExternalId
-  extends ExternalDatapoints,
-    ExternalId {}
-
-export interface ExternalDatapointInstanceId
-  extends ExternalDatapoints,
-    InstanceId {}
-
-export interface ExternalDatapointId extends ExternalDatapoints, InternalId {}
-
-export type DatapointsQuery =
-  | DatapointsQueryId
-  | DatapointsQueryExternalId
-  | DatapointsQueryInstanceId;
-
-export interface DatapointsQueryExternalId
-  extends DatapointsQueryProperties,
-    ExternalId {}
-
-export interface DatapointsQueryId
-  extends DatapointsQueryProperties,
-    InternalId {}
-
-export interface DatapointsQueryInstanceId
-  extends DatapointsQueryProperties,
-    InstanceId {}
-
-export interface DatapointsQueryProperties extends Limit, Cursor {
-  /**
-   * Get datapoints after this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send in Date object. Note that when using aggregates, the start time will be rounded down to a whole granularity unit (in UTC timezone). For granularity 2d it will be rounded to 0:00 AM on the same day, for 3h it will be rounded to the start of the hour, etc.
-   */
-  start?: string | Timestamp;
-  /**
-   * Get datapoints up to this time. Same format as for start. Note that when using aggregates, the end will be rounded up such that the last aggregate represents a full aggregation interval containing the original end, where the interval is the granularity unit times the granularity multiplier. For granularity 2d, the aggregation interval is 2 days, if end was originally 3 days after the start, it will be rounded to 4 days after the start.
-   */
-  end?: string | Timestamp;
-  /**
-   * The aggregates to be returned.  Use default if null. An empty string must be sent to get raw data if the default is a set of aggregates.
-   */
-  aggregates?: Aggregate[];
-  /**
-   * The granularity size and granularity of the aggregates (2h)
-   */
-  granularity?: string;
-  /**
-   * Whether to include the last datapoint before the requested time period,and the first one after the requested period. This can be useful for interpolating data. Not available for aggregates.
-   */
-  includeOutsidePoints?: boolean;
-  /**
-   * The unit externalId of the data points returned.
-   * If the time series does not have a unitExternalId that
-   * can be converted to the targetUnit,
-   * an error will be returned. Cannot be used with targetUnitSystem.
-   */
-  targetUnit?: CogniteExternalId;
-  /**
-   * The unit system of the data points returned. Cannot be used with targetUnit.
-   */
-  targetUnitSystem?: CogniteExternalId;
-  /**
-   * Default: "UTC" Which time zone to align aggregates to. Omit to use top-level value.
-   */
-  timeZone?: string;
-}
-
 export type DeleteAssetMapping3D = AssetMapping3DBase;
 
 export type EXECUTE = 'EXECUTE';
@@ -1182,27 +980,6 @@ export interface FilesSearchFilter extends FileFilter {
   };
 }
 
-export interface DatapointAggregate extends DatapointInfo {
-  average?: number;
-  max?: number;
-  min?: number;
-  count?: number;
-  sum?: number;
-  interpolation?: number;
-  stepInterpolation?: number;
-  continuousVariance?: number;
-  discreteVariance?: number;
-  totalVariation?: number;
-}
-
-export interface DoubleDatapoint extends DatapointInfo {
-  value: number;
-}
-
-export interface StringDatapoint extends DatapointInfo {
-  value: string;
-}
-
 export type FileGeoLocationType = 'Feature';
 export type FileGeoLocationGeometryType =
   | 'Point'
@@ -1357,32 +1134,12 @@ export interface GroupSpec {
 
 export type Groups = CogniteInternalId[];
 
-export interface IgnoreUnknownIds {
-  /**
-   * Ignore IDs and external IDs that are not found
-   * @default false
-   */
-  ignoreUnknownIds?: boolean;
-}
-
 /**
  * Range between two integers
  */
 export type IntegerRange = Range<number>;
 
 export type LIST = 'LIST';
-
-export type LatestDataBeforeRequest =
-  | (InternalId & LatestDataPropertyFilter)
-  | (ExternalId & LatestDataPropertyFilter)
-  | (InstanceId & LatestDataPropertyFilter);
-
-export interface LatestDataPropertyFilter {
-  /**
-   * Get first datapoint before this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time as a Date object or number of milliseconds since epoch.
-   */
-  before?: string | Date | number;
-}
 
 export interface List3DNodesQuery extends FilterQuery {
   /**
@@ -1547,11 +1304,6 @@ export interface Node3DProperties {
 export type NullableProperty<T> = T | { isNull: boolean };
 
 export type OWNER = 'OWNER';
-
-export interface ExternalDatapoint {
-  timestamp: Timestamp;
-  value: number | string;
-}
 
 /**
  * The display name of the project.

--- a/packages/stable/src/types/common.ts
+++ b/packages/stable/src/types/common.ts
@@ -73,3 +73,11 @@ export type MetadataPatch = ObjectPatch<string>;
 export type ArrayPatchLong =
   | { set: number[] }
   | { add?: number[]; remove?: number[] };
+
+export interface IgnoreUnknownIds {
+  /**
+   * Ignore IDs and external IDs that are not found
+   * @default false
+   */
+  ignoreUnknownIds?: boolean;
+}


### PR DESCRIPTION
- Moved all data points related types from the global `types.ts` to a dedicated `api/dataPoints/types.ts` module
- Moved `IgnoreUnknownIds` to `types/common.ts` as a shared primitive to avoid circular dependencies
- Updated imports in `dataPointsApi.ts` to use the new modules
- Re-exported all types from `types.ts` to maintain backward compatibility