### PR TITLE
feat(timeseries,datapoints): align types with latest API spec

### DIFF
--- a/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
+++ b/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
@@ -3,7 +3,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
 import type { Timeseries } from '../../index';
-import type { Datapoints } from '../../types';
+import type { Datapoints } from '@cognite/sdk';
 import { setupLoggedInClient } from '../testUtils';
 
 const Status = {

--- a/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
+++ b/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
@@ -1,9 +1,9 @@
 /// Copyright 2020 Cognite AS
 
+import type { Datapoints } from '@cognite/sdk';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
 import type { Timeseries } from '../../index';
-import type { Datapoints } from '@cognite/sdk';
 import { setupLoggedInClient } from '../testUtils';
 
 const Status = {

--- a/packages/beta/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/beta/src/api/dataPoints/dataPointsApi.ts
@@ -1,15 +1,12 @@
 import {
   DataPointsAPI as DataPointsAPIStable,
+  type DatapointAggregate,
+  type DatapointAggregates,
+  type Datapoints,
+  type DatapointsMonthlyGranularityMultiQuery,
+  type DatapointsMultiQuery,
   type ItemsWrapper,
 } from '@cognite/sdk';
-
-import type {
-  DatapointAggregate,
-  DatapointAggregates,
-  Datapoints,
-  DatapointsMonthlyGranularityMultiQuery,
-  DatapointsMultiQuery,
-} from '../../types';
 
 export class DataPointsAPI extends DataPointsAPIStable {
   public retrieve = (

--- a/packages/beta/src/index.ts
+++ b/packages/beta/src/index.ts
@@ -3,21 +3,3 @@
 export * from '@cognite/sdk';
 export { default as CogniteClient } from './cogniteClient';
 export * from './types';
-export {
-  Aggregate,
-  DatapointAggregate,
-  DatapointAggregates,
-  Datapoints,
-  DatapointsMonthlyGranularityMultiQuery,
-  DatapointsMultiQuery,
-  DatapointsMultiQueryBase,
-  DatapointsQuery,
-  DatapointsQueryExternalId,
-  DatapointsQueryInstanceId,
-  DatapointsQueryId,
-  DatapointsQueryProperties,
-  DoubleDatapoint,
-  DoubleDatapoints,
-  StringDatapoint,
-  StringDatapoints,
-} from './types';

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -1,22 +1,13 @@
 // Copyright 2020 Cognite AS
 
 import type {
-  Aggregate as AggregateStable,
-  DatapointsMultiQueryBase as DataPointsMultiQueryBaseStable,
-  DatapointAggregate as DatapointAggregateStable,
-  DatapointAggregates as DatapointAggregatesStable,
-  DatapointsQueryProperties as DatapointsQueryPropertiesStable,
   DateRange,
-  DoubleDatapoint as DoubleDatapointStable,
-  DoubleDatapoints as DoubleDatapointsStable,
   Metadata,
   MetadataPatch,
   SinglePatchRequired,
   SinglePatchRequiredString,
   SinglePatchString,
   SortOrder,
-  StringDatapoint as StringDatapointStable,
-  StringDatapoints as StringDatapointsStable,
   Timestamp,
 } from '@cognite/sdk';
 import type {
@@ -24,7 +15,6 @@ import type {
   CogniteInternalId,
   ExternalId,
   FilterQuery,
-  InstanceId,
   InternalId,
 } from '@cognite/sdk-core';
 
@@ -345,108 +335,4 @@ export interface Subscription {
   subscriberId: CogniteInternalId;
   subscriberExternalId?: CogniteExternalId;
   metadata?: Metadata;
-}
-
-export interface DatapointsMultiQuery extends DatapointsMultiQueryBase {
-  items: DatapointsQuery[];
-}
-
-export interface DatapointsMonthlyGranularityMultiQuery
-  extends Omit<DatapointsMultiQueryBase, 'granularity'> {
-  items: DatapointsQuery[];
-}
-export interface DatapointsMultiQueryBase
-  extends Omit<DataPointsMultiQueryBaseStable, 'aggregates'> {
-  /**
-   * The aggregates to be returned. This value overrides top-level default aggregates list when set. Specify all aggregates to be retrieved here. Specify empty array if this sub-query needs to return datapoints without aggregation.
-   */
-  aggregates?: Aggregate[];
-}
-
-export type DatapointsQuery =
-  | DatapointsQueryId
-  | DatapointsQueryExternalId
-  | DatapointsQueryInstanceId;
-
-export interface DatapointsQueryExternalId
-  extends DatapointsQueryProperties,
-    ExternalId {}
-
-export interface DatapointsQueryId
-  extends DatapointsQueryProperties,
-    InternalId {}
-
-export interface DatapointsQueryInstanceId
-  extends DatapointsQueryProperties,
-    InstanceId {}
-
-export type Aggregate =
-  | AggregateStable
-  | 'countGood'
-  | 'countUncertain'
-  | 'countBad'
-  | 'durationGood'
-  | 'durationUncertain'
-  | 'durationBad';
-
-export interface DatapointsQueryProperties
-  extends Omit<DatapointsQueryPropertiesStable, 'aggregates'> {
-  /**
-   * The aggregates to be returned. This value overrides top-level default aggregates list when set. Specify all aggregates to be retrieved here. Specify empty array if this sub-query needs to return datapoints without aggregation.
-   */
-  aggregates?: Aggregate[];
-  /**
-   * denotes that the status of the data point should be included in the response.
-   */
-  includeStatus?: boolean;
-  /**
-   * returns data points marked with the uncertain status code.
-   * The default behavior of the API is to treat them the same as bad data points and don't returned them.
-   */
-  treatUncertainAsBad?: boolean;
-  /**
-   * denotes that the API should return bad data points.
-   * Because the API treats uncertain data points as bad by default,
-   * this parameter includes both uncertain and bad data points.
-   */
-  ignoreBadDataPoints?: boolean;
-}
-
-export interface DatapointStatus {
-  code: number;
-  symbol: string;
-}
-
-export interface DatapointAggregates
-  extends Omit<DatapointAggregatesStable, 'datapoints'> {
-  datapoints: DatapointAggregate[];
-}
-
-export interface DatapointAggregate extends DatapointAggregateStable {
-  countGood?: number;
-  countUncertain?: number;
-  countBad?: number;
-  durationGood?: number;
-  durationUncertain?: number;
-  durationBad?: number;
-}
-
-export type Datapoints = StringDatapoints | DoubleDatapoints;
-
-export interface DoubleDatapoints
-  extends Omit<DoubleDatapointsStable, 'datapoints'> {
-  datapoints: DoubleDatapoint[];
-}
-
-export interface StringDatapoints
-  extends Omit<StringDatapointsStable, 'datapoints'> {
-  datapoints: StringDatapoint[];
-}
-
-export interface DoubleDatapoint extends DoubleDatapointStable {
-  status?: DatapointStatus;
-}
-
-export interface StringDatapoint extends StringDatapointStable {
-  status?: DatapointStatus;
 }

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -230,10 +230,9 @@ describe('Datapoints integration test', () => {
     ]);
     expect(response[0].datapoints.length).toBeGreaterThan(0);
     const dp = response[0].datapoints[0] as DoubleDatapoint;
-    if (dp.status) {
-      expect(dp.status.symbol).toBeDefined();
-      expect(typeof dp.status.code).toBe('number');
-    }
+    expect(dp.status).toBeDefined();
+    expect(dp.status?.symbol).toBeDefined();
+    expect(typeof dp.status?.code).toBe('number');
   });
 
   test('retrieve with new aggregate types', async () => {

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -2,7 +2,12 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
-import type { DatapointAggregate, NodeWrite, Timeseries } from '../../types';
+import type {
+  DatapointAggregate,
+  DoubleDatapoint,
+  NodeWrite,
+  Timeseries,
+} from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Datapoints integration test', () => {
@@ -156,12 +161,139 @@ describe('Datapoints integration test', () => {
     expect(nextResponse[0].datapoints).not.toEqual(response);
   });
 
+  test('insert with status code and retrieve with includeStatus', async () => {
+    const statusTimestamp = Date.now() - 10000;
+    const statusDatapoints = [
+      {
+        timestamp: statusTimestamp,
+        value: 42,
+        status: { code: 1073741824, symbol: 'Uncertain' },
+      },
+    ];
+    await client.datapoints.insert([
+      { id: timeserie.id, datapoints: statusDatapoints },
+    ]);
+    const response = await client.datapoints.retrieve({
+      items: [
+        {
+          id: timeserie.id,
+          includeStatus: true,
+          ignoreBadDataPoints: false,
+          treatUncertainAsBad: false,
+        },
+      ],
+      start: '1d-ago',
+      end: new Date(),
+    });
+    expect(response[0].datapoints.length).toBeGreaterThan(0);
+    const uncertainDp = (response[0].datapoints as DoubleDatapoint[]).find(
+      (dp) => dp.timestamp.getTime() === statusTimestamp
+    );
+    expect(uncertainDp).toBeDefined();
+    expect(uncertainDp?.status).toBeDefined();
+    expect(uncertainDp?.status?.symbol).toBe('Uncertain');
+    expect(typeof uncertainDp?.status?.code).toBe('number');
+  });
+
+  test('retrieve with ignoreBadDataPoints and treatUncertainAsBad', async () => {
+    const response = await client.datapoints.retrieve({
+      items: [
+        {
+          id: timeserie.id,
+          includeStatus: true,
+          ignoreBadDataPoints: false,
+          treatUncertainAsBad: false,
+        },
+      ],
+      start: '1d-ago',
+      end: new Date(),
+    });
+    expect(response[0].datapoints.length).toBeGreaterThan(0);
+    const withStatus = (response[0].datapoints as DoubleDatapoint[]).filter(
+      (dp) => dp.status !== undefined
+    );
+    expect(withStatus.length).toBeGreaterThan(0);
+    for (const dp of withStatus) {
+      expect(dp.status?.symbol).toBeDefined();
+      expect(typeof dp.status?.code).toBe('number');
+    }
+  });
+
+  test('retrieveLatest with includeStatus', async () => {
+    const response = await client.datapoints.retrieveLatest([
+      {
+        id: timeserie.id,
+        includeStatus: true,
+        ignoreBadDataPoints: false,
+        treatUncertainAsBad: false,
+      },
+    ]);
+    expect(response[0].datapoints.length).toBeGreaterThan(0);
+    const dp = response[0].datapoints[0] as DoubleDatapoint;
+    if (dp.status) {
+      expect(dp.status.symbol).toBeDefined();
+      expect(typeof dp.status.code).toBe('number');
+    }
+  });
+
+  test('retrieve with new aggregate types', async () => {
+    const response = await client.datapoints.retrieve({
+      items: [
+        {
+          id: timeserie.id,
+          aggregates: [
+            'maxDatapoint',
+            'minDatapoint',
+            'countGood',
+            'countUncertain',
+            'countBad',
+            'durationGood',
+            'durationUncertain',
+            'durationBad',
+          ],
+          granularity: '2d',
+        },
+      ],
+      start: '3d-ago',
+      end: new Date(),
+    });
+    expect(response.length).toBe(1);
+    expect(response[0].datapoints.length).toBeGreaterThan(0);
+
+    const dp = response[0].datapoints[0] as DatapointAggregate;
+    expect(dp.maxDatapoint).toBeDefined();
+    expect(dp.maxDatapoint?.timestamp).toBeInstanceOf(Date);
+    expect(typeof dp.maxDatapoint?.value).toBe('number');
+    expect(dp.minDatapoint).toBeDefined();
+    expect(dp.minDatapoint?.timestamp).toBeInstanceOf(Date);
+    expect(typeof dp.minDatapoint?.value).toBe('number');
+    expect(typeof dp.countGood).toBe('number');
+    expect(typeof dp.countUncertain).toBe('number');
+    expect(typeof dp.countBad).toBe('number');
+    expect(typeof dp.durationGood).toBe('number');
+    expect(typeof dp.durationUncertain).toBe('number');
+    expect(typeof dp.durationBad).toBe('number');
+  });
+
   test('synthetic query', async () => {
     const result = await client.timeseries.syntheticQuery([
       {
         expression: `24 * TS{id=${timeserie.id}}`,
         start: '48h-ago',
         limit: 1,
+      },
+    ]);
+    expect(result.length).toBe(1);
+    expect(result[0].datapoints[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  test('synthetic query with timeZone', async () => {
+    const result = await client.timeseries.syntheticQuery([
+      {
+        expression: `24 * TS{id=${timeserie.id}}`,
+        start: '48h-ago',
+        limit: 1,
+        timeZone: 'Europe/Oslo',
       },
     ]);
     expect(result.length).toBe(1);

--- a/packages/stable/src/__tests__/api/timeseries.int.spec.ts
+++ b/packages/stable/src/__tests__/api/timeseries.int.spec.ts
@@ -151,6 +151,39 @@ describe('Timeseries integration test', () => {
     expect(createdTimeseries[0].metadata?.createdTime).not.toBeInstanceOf(Date);
   });
 
+  test('type field defaults to numeric for non-string timeseries', async () => {
+    const [numeric] = await client.timeseries.retrieve([
+      { id: createdTimeseries[0].id },
+    ]);
+    expect(numeric.type).toBe('numeric');
+
+    const [stringTs] = await client.timeseries.retrieve([
+      { id: createdTimeseries[1].id },
+    ]);
+    expect(stringTs.type).toBe('string');
+  });
+
+  test('type field is consistent with isString on create', async () => {
+    const [stringTs] = await client.timeseries.create([
+      {
+        name: `ts_string_type_${randomInt()}`,
+        isString: true,
+      },
+    ]);
+    expect(stringTs.type).toBe('string');
+    expect(stringTs.isString).toBe(true);
+
+    const [numericTs] = await client.timeseries.create([
+      {
+        name: `ts_numeric_type_${randomInt()}`,
+      },
+    ]);
+    expect(numericTs.type).toBe('numeric');
+    expect(numericTs.isString).toBe(false);
+
+    await client.timeseries.delete([{ id: stringTs.id }, { id: numericTs.id }]);
+  });
+
   test('retrieve', async () => {
     const [single] = await client.timeseries.retrieve([
       { id: createdTimeseries[0].id },

--- a/packages/stable/src/__tests__/api/timeseriesWithUnits.int.spec.ts
+++ b/packages/stable/src/__tests__/api/timeseriesWithUnits.int.spec.ts
@@ -110,6 +110,42 @@ describe('Timeseries integration test', () => {
     expect((res[0].datapoints[0] as DoubleDatapoint).value).toBe(373.15);
   });
 
+  test('retrieveLatest with targetUnit', async () => {
+    const res = await client.datapoints.retrieveLatest([
+      {
+        id: createdTimeseries.id,
+        targetUnit: 'temperature:deg_f',
+      },
+    ]);
+    expect(res.length).toBe(1);
+    expect(res[0].datapoints.length).toBeGreaterThan(0);
+    expect((res[0].datapoints[0] as DoubleDatapoint).value).toBe(212);
+  });
+
+  test('retrieveLatest with targetUnitSystem', async () => {
+    const res = await client.datapoints.retrieveLatest([
+      {
+        id: createdTimeseries.id,
+        targetUnitSystem: 'SI',
+      },
+    ]);
+    expect(res.length).toBe(1);
+    expect(res[0].datapoints.length).toBeGreaterThan(0);
+    expect((res[0].datapoints[0] as DoubleDatapoint).value).toBe(373.15);
+  });
+
+  test('list with unitQuantity filter', async () => {
+    await runTestWithRetryWhenFailing(async () => {
+      const { items } = await client.timeseries.list({
+        filter: {
+          unitQuantity: 'Temperature',
+        },
+      });
+      expect(items.length).toBeGreaterThan(0);
+      expect(items[0].unitExternalId).toBeDefined();
+    });
+  });
+
   test('delete', async () => {
     await client.timeseries.delete([{ id: createdTimeseries.id }]);
   });

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -26,7 +26,7 @@ export class DataPointsAPI extends BaseResourceAPI<
    */
   protected getDateProps() {
     return this.pickDateProps<DatapointInfo>(
-      ['items', 'datapoints'],
+      ['items', 'datapoints', 'maxDatapoint', 'minDatapoint'],
       ['timestamp']
     );
   }

--- a/packages/stable/src/api/dataPoints/types.ts
+++ b/packages/stable/src/api/dataPoints/types.ts
@@ -29,11 +29,43 @@ export type Aggregate =
   | 'stepInterpolation'
   | 'totalVariation'
   | 'continuousVariance'
-  | 'discreteVariance';
+  | 'discreteVariance'
+  | 'maxDatapoint'
+  | 'minDatapoint'
+  | 'countGood'
+  | 'countUncertain'
+  | 'countBad'
+  | 'durationGood'
+  | 'durationUncertain'
+  | 'durationBad';
+
+// =====================================================
+// Data point status types
+// =====================================================
+
+/**
+ * Status code for a data point, following OPC UA conventions.
+ * Either `code` or `symbol` is required; if both are set they must be consistent.
+ * @see https://docs.cognite.com/dev/concepts/reference/status_codes
+ */
+export interface DatapointStatus {
+  /** Numeric status code (e.g. 0 for Good, 2147483648 for Bad) */
+  code: number;
+  /** Status symbol name (e.g. 'Good', 'Uncertain', 'Bad') */
+  symbol: string;
+}
 
 // =====================================================
 // Data point value types
 // =====================================================
+
+/**
+ * The timestamp and value of a min/max data point aggregate.
+ */
+export interface DatapointExtremum {
+  timestamp: Date;
+  value: number;
+}
 
 export interface DatapointAggregate extends DatapointInfo {
   average?: number;
@@ -46,19 +78,33 @@ export interface DatapointAggregate extends DatapointInfo {
   continuousVariance?: number;
   discreteVariance?: number;
   totalVariation?: number;
+  maxDatapoint?: DatapointExtremum;
+  minDatapoint?: DatapointExtremum;
+  countGood?: number;
+  countUncertain?: number;
+  countBad?: number;
+  /** Duration in milliseconds with Good status */
+  durationGood?: number;
+  /** Duration in milliseconds with Uncertain status */
+  durationUncertain?: number;
+  /** Duration in milliseconds with Bad status */
+  durationBad?: number;
 }
 
 export interface DoubleDatapoint extends DatapointInfo {
   value: number;
+  status?: DatapointStatus;
 }
 
 export interface StringDatapoint extends DatapointInfo {
   value: string;
+  status?: DatapointStatus;
 }
 
 export interface ExternalDatapoint {
   timestamp: Timestamp;
   value: number | string;
+  status?: DatapointStatus;
 }
 
 // =====================================================
@@ -266,6 +312,22 @@ export interface DatapointsQueryProperties extends Limit, Cursor {
    * Default: "UTC" Which time zone to align aggregates to. Omit to use top-level value.
    */
   timeZone?: string;
+  /**
+   * Include status codes in the response. Good (code 0) status codes are always omitted.
+   * @default false
+   */
+  includeStatus?: boolean;
+  /**
+   * Treat data points with Bad status codes as if they do not exist.
+   * Set to false to include bad data points.
+   * @default true
+   */
+  ignoreBadDataPoints?: boolean;
+  /**
+   * Treat data points with Uncertain status codes as Bad.
+   * @default true
+   */
+  treatUncertainAsBad?: boolean;
 }
 
 // =====================================================
@@ -282,4 +344,30 @@ export interface LatestDataPropertyFilter {
    * Get first datapoint before this time. Format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' will get everything that is up to 2 days old. Can also send time as a Date object or number of milliseconds since epoch.
    */
   before?: string | Date | number;
+  /**
+   * The unit externalId of the data points returned. If the time series does not have a
+   * unitExternalId that can be converted to the targetUnit, an error will be returned.
+   * Cannot be used with targetUnitSystem.
+   */
+  targetUnit?: string;
+  /**
+   * The unit system of the data points returned. Cannot be used with targetUnit.
+   */
+  targetUnitSystem?: string;
+  /**
+   * Include status codes in the response. Good (code 0) status codes are always omitted.
+   * @default false
+   */
+  includeStatus?: boolean;
+  /**
+   * Treat data points with Bad status codes as if they do not exist.
+   * Set to false to include bad data points.
+   * @default true
+   */
+  ignoreBadDataPoints?: boolean;
+  /**
+   * Treat data points with Uncertain status codes as Bad.
+   * @default true
+   */
+  treatUncertainAsBad?: boolean;
 }

--- a/packages/stable/src/api/timeSeries/types.ts
+++ b/packages/stable/src/api/timeSeries/types.ts
@@ -60,6 +60,11 @@ export type TimeseriesIdEither = InternalId | ExternalId;
 // =====================================================
 
 /**
+ * The type of time series.
+ */
+export type TimeseriesType = 'numeric' | 'string' | 'state';
+
+/**
  * A time series in Cognite Data Fusion
  */
 export interface Timeseries extends InternalId, CreatedAndLastUpdatedTime {
@@ -73,6 +78,10 @@ export interface Timeseries extends InternalId, CreatedAndLastUpdatedTime {
   instanceId?: CogniteInstanceId;
   name?: TimeseriesName;
   isString: TimeseriesIsString;
+  /**
+   * The type of the time series.
+   */
+  type?: TimeseriesType;
   /**
    * Additional metadata. String key -> String value.
    */
@@ -191,6 +200,10 @@ export interface TimeseriesFilter extends CreatedAndLastUpdatedTimeFilter {
    * The physical unit of the time series (reference to unit catalog).
    */
   unitExternalId?: CogniteExternalId;
+  /**
+   * Filter on the physical quantity of the unit (e.g., 'temperature', 'pressure').
+   */
+  unitQuantity?: string;
 }
 
 /**
@@ -328,6 +341,12 @@ export interface SyntheticQuery extends Limit {
   expression: string;
   start?: string | Timestamp;
   end?: string | Timestamp;
+  /**
+   * For aggregates of granularity 'hour' and longer, which time zone to align to.
+   * @default "UTC"
+   * @example "Europe/Oslo"
+   */
+  timeZone?: string;
 }
 
 /**


### PR DESCRIPTION
This PR aligns the stable SDK types with the latest API specification for time series and data points, adding support for status codes, new aggregate types, and additional query capabilities. Redundant type overrides in beta are removed since they are now covered by stable.

**Time Series types** (`api/timeSeries/types.ts`):
- Added `TimeseriesType` (`'numeric' | 'string' | 'state'`) and optional `type` field to `Timeseries` response type
- Added `unitQuantity` filter to `TimeseriesFilter`
- Added `timeZone` to `SyntheticQuery`

**Data Points types** (`api/dataPoints/types.ts`):
- Added `DatapointStatus` interface and `status` field to `DoubleDatapoint`, `StringDatapoint`, and `ExternalDatapoint`
- Added new aggregate types: `maxDatapoint`, `minDatapoint`, `countGood`, `countUncertain`, `countBad`, `durationGood`, `durationUncertain`, `durationBad`
- Added `DatapointExtremum` interface for min/max aggregate responses
- Added `includeStatus`, `ignoreBadDataPoints`, `treatUncertainAsBad` to `DatapointsQueryProperties` and `LatestDataPropertyFilter`
- Added `targetUnit` and `targetUnitSystem` to `LatestDataPropertyFilter`
- Fixed date parsing for nested `timestamp` fields inside `maxDatapoint`/`minDatapoint` aggregates

**Beta cleanup**:
- Removed redundant datapoints type overrides from `@cognite/sdk-beta` (`DatapointStatus`, `Aggregate`, `DatapointsQueryProperties`, `DatapointAggregate`, `Datapoints`, `DoubleDatapoint`, `StringDatapoint`, etc.) now that they are available in stable
- Removed explicit re-exports from `beta/src/index.ts` as `export * from '@cognite/sdk'` now covers them

All changes are additive to stable. No breaking changes for consumers of either package.