### PR TITLE
feat(core): support isAutoRetryable flag in HTTP retry loop

### DIFF
--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -148,6 +148,5 @@ function hasAutoRetryableError(data: unknown): boolean {
 
   const { error } = data;
   if (typeof error !== 'object' || error === null) return false;
-  
   return 'isAutoRetryable' in error && error.isAutoRetryable === true;
 }

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -112,10 +112,11 @@ export class RetryableHttpClient extends BasicHttpClient {
         ? request.retryValidator
         : this.retryValidator;
 
+      const isAutoRetryable = hasAutoRetryableError(response.data);
       const shouldRetry =
         retryCount < MAX_RETRY_ATTEMPTS &&
         request.retryValidator !== false &&
-        retryValidator(request, response, retryCount);
+        (isAutoRetryable || retryValidator(request, response, retryCount));
       if (!shouldRetry) {
         return response;
       }
@@ -139,3 +140,14 @@ export type RetryableHttpRequestOptions = HttpRequestOptions &
 type HttpRequestRetryValidatorOptions = {
   retryValidator?: false | RetryValidator;
 };
+
+function hasAutoRetryableError(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) return false;
+
+  if (!('error' in data)) return false;
+
+  const { error } = data;
+  if (typeof error !== 'object' || error === null) return false;
+  
+  return 'isAutoRetryable' in error && error.isAutoRetryable === true;
+}

--- a/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
@@ -71,4 +71,60 @@ describe('RetryableHttpClient', () => {
     }
     expect(scope.isDone()).toBe(true);
   });
+
+  test('should retry non-retryable status when isAutoRetryable is true', async () => {
+    const scope = nock(baseUrl)
+      .get('/')
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+    nock(baseUrl).get('/').reply(200, { a: 42 });
+    const res = await client.get('/');
+    expect(scope.isDone()).toBeTruthy();
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ a: 42 });
+  });
+
+  test('should respect MAX_RETRY_ATTEMPTS even when isAutoRetryable is true', async () => {
+    nock(baseUrl)
+      .get('/')
+      .times(6)
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+    await expect(client.get('/')).rejects.toThrow(
+      'Request failed | status code: 400'
+    );
+  }, 30_000);
+
+  test('should fall through to normal retry validation when isAutoRetryable is false', async () => {
+    nock(baseUrl)
+      .get('/')
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: false } });
+    await expect(client.get('/')).rejects.toThrow(
+      'Request failed | status code: 400'
+    );
+  });
+
+  test('should fall through to normal retry validation when isAutoRetryable is missing', async () => {
+    nock(baseUrl)
+      .get('/')
+      .reply(400, { error: { code: 400, message: 'Bad request' } });
+    await expect(client.get('/')).rejects.toThrow(
+      'Request failed | status code: 400'
+    );
+  });
+
+  test('should not retry when retryValidator is false even if isAutoRetryable is true', async () => {
+    const scope = nock(baseUrl)
+      .get('/')
+      .times(1)
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+    expect.assertions(2);
+    try {
+      await client.get('/', { retryValidator: false });
+    } catch (err) {
+      if (!(err instanceof HttpError)) {
+        throw err;
+      }
+      expect(err.status).toBe(400);
+    }
+    expect(scope.isDone()).toBe(true);
+  });
 });

--- a/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
@@ -75,7 +75,9 @@ describe('RetryableHttpClient', () => {
   test('should retry non-retryable status when isAutoRetryable is true', async () => {
     const scope = nock(baseUrl)
       .get('/')
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: true },
+      });
     nock(baseUrl).get('/').reply(200, { a: 42 });
     const res = await client.get('/');
     expect(scope.isDone()).toBeTruthy();
@@ -87,7 +89,9 @@ describe('RetryableHttpClient', () => {
     nock(baseUrl)
       .get('/')
       .times(6)
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: true },
+      });
     await expect(client.get('/')).rejects.toThrow(
       'Request failed | status code: 400'
     );
@@ -96,7 +100,9 @@ describe('RetryableHttpClient', () => {
   test('should fall through to normal retry validation when isAutoRetryable is false', async () => {
     nock(baseUrl)
       .get('/')
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: false } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: false },
+      });
     await expect(client.get('/')).rejects.toThrow(
       'Request failed | status code: 400'
     );
@@ -115,7 +121,9 @@ describe('RetryableHttpClient', () => {
     const scope = nock(baseUrl)
       .get('/')
       .times(1)
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: true },
+      });
     expect.assertions(2);
     try {
       await client.get('/', { retryValidator: false });


### PR DESCRIPTION
## Summary

When the API response body contains `error.isAutoRetryable: true`, bypass normal retry validation and retry the request (still respecting MAX_RETRY_ATTEMPTS and retryValidator: false opt-out). This aligns the JS SDK retry behavior with the Python SDK.

- Add `isAutoRetryable` support to the `RetryableHttpClient` retry loop — when the API response body includes `error.isAutoRetryable: true`, to align with Python SDK
- Uses runtime structural narrowing (`in` operator) to inspect the response data without unsafe casts
- Respects existing guardrails: `MAX_RETRY_ATTEMPTS` limit and `retryValidator: false` opt-out both still apply