### PR TITLE
fix(core): stop retrying DELETE requests on 5xx errors to align with …

### DIFF
--- a/packages/core/src/httpClient/cdfHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.unit.spec.ts
@@ -196,17 +196,17 @@ describe('CDFHttpClient', () => {
       const headerValue = '123';
       client.addOneTimeHeader(headerKey, headerValue);
       nock(baseUrl, { reqheaders: { [headerKey]: headerValue } })
-        .delete('/')
+        .put('/')
         .reply(101, {});
       nock(baseUrl, { reqheaders: { [headerKey]: headerValue } })
-        .delete('/')
+        .put('/')
         .reply(200, [1]);
       nock(baseUrl, { badheaders: [headerKey] })
-        .delete('/')
+        .put('/')
         .reply(200, {});
-      const res = await client.delete(baseUrl);
+      const res = await client.put(baseUrl);
       expect(res.data).toEqual([1]);
-      await client.delete(baseUrl);
+      await client.put(baseUrl);
     });
   });
 });

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -56,7 +56,7 @@ export const createUniversalRetryValidator =
       return true;
     }
     // By default, retry requests with HTTP verbs that are meant to be idempotent
-    const httpMethodsToRetry = ['GET', 'HEAD', 'OPTIONS', 'DELETE', 'PUT'];
+    const httpMethodsToRetry = ['GET', 'HEAD', 'OPTIONS', 'PUT'];
     const isRetryableHttpMethod =
       httpMethodsToRetry.indexOf(request.method.toUpperCase()) !== -1;
     if (!isRetryableHttpMethod) {

--- a/packages/core/src/httpClient/retryValidator.unit.spec.ts
+++ b/packages/core/src/httpClient/retryValidator.unit.spec.ts
@@ -79,4 +79,30 @@ describe('cdfRetryValidator', () => {
   test("don't retry GET 4xx (except 429)", () => {
     expect(retryValidator(getRequest, response415, 0)).toBeFalsy();
   });
+
+  describe('DELETE method retry behavior', () => {
+    const deleteRequest: HttpRequest = {
+      ...baseRequest,
+      method: HttpMethod.Delete,
+    };
+    const response502: HttpResponse<unknown> = { ...baseResponse, status: 502 };
+    const response503: HttpResponse<unknown> = { ...baseResponse, status: 503 };
+    const response504: HttpResponse<unknown> = { ...baseResponse, status: 504 };
+
+    test("don't retry DELETE on 502", () => {
+      expect(retryValidator(deleteRequest, response502, 0)).toBeFalsy();
+    });
+
+    test("don't retry DELETE on 503", () => {
+      expect(retryValidator(deleteRequest, response503, 0)).toBeFalsy();
+    });
+
+    test("don't retry DELETE on 504", () => {
+      expect(retryValidator(deleteRequest, response504, 0)).toBeFalsy();
+    });
+
+    test('retry DELETE on 429', () => {
+      expect(retryValidator(deleteRequest, response429, 0)).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

DELETE is not safely idempotent in all cases, so it should not be automatically retried on server errors. This aligns with the Python SDK's behavior where DELETE is routed through the non-retryable HTTP
client. Retry on 429 (Too Many Requests) is preserved since that applies unconditionally regardless of HTTP method.

- Remove `DELETE` from the retryable HTTP methods list in `createUniversalRetryValidator`, aligning retry behavior with the Python SDK where DELETE requests are not automatically retried on 5xx errors.
- 429 (Too Many Requests) responses are still retried for DELETE, since that logic applies unconditionally to all methods.

## Background

The Python SDK routes DELETE requests through its non-retryable HTTP client, meaning they are only retried on 429 (via rate-limit handling) and never on 5xx. The TypeScript SDK was treating DELETE as fully idempotent and retrying it on all server errors, which could lead to unintended duplicate deletions in failure scenarios.