### PR TITLE
fix(core): pass null/undefined date fields through instead of converting to epoch

### DIFF
--- a/packages/core/src/__tests__/dateParser.unit.spec.ts
+++ b/packages/core/src/__tests__/dateParser.unit.spec.ts
@@ -22,6 +22,13 @@ describe('DateParser', () => {
     expect(output.items[0].timestamp).toEqual(nowInUnixTimestamp);
   });
 
+  test('preserves null and undefined for date fields instead of converting to epoch', () => {
+    const input = { items: [{ createdTime: null, deletedTime: undefined }] };
+    const output = dateParser.parseToDates(input);
+    expect(output.items[0].createdTime).toBeNull();
+    expect(output.items[0].deletedTime).toBeUndefined();
+  });
+
   test('transform unix timestamp in response to Date', async () => {
     const input = {
       createdTime: nowInUnixTimestamp,

--- a/packages/core/src/dateParser.ts
+++ b/packages/core/src/dateParser.ts
@@ -26,7 +26,13 @@ export default class DateParser {
    */
   parseToDates<T>(data: T): T {
     return cloneDeepWith(data, (value, key, object) => {
-      if (this.isDatePropName(key)) return new Date(value);
+      // NOTE: null/undefined are passed through unchanged so callers can
+      // distinguish "field not set" from a real timestamp. The TypeScript
+      // types for optional date fields (e.g. `deletedTime?: Date`) don't
+      // yet reflect this — they should be `Date | null` — but that is a
+      // semver-major breaking change deferred to a future release.
+      if (this.isDatePropName(key))
+        return value == null ? value : new Date(value);
       if (key !== undefined && !this.isPath(key) && !Array.isArray(object)) {
         // There is a key, but it is not in lead.
         // The key is not the index of an array.


### PR DESCRIPTION
Fix a silent footgun where optional date fields returned as `null` by the API were converted to `1970-01-01T00:00:00.000Z` instead of being passed through, making it impossible for callers to distinguish "not set" from a real timestamp.

## The fix

`new Date(null)` silently returns the epoch date — a realistic-looking value that callers accept without complaint. This affects every date field registered across all 29+ API subclasses (`createdTime`, `lastUpdatedTime`, `sourceCreatedTime`, `uploadedTime`, `deletedTime`, etc.).

**One-line guard in `packages/core/src/dateParser.ts`:**

```typescript
// Before
if (this.isDatePropName(key)) return new Date(value);

// After — null/undefined pass through unchanged
if (this.isDatePropName(key)) return value == null ? value : new Date(value);
```

## Tests

New unit tests verify `null` and `undefined` are preserved rather than converted to epoch. All existing tests continue to pass.

## Open question: TypeScript types

The runtime fix is correct, but the static types for optional date fields (e.g. `deletedTime?: Date`, `uploadedTime?: Date`, `sourceCreatedTime?: Date`) don't reflect the new reality — they should be `Date | null` to be accurate. However, changing them is a **semver-major breaking change**: callers with `const t: Date | undefined = group.deletedTime` would get a compile error.

One alternative considered was normalizing `null` → `undefined` at the parser level (which would fit existing `?: Date` types without a breaking change), but `cloneDeepWith`'s customizer treats a returned `undefined` as "fall back to default cloning" — so returning `undefined` for a `null` value still produces `null` in the output. Mutating the parent object mid-traversal to delete the key was deemed too fragile.

**Decision deferred**: ship the runtime fix now; update the types to `Date | null` in the next major version bump.