### PR TITLE
fix(core): restrict retryable HTTP status codes to match Python SDK

### DIFF
--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -68,7 +68,7 @@ describe('CogniteClient', () => {
     });
 
     test('custom validator retries set to 1 should prevent from retrying a failed call', async () => {
-      const scope = nock(mockBaseUrl).get('/').times(2).reply(500, {});
+      const scope = nock(mockBaseUrl).get('/').times(2).reply(502, {});
       nock(mockBaseUrl).get('/').reply(200, { a: 42 });
       const client = new BaseCogniteClient({
         appId: 'unit-test',
@@ -78,7 +78,7 @@ describe('CogniteClient', () => {
         retryValidator: createUniversalRetryValidator(1),
       });
       await expect(client.get('/')).rejects.toThrowErrorMatchingInlineSnapshot(
-        '[Error: Request failed | status code: 500]'
+        '[Error: Request failed | status code: 502]'
       );
       expect(scope.isDone()).toBeTruthy();
     });

--- a/packages/core/src/httpClient/cdfHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.unit.spec.ts
@@ -197,7 +197,7 @@ describe('CDFHttpClient', () => {
       client.addOneTimeHeader(headerKey, headerValue);
       nock(baseUrl, { reqheaders: { [headerKey]: headerValue } })
         .delete('/')
-        .reply(101, {});
+        .reply(502, {});
       nock(baseUrl, { reqheaders: { [headerKey]: headerValue } })
         .delete('/')
         .reply(200, [1]);

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -1,6 +1,5 @@
 // Copyright 2020 Cognite AS
 
-import inRange from 'lodash/inRange';
 import some from 'lodash/some';
 
 import type { HttpMethod, HttpResponse } from './basicHttpClient';
@@ -65,12 +64,10 @@ export const createUniversalRetryValidator =
     return isValidRetryStatusCode(response.status);
   };
 
+const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
+
 function isValidRetryStatusCode(status: number) {
-  return (
-    inRange(status, 100, 200) ||
-    inRange(status, 429, 430) ||
-    inRange(status, 500, 600)
-  );
+  return RETRYABLE_STATUS_CODES.has(status);
 }
 
 function matchPathWithEndpoints(path: string, endpoints: string[]) {

--- a/packages/core/src/httpClient/retryValidator.unit.spec.ts
+++ b/packages/core/src/httpClient/retryValidator.unit.spec.ts
@@ -42,6 +42,10 @@ describe('cdfRetryValidator', () => {
     ...baseResponse,
     status: 500,
   };
+  const response502: HttpResponse<unknown> = {
+    ...baseResponse,
+    status: 502,
+  };
 
   const endpointList = {
     [HttpMethod.Post]: ['/assets/list'],
@@ -53,23 +57,27 @@ describe('cdfRetryValidator', () => {
   });
 
   test('only retry reasonable times', () => {
-    expect(retryValidator(getRequest, response500, 10)).toBeFalsy();
+    expect(retryValidator(getRequest, response502, 10)).toBeFalsy();
   });
 
-  test('retry GET 500', () => {
-    expect(retryValidator(getRequest, response500, 0)).toBeTruthy();
+  test('retry GET 502', () => {
+    expect(retryValidator(getRequest, response502, 0)).toBeTruthy();
   });
 
   test('retry GET 429', () => {
     expect(retryValidator(getRequest, response429, 0)).toBeTruthy();
   });
 
-  test("don't retry generic POST 500", () => {
-    expect(retryValidator(postRequest, response500, 0)).toBeFalsy();
+  test("don't retry GET 500", () => {
+    expect(retryValidator(getRequest, response500, 0)).toBeFalsy();
   });
 
-  test('retry POST 500 to retryable endpoint', () => {
-    expect(retryValidator(postRetryRequest, response500, 0)).toBeTruthy();
+  test("don't retry generic POST 502", () => {
+    expect(retryValidator(postRequest, response502, 0)).toBeFalsy();
+  });
+
+  test('retry POST 502 to retryable endpoint', () => {
+    expect(retryValidator(postRetryRequest, response502, 0)).toBeTruthy();
   });
 
   test("don't retry POST 4xx (except 429) to retryable endpoint", () => {


### PR DESCRIPTION
## Summary

- Restricts retryable HTTP status codes in `isValidRetryStatusCode()` from `{1xx, 429, 5xx}` to `{429, 502, 503, 504}`, matching the [Python SDK's default `status_forcelist`](https://github.com/cognitedata/cognite-sdk-python/blob/65b6af3e34be86337966af8273f6e44e9786a687/cognite/client/config.py#L52).
- Removes the `lodash/inRange` dependency from the retry validator.
- Updates unit tests to cover the new status code boundaries (502 for retryable scenarios, 500 as explicitly non-retryable).

## Motivation

The TypeScript SDK was retrying on status codes like 500 (Internal Server Error) and 501 (Not Implemented), which the Python SDK intentionally excludes. Retrying 500s can cause duplicate side effects for non-idempotent operations. This change brings the two SDKs into alignment.