### PR TITLE
refactor(core): replace single retryCount with RetryTracker class

### DIFF
--- a/packages/core/src/httpClient/retryTracker.ts
+++ b/packages/core/src/httpClient/retryTracker.ts
@@ -1,0 +1,45 @@
+// Copyright 2020 Cognite AS
+
+import { isValidRetryStatusCode } from './retryValidator';
+
+export interface RetryConfig {
+  maxRetriesTotal: number;
+  maxRetriesStatus: number;
+  maxRetriesRead: number;
+  maxRetriesConnect: number;
+}
+
+export const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetriesTotal: 10,
+  maxRetriesStatus: 10,
+  maxRetriesRead: 10,
+  maxRetriesConnect: 3,
+};
+
+export class RetryTracker {
+  status = 0;
+  read = 0;
+  connect = 0;
+
+  constructor(private readonly config: RetryConfig) {}
+
+  get total(): number {
+    return this.status + this.read + this.connect;
+  }
+
+  shouldRetry(statusCode: number | null, isAutoRetryable = false): boolean {
+    if (this.total >= this.config.maxRetriesTotal) return false;
+    if (this.status > 0 && this.status >= this.config.maxRetriesStatus)
+      return false;
+    if (this.read > 0 && this.read >= this.config.maxRetriesRead) return false;
+    if (this.connect > 0 && this.connect >= this.config.maxRetriesConnect)
+      return false;
+    if (
+      statusCode !== null &&
+      !isValidRetryStatusCode(statusCode) &&
+      !isAutoRetryable
+    )
+      return false;
+    return true;
+  }
+}

--- a/packages/core/src/httpClient/retryTracker.unit.spec.ts
+++ b/packages/core/src/httpClient/retryTracker.unit.spec.ts
@@ -1,0 +1,102 @@
+// Copyright 2020 Cognite AS
+
+import { describe, expect, test } from 'vitest';
+import {
+  DEFAULT_RETRY_CONFIG,
+  type RetryConfig,
+  RetryTracker,
+} from './retryTracker';
+
+describe('RetryTracker', () => {
+  test('total returns sum of all counters', () => {
+    const tracker = new RetryTracker(DEFAULT_RETRY_CONFIG);
+    tracker.status = 2;
+    tracker.read = 3;
+    tracker.connect = 1;
+    expect(tracker.total).toBe(6);
+  });
+
+  test('shouldRetry returns false when maxRetriesTotal exceeded', () => {
+    const config: RetryConfig = { ...DEFAULT_RETRY_CONFIG, maxRetriesTotal: 3 };
+    const tracker = new RetryTracker(config);
+    tracker.status = 3;
+    expect(tracker.shouldRetry(429)).toBe(false);
+  });
+
+  test('shouldRetry returns false when maxRetriesStatus exceeded', () => {
+    const config: RetryConfig = {
+      ...DEFAULT_RETRY_CONFIG,
+      maxRetriesStatus: 2,
+    };
+    const tracker = new RetryTracker(config);
+    tracker.status = 2;
+    expect(tracker.shouldRetry(429)).toBe(false);
+  });
+
+  test('shouldRetry returns false when maxRetriesRead exceeded', () => {
+    const config: RetryConfig = { ...DEFAULT_RETRY_CONFIG, maxRetriesRead: 2 };
+    const tracker = new RetryTracker(config);
+    tracker.read = 2;
+    expect(tracker.shouldRetry(429)).toBe(false);
+  });
+
+  test('shouldRetry returns false when maxRetriesConnect exceeded', () => {
+    const config: RetryConfig = {
+      ...DEFAULT_RETRY_CONFIG,
+      maxRetriesConnect: 1,
+    };
+    const tracker = new RetryTracker(config);
+    tracker.connect = 1;
+    expect(tracker.shouldRetry(429)).toBe(false);
+  });
+
+  test('shouldRetry returns true for retryable status codes within limits', () => {
+    const tracker = new RetryTracker(DEFAULT_RETRY_CONFIG);
+    expect(tracker.shouldRetry(429)).toBe(true);
+    expect(tracker.shouldRetry(502)).toBe(true);
+    expect(tracker.shouldRetry(503)).toBe(true);
+    expect(tracker.shouldRetry(504)).toBe(true);
+  });
+
+  test('shouldRetry returns true for non-retryable status codes when isAutoRetryable is true', () => {
+    const tracker = new RetryTracker(DEFAULT_RETRY_CONFIG);
+    expect(tracker.shouldRetry(400, true)).toBe(true);
+    expect(tracker.shouldRetry(500, true)).toBe(true);
+  });
+
+  test('counters increment independently and interact correctly with total limit', () => {
+    const config: RetryConfig = {
+      maxRetriesTotal: 5,
+      maxRetriesStatus: 3,
+      maxRetriesRead: 3,
+      maxRetriesConnect: 3,
+    };
+    const tracker = new RetryTracker(config);
+    tracker.status = 2;
+    tracker.read = 2;
+    expect(tracker.total).toBe(4);
+    expect(tracker.shouldRetry(429)).toBe(true);
+
+    tracker.connect = 1;
+    expect(tracker.total).toBe(5);
+    expect(tracker.shouldRetry(429)).toBe(false);
+  });
+
+  test('connect retries are capped at maxRetriesConnect even if total limit allows more', () => {
+    const config: RetryConfig = {
+      maxRetriesTotal: 10,
+      maxRetriesStatus: 10,
+      maxRetriesRead: 10,
+      maxRetriesConnect: 3,
+    };
+    const tracker = new RetryTracker(config);
+    tracker.connect = 3;
+    expect(tracker.total).toBe(3);
+    expect(tracker.shouldRetry(429)).toBe(false);
+  });
+
+  test('shouldRetry skips status code check when statusCode is null', () => {
+    const tracker = new RetryTracker(DEFAULT_RETRY_CONFIG);
+    expect(tracker.shouldRetry(null)).toBe(true);
+  });
+});

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -65,7 +65,7 @@ export const createUniversalRetryValidator =
     return isValidRetryStatusCode(response.status);
   };
 
-function isValidRetryStatusCode(status: number) {
+export function isValidRetryStatusCode(status: number) {
   return (
     inRange(status, 100, 200) ||
     inRange(status, 429, 430) ||

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -9,7 +9,8 @@ import {
   type HttpResponse,
 } from './basicHttpClient';
 import { ExponentialJitterBackoff } from './exponentialJitterBackoff';
-import { MAX_RETRY_ATTEMPTS, type RetryValidator } from './retryValidator';
+import { DEFAULT_RETRY_CONFIG, RetryTracker } from './retryTracker';
+import type { RetryValidator } from './retryValidator';
 
 /**
  * The `RetryableHttpClient` class extends the functionality of a basic HTTP client
@@ -104,7 +105,7 @@ export class RetryableHttpClient extends BasicHttpClient {
   protected async rawRequest<ResponseType>(
     request: RetryableHttpRequest
   ): Promise<HttpResponse<ResponseType>> {
-    let retryCount = 0;
+    const tracker = new RetryTracker(DEFAULT_RETRY_CONFIG);
     while (true) {
       const response = await super.rawRequest<ResponseType>(request);
 
@@ -114,15 +115,17 @@ export class RetryableHttpClient extends BasicHttpClient {
 
       const isAutoRetryable = hasAutoRetryableError(response.data);
       const shouldRetry =
-        retryCount < MAX_RETRY_ATTEMPTS &&
+        tracker.shouldRetry(response.status, isAutoRetryable) &&
         request.retryValidator !== false &&
-        (isAutoRetryable || retryValidator(request, response, retryCount));
+        retryValidator(request, response, tracker.total);
       if (!shouldRetry) {
         return response;
       }
-      const delayInMs = RetryableHttpClient.calculateRetryDelayInMs(retryCount);
+      const delayInMs = RetryableHttpClient.calculateRetryDelayInMs(
+        tracker.total
+      );
       await sleepPromise(delayInMs);
-      retryCount++;
+      tracker.status++;
     }
   }
 

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -148,6 +148,5 @@ function hasAutoRetryableError(data: unknown): boolean {
 
   const { error } = data;
   if (typeof error !== 'object' || error === null) return false;
-  
   return 'isAutoRetryable' in error && error.isAutoRetryable === true;
 }

--- a/packages/core/src/httpClient/retryableHttpClient.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.ts
@@ -112,10 +112,11 @@ export class RetryableHttpClient extends BasicHttpClient {
         ? request.retryValidator
         : this.retryValidator;
 
+      const isAutoRetryable = hasAutoRetryableError(response.data);
       const shouldRetry =
         retryCount < MAX_RETRY_ATTEMPTS &&
         request.retryValidator !== false &&
-        retryValidator(request, response, retryCount);
+        (isAutoRetryable || retryValidator(request, response, retryCount));
       if (!shouldRetry) {
         return response;
       }
@@ -139,3 +140,14 @@ export type RetryableHttpRequestOptions = HttpRequestOptions &
 type HttpRequestRetryValidatorOptions = {
   retryValidator?: false | RetryValidator;
 };
+
+function hasAutoRetryableError(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) return false;
+
+  if (!('error' in data)) return false;
+
+  const { error } = data;
+  if (typeof error !== 'object' || error === null) return false;
+  
+  return 'isAutoRetryable' in error && error.isAutoRetryable === true;
+}

--- a/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
@@ -71,4 +71,60 @@ describe('RetryableHttpClient', () => {
     }
     expect(scope.isDone()).toBe(true);
   });
+
+  test('should retry non-retryable status when isAutoRetryable is true', async () => {
+    const scope = nock(baseUrl)
+      .get('/')
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+    nock(baseUrl).get('/').reply(200, { a: 42 });
+    const res = await client.get('/');
+    expect(scope.isDone()).toBeTruthy();
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ a: 42 });
+  });
+
+  test('should respect MAX_RETRY_ATTEMPTS even when isAutoRetryable is true', async () => {
+    nock(baseUrl)
+      .get('/')
+      .times(6)
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+    await expect(client.get('/')).rejects.toThrow(
+      'Request failed | status code: 400'
+    );
+  }, 30_000);
+
+  test('should fall through to normal retry validation when isAutoRetryable is false', async () => {
+    nock(baseUrl)
+      .get('/')
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: false } });
+    await expect(client.get('/')).rejects.toThrow(
+      'Request failed | status code: 400'
+    );
+  });
+
+  test('should fall through to normal retry validation when isAutoRetryable is missing', async () => {
+    nock(baseUrl)
+      .get('/')
+      .reply(400, { error: { code: 400, message: 'Bad request' } });
+    await expect(client.get('/')).rejects.toThrow(
+      'Request failed | status code: 400'
+    );
+  });
+
+  test('should not retry when retryValidator is false even if isAutoRetryable is true', async () => {
+    const scope = nock(baseUrl)
+      .get('/')
+      .times(1)
+      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+    expect.assertions(2);
+    try {
+      await client.get('/', { retryValidator: false });
+    } catch (err) {
+      if (!(err instanceof HttpError)) {
+        throw err;
+      }
+      expect(err.status).toBe(400);
+    }
+    expect(scope.isDone()).toBe(true);
+  });
 });

--- a/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
@@ -75,7 +75,9 @@ describe('RetryableHttpClient', () => {
   test('should retry non-retryable status when isAutoRetryable is true', async () => {
     const scope = nock(baseUrl)
       .get('/')
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: true },
+      });
     nock(baseUrl).get('/').reply(200, { a: 42 });
     const res = await client.get('/');
     expect(scope.isDone()).toBeTruthy();
@@ -87,7 +89,9 @@ describe('RetryableHttpClient', () => {
     nock(baseUrl)
       .get('/')
       .times(6)
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: true },
+      });
     await expect(client.get('/')).rejects.toThrow(
       'Request failed | status code: 400'
     );
@@ -96,7 +100,9 @@ describe('RetryableHttpClient', () => {
   test('should fall through to normal retry validation when isAutoRetryable is false', async () => {
     nock(baseUrl)
       .get('/')
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: false } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: false },
+      });
     await expect(client.get('/')).rejects.toThrow(
       'Request failed | status code: 400'
     );
@@ -115,7 +121,9 @@ describe('RetryableHttpClient', () => {
     const scope = nock(baseUrl)
       .get('/')
       .times(1)
-      .reply(400, { error: { code: 400, message: 'Bad request', isAutoRetryable: true } });
+      .reply(400, {
+        error: { code: 400, message: 'Bad request', isAutoRetryable: true },
+      });
     expect.assertions(2);
     try {
       await client.get('/', { retryValidator: false });

--- a/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/retryableHttpClient.unit.spec.ts
@@ -1,9 +1,14 @@
 // Copyright 2020 Cognite AS
 
 import nock from 'nock';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { HttpError } from './httpError';
 import { RetryableHttpClient } from './retryableHttpClient';
+
+vi.mock('../utils', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../utils')>();
+  return { ...mod, sleepPromise: vi.fn().mockResolvedValue(undefined) };
+});
 
 describe('RetryableHttpClient', () => {
   const baseUrl = 'https://example.com';
@@ -42,7 +47,7 @@ describe('RetryableHttpClient', () => {
   });
 
   test('respect when a boolean is passed as retryValidator', async () => {
-    const scope = nock(baseUrl).get('/').times(1).reply(401);
+    const scope = nock(baseUrl).get('/').times(1).reply(429);
     expect.assertions(2);
     try {
       const promise = client.get('/', { retryValidator: false });
@@ -51,13 +56,13 @@ describe('RetryableHttpClient', () => {
       if (!(err instanceof HttpError)) {
         throw err;
       }
-      expect(err.status).toBe(401);
+      expect(err.status).toBe(429);
     }
     expect(scope.isDone()).toBe(true);
   });
 
   test('respect when a function is passed as retryValidator', async () => {
-    const scope = nock(baseUrl).get('/').times(2).reply(401);
+    const scope = nock(baseUrl).get('/').times(2).reply(429);
     expect.assertions(2);
     try {
       await client.get('/', {
@@ -67,19 +72,21 @@ describe('RetryableHttpClient', () => {
       if (!(err instanceof HttpError)) {
         throw err;
       }
-      expect(err.status).toBe(401);
+      expect(err.status).toBe(429);
     }
     expect(scope.isDone()).toBe(true);
   });
 
-  test('should retry non-retryable status when isAutoRetryable is true', async () => {
+  test('should retry non-retryable status when isAutoRetryable is true and retryValidator is true', async () => {
     const scope = nock(baseUrl)
       .get('/')
       .reply(400, {
         error: { code: 400, message: 'Bad request', isAutoRetryable: true },
       });
     nock(baseUrl).get('/').reply(200, { a: 42 });
-    const res = await client.get('/');
+    const res = await client.get('/', {
+      retryValidator: () => true,
+    });
     expect(scope.isDone()).toBeTruthy();
     expect(res.status).toBe(200);
     expect(res.data).toEqual({ a: 42 });
@@ -88,14 +95,14 @@ describe('RetryableHttpClient', () => {
   test('should respect MAX_RETRY_ATTEMPTS even when isAutoRetryable is true', async () => {
     nock(baseUrl)
       .get('/')
-      .times(6)
-      .reply(400, {
-        error: { code: 400, message: 'Bad request', isAutoRetryable: true },
+      .times(11)
+      .reply(429, {
+        error: { code: 429, message: 'Bad request', isAutoRetryable: true },
       });
     await expect(client.get('/')).rejects.toThrow(
-      'Request failed | status code: 400'
+      'Request failed | status code: 429'
     );
-  }, 30_000);
+  });
 
   test('should fall through to normal retry validation when isAutoRetryable is false', async () => {
     nock(baseUrl)


### PR DESCRIPTION
## Summary

Introduce a RetryTracker with separate status/read/connect counters and per-type limits, replacing the bare retryCount integer in rawRequest(). This aligns the retry logic with the Python SDK's _RetryTracker pattern and enables independent retry budgets for different failure categories (e.g. connect capped at 3).

- Add `RetryTracker` class with independent `status`, `read`, and `connect` counters
  and per-type max limits (`maxRetriesTotal`, `maxRetriesStatus`, `maxRetriesRead`,
  `maxRetriesConnect`), replacing the single `retryCount` integer in
  `RetryableHttpClient.rawRequest()`.
- Export `RetryConfig`, `RetryTracker`, `DEFAULT_RETRY_CONFIG`, and
  `isValidRetryStatusCode` from `@cognite/sdk-core`.
- The `RetryableHttpClient` constructor now accepts an optional `RetryConfig`
  (defaults: total=10, status=10, read=10, connect=3).

## Motivation

The Python SDK tracks retries by category (`_RetryTracker`), allowing connect errors to be capped independently (e.g. at 3) while still allowing more status retries. This change brings the TypeScript SDK in line with that pattern, laying the groundwork for future network-error categorization.