### PR TITLE
fix: type exports in beta

### DIFF
--- a/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
+++ b/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
@@ -2,8 +2,8 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
-import type { Datapoints } from '../../types';
 import type { Timeseries } from '../../index';
+import type { Datapoints } from '../../types';
 import { setupLoggedInClient } from '../testUtils';
 
 const Status = {

--- a/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
+++ b/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
@@ -2,7 +2,8 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
-import type { Datapoints, Timeseries } from '../../types';
+import type { Datapoints } from '../../types';
+import type { Timeseries } from '../../index';
 import { setupLoggedInClient } from '../testUtils';
 
 const Status = {

--- a/packages/beta/src/index.ts
+++ b/packages/beta/src/index.ts
@@ -3,7 +3,7 @@
 export * from '@cognite/sdk';
 export { default as CogniteClient } from './cogniteClient';
 export * from './types';
-export {
+export type {
   Aggregate,
   DatapointAggregate,
   DatapointAggregates,

--- a/packages/beta/src/types.ts
+++ b/packages/beta/src/types.ts
@@ -28,8 +28,6 @@ import type {
   InternalId,
 } from '@cognite/sdk-core';
 
-export * from '@cognite/sdk';
-
 // This file is here mostly to allow apis to import { ... } from '../../types';
 // Overriding types should probably be done in their respective API endpoint files, where possible
 


### PR DESCRIPTION
The type exports were wrong causing a build error.
```
NX   node_modules/.pnpm/@cognite+sdk-beta@6.0.0_encoding@0.1.13/node_modules/@cognite/sdk-beta/dist/index.js (31:9): "Aggregate" is not exported by "node_modules/.pnpm/@cognite+sdk@10.5.0_encoding@0.1.13/node_modules/@cognite/sdk/dist/index.js", imported by "node_modules/.pnpm/@cognite+sdk-beta@6.0.0_encoding@0.1.13/node_modules/@cognite/sdk-beta/dist/index.js".

file: /home/test/node_modules/.pnpm/@cognite+sdk-beta@6.0.0_encoding@0.1.13/node_modules/@cognite/sdk-beta/dist/index.js:31:9

29: import { DataPointsAPI as C, CogniteClient as S } from "@cognite/sdk";
30: export * from "@cognite/sdk";
31: import { Aggregate as j, DatapointAggregate as z, DatapointAggregates as J, Datapoints as K, DatapointsMonthlyGranula...
             ^
32: import { BaseResourceAPI as d, accessApi as y } from "@cognite/sdk-core";
33: const M = "6.0.0";
```
