### PR TITLE
ci: reject Jira ticket IDs in PR titles

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -30,3 +30,14 @@ jobs:
         run: yarn install --immutable
 
       - uses: JulienKode/pull-request-name-linter-action@v0.5.0
+
+      - name: Reject Jira ticket IDs in PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -qE '\b[A-Z]{2,}-[0-9]+\b'; then
+            echo "❌ PR title contains a Jira ticket ID: \"$PR_TITLE\""
+            echo "Describe the change so that it's suitable for the release notes on https://github.com/cognitedata/cognite-sdk-js/releases."
+            echo "E.g.: feat(containers): add usedFor filter parameter to containers"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

Jira ticket IDs have slipped into PR titles and ended up verbatim in release notes, since we squash-merge and the PR title becomes the commit message.

Examples of this in the wild:
- https://github.com/cognitedata/cognite-sdk-js/releases/tag/%40cognite%2Fsdk%4010.10.0
- https://github.com/cognitedata/cognite-sdk-js/releases/tag/%40cognite%2Fsdk%4010.3.0

## Fix

Add a step to the existing PR title CI workflow that fails if the title matches `[A-Z]{2,}-[0-9]+` (e.g. `SDK-123`, `PROJ-4567`). The error message points to what the title should look like instead.