### PR TITLE
fix(core): align HTTP method retry behavior with Python SDK

### DIFF
--- a/packages/core/src/httpClient/cdfHttpClient.unit.spec.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.unit.spec.ts
@@ -196,17 +196,17 @@ describe('CDFHttpClient', () => {
       const headerValue = '123';
       client.addOneTimeHeader(headerKey, headerValue);
       nock(baseUrl, { reqheaders: { [headerKey]: headerValue } })
-        .delete('/')
+        .put('/')
         .reply(101, {});
       nock(baseUrl, { reqheaders: { [headerKey]: headerValue } })
-        .delete('/')
+        .put('/')
         .reply(200, [1]);
       nock(baseUrl, { badheaders: [headerKey] })
-        .delete('/')
+        .put('/')
         .reply(200, {});
-      const res = await client.delete(baseUrl);
+      const res = await client.put(baseUrl);
       expect(res.data).toEqual([1]);
-      await client.delete(baseUrl);
+      await client.put(baseUrl);
     });
   });
 });

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -56,7 +56,7 @@ export const createUniversalRetryValidator =
       return true;
     }
     // By default, retry requests with HTTP verbs that are meant to be idempotent
-    const httpMethodsToRetry = ['GET', 'HEAD', 'OPTIONS', 'PUT'];
+    const httpMethodsToRetry = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'PATCH'];
     const isRetryableHttpMethod =
       httpMethodsToRetry.indexOf(request.method.toUpperCase()) !== -1;
     if (!isRetryableHttpMethod) {

--- a/packages/core/src/httpClient/retryValidator.ts
+++ b/packages/core/src/httpClient/retryValidator.ts
@@ -56,7 +56,7 @@ export const createUniversalRetryValidator =
       return true;
     }
     // By default, retry requests with HTTP verbs that are meant to be idempotent
-    const httpMethodsToRetry = ['GET', 'HEAD', 'OPTIONS', 'DELETE', 'PUT'];
+    const httpMethodsToRetry = ['GET', 'HEAD', 'OPTIONS', 'PUT'];
     const isRetryableHttpMethod =
       httpMethodsToRetry.indexOf(request.method.toUpperCase()) !== -1;
     if (!isRetryableHttpMethod) {

--- a/packages/core/src/httpClient/retryValidator.unit.spec.ts
+++ b/packages/core/src/httpClient/retryValidator.unit.spec.ts
@@ -79,4 +79,30 @@ describe('cdfRetryValidator', () => {
   test("don't retry GET 4xx (except 429)", () => {
     expect(retryValidator(getRequest, response415, 0)).toBeFalsy();
   });
+
+  describe('DELETE method retry behavior', () => {
+    const deleteRequest: HttpRequest = {
+      ...baseRequest,
+      method: HttpMethod.Delete,
+    };
+    const response502: HttpResponse<unknown> = { ...baseResponse, status: 502 };
+    const response503: HttpResponse<unknown> = { ...baseResponse, status: 503 };
+    const response504: HttpResponse<unknown> = { ...baseResponse, status: 504 };
+
+    test("don't retry DELETE on 502", () => {
+      expect(retryValidator(deleteRequest, response502, 0)).toBeFalsy();
+    });
+
+    test("don't retry DELETE on 503", () => {
+      expect(retryValidator(deleteRequest, response503, 0)).toBeFalsy();
+    });
+
+    test("don't retry DELETE on 504", () => {
+      expect(retryValidator(deleteRequest, response504, 0)).toBeFalsy();
+    });
+
+    test('retry DELETE on 429', () => {
+      expect(retryValidator(deleteRequest, response429, 0)).toBeTruthy();
+    });
+  });
 });

--- a/packages/core/src/httpClient/retryValidator.unit.spec.ts
+++ b/packages/core/src/httpClient/retryValidator.unit.spec.ts
@@ -80,6 +80,26 @@ describe('cdfRetryValidator', () => {
     expect(retryValidator(getRequest, response415, 0)).toBeFalsy();
   });
 
+  describe('PATCH method retry behavior', () => {
+    const patchRequest: HttpRequest = {
+      ...baseRequest,
+      method: HttpMethod.Patch,
+    };
+    const response502: HttpResponse<unknown> = { ...baseResponse, status: 502 };
+
+    test('retry PATCH 502', () => {
+      expect(retryValidator(patchRequest, response502, 0)).toBeTruthy();
+    });
+
+    test("don't retry PATCH 4xx (except 429)", () => {
+      expect(retryValidator(patchRequest, response415, 0)).toBeFalsy();
+    });
+
+    test('retry PATCH 429', () => {
+      expect(retryValidator(patchRequest, response429, 0)).toBeTruthy();
+    });
+  });
+
   describe('DELETE method retry behavior', () => {
     const deleteRequest: HttpRequest = {
       ...baseRequest,


### PR DESCRIPTION
## Summary

- **Remove DELETE** from the default retryable methods list in `createUniversalRetryValidator` — the Python SDK does not retry it on 5xx.
- **Add PATCH** to the default retryable methods list — the Python SDK treats PATCH as retryable alongside GET and PUT, but the JS SDK was missing it.
- Add unit tests for both PATCH retry behavior and DELETE non-retry behavior.

## Motivation

The Python SDK's `_is_retryable` considers `GET`, `PUT`, and `PATCH` retryable, while the JS SDK had `GET`, `HEAD`, `OPTIONS`, `DELETE`, `PUT`. This PR brings them into alignment.