### PR TITLE
feat(alpha): add support for metering-service

### DIFF
--- a/packages/alpha/src/__tests__/api/limitsApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/limitsApi.unit.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2025 Cognite AS
 
-import type { LimitAdvanceFilter } from 'alpha/src/types';
+import type { LimitsFilterQuery } from 'alpha/src/types';
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
@@ -66,7 +66,7 @@ describe('Limits API unit tests', () => {
 
   describe('retrieveByAdvancedFilter', () => {
     test('should retrieve limits with filter', async () => {
-      const filter: LimitAdvanceFilter = {
+      const filter: LimitsFilterQuery = {
         filter: {
           prefix: {
             property: ['limitId'],
@@ -128,7 +128,7 @@ describe('Limits API unit tests', () => {
     });
 
     test('should handle empty results', async () => {
-      const filter: LimitAdvanceFilter = {
+      const filter: LimitsFilterQuery = {
         filter: {
           prefix: {
             property: ['limitId'],

--- a/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
@@ -17,102 +17,7 @@ describe('Metering API unit tests', () => {
     client = setupMockableClient();
   });
 
-  describe('retrieveConsumptionData', () => {
-    test('should retrieve consumption data for a single meter', async () => {
-      const meterId = 'atlas.monthly_ai_tokens';
-      const mockedResponse = {
-        meterId: 'atlas.monthly_ai_tokens',
-        datapoints: [],
-      };
-
-      nock(mockBaseUrl)
-        .get(
-          /\/api\/v1\/projects\/.*\/metering\/meters\/atlas\.monthly_ai_tokens$/
-        )
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(200, mockedResponse);
-
-      const result = await client.metering.retrieveConsumptionData(meterId);
-      expect(result.meterId).toEqual(mockedResponse.meterId);
-      expect(result.datapoints).toEqual([]);
-    });
-
-    test('should convert datapoint timestamps from epoch ms to Date', async () => {
-      const meterId = 'files.storage_bytes';
-      const mockedResponse = {
-        meterId: 'files.storage_bytes',
-        datapoints: [{ timestamp: epochMs, value: 42.5 }],
-      };
-
-      nock(mockBaseUrl)
-        .get(/\/api\/v1\/projects\/.*\/metering\/meters\/files\.storage_bytes$/)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(200, mockedResponse);
-
-      const result = await client.metering.retrieveConsumptionData(meterId);
-      expect(result.datapoints).toHaveLength(1);
-      expect(result.datapoints[0].value).toBe(42.5);
-      expect(result.datapoints[0].timestamp).toEqual(new Date(epochMs));
-    });
-
-    test('should pass optional range query params', async () => {
-      const meterId = 'atlas.monthly_ai_tokens';
-      const query = {
-        start: 1000,
-        end: 2000,
-        numberOfDatapoints: 3,
-      };
-      const mockedResponse = {
-        meterId,
-        datapoints: [{ timestamp: epochMs, value: 1 }],
-      };
-
-      nock(mockBaseUrl)
-        .get(
-          /\/api\/v1\/projects\/.*\/metering\/meters\/atlas\.monthly_ai_tokens$/
-        )
-        .query(query)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(200, mockedResponse);
-
-      const result = await client.metering.retrieveConsumptionData(
-        meterId,
-        query
-      );
-      expect(result.datapoints[0].timestamp).toEqual(new Date(epochMs));
-    });
-
-    test('should URL-encode special characters in meterId', async () => {
-      const meterId = 'service/meter_name';
-      const mockedResponse = {
-        meterId: 'service/meter_name',
-        datapoints: [],
-      };
-
-      nock(mockBaseUrl)
-        .get(/\/api\/v1\/projects\/.*\/metering\/meters\/service%2Fmeter_name$/)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(200, mockedResponse);
-
-      const result = await client.metering.retrieveConsumptionData(meterId);
-      expect(result.meterId).toEqual(mockedResponse.meterId);
-    });
-
-    test('should reject when meter is not found', async () => {
-      const meterId = 'non.existent_meter';
-
-      nock(mockBaseUrl)
-        .get(/\/api\/v1\/projects\/.*\/metering\/meters\/non\.existent_meter$/)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(404, { error: { message: 'Meter not found', code: 404 } });
-
-      await expect(
-        client.metering.retrieveConsumptionData(meterId)
-      ).rejects.toThrow();
-    });
-  });
-
-  describe('filterMeters', () => {
+  describe('retrieveMeters', () => {
     test('should filter meters with prefix on meterId', async () => {
       const filter: MeterConsumptionFilterQuery = {
         filter: {
@@ -148,7 +53,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.filterMeters(filter);
+      const result = await client.metering.retrieveMeters(filter);
       expect(result.items).toEqual(mockedResponse.items);
       expect(result.nextCursor).toBe('cursor-123');
       expect(result.items.length).toBe(2);
@@ -170,12 +75,12 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.filterMeters(filter);
+      const result = await client.metering.retrieveMeters(filter);
       expect(result.items).toEqual(mockedResponse.items);
       expect(result.items.length).toBe(1);
     });
 
-    test('should handle empty filter results', async () => {
+    test('should handle empty filter results in retrieve all Meters', async () => {
       const filter: MeterConsumptionFilterQuery = {
         filter: {
           prefix: {
@@ -198,9 +103,56 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.filterMeters(filter);
+      const result = await client.metering.retrieveMeters(filter);
       expect(result.items).toEqual([]);
       expect(result.items.length).toBe(0);
+    });
+
+    test('should return historical datapoints for meters', async () => {
+      const filter: MeterConsumptionFilterQuery = {
+        filter: {
+          prefix: {
+            property: ['meterId'],
+            value: 'atlas.',
+          },
+        },
+        start: epochMs,
+        end: epochMs + 2000,
+        numberOfDatapoints: 10,
+      };
+
+      const mockedResponse = {
+        items: [
+          {
+            meterId: 'atlas.monthly_ai_tokens',
+            datapoints: [
+              { timestamp: epochMs, value: 10 },
+              { timestamp: epochMs + 1000, value: 20 },
+            ],
+          },
+        ],
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/list/, (body) => {
+          return (
+            body.filter?.prefix?.property?.includes('meterId') &&
+            body.filter?.prefix?.value === 'atlas.'
+          );
+        })
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.retrieveMeters(filter);
+      expect(result.items[0].meterId).toBe('atlas.monthly_ai_tokens');
+      expect(result.items[0].datapoints[0].timestamp).toEqual(
+        new Date(epochMs)
+      );
+      expect(result.items[0].datapoints[1].timestamp).toEqual(
+        new Date(epochMs + 1000)
+      );
+      expect(result.items[0].datapoints[0].value).toBe(10);
+      expect(result.items[0].datapoints[1].value).toBe(20);
     });
 
     test('should handle pagination with cursor', async () => {
@@ -224,7 +176,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.filterMeters(filter);
+      const result = await client.metering.retrieveMeters(filter);
       expect(result.items[0].meterId).toBe('functions.concurrent_executions');
       expect(result.items[0].datapoints[0].timestamp).toEqual(
         new Date(epochMs)
@@ -233,81 +185,47 @@ describe('Metering API unit tests', () => {
     });
   });
 
-  describe('listMeters', () => {
-    test('should list meters without query params', async () => {
-      const mockedResponse = {
-        items: [
-          { meterId: 'atlas.monthly_ai_tokens', datapoints: [] },
-          { meterId: 'files.storage_bytes', datapoints: [] },
-        ],
-      };
-
-      nock(mockBaseUrl)
-        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(200, mockedResponse);
-
-      const result = await client.metering.listMeters({});
-      expect(result.items).toEqual(mockedResponse.items);
-      expect(result.items.length).toBe(2);
-    });
-
-    test('should list meters with query params', async () => {
-      const queryParams = {
-        limit: 100,
-        cursor: 'initial-cursor',
-        start: 1,
-        end: 2,
-        numberOfDatapoints: 5,
-      };
-      const mockedResponse = {
-        items: [{ meterId: 'atlas.monthly_ai_tokens', datapoints: [] }],
-        nextCursor: 'next-cursor',
-      };
-
-      nock(mockBaseUrl)
-        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
-        .query(queryParams)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(200, mockedResponse);
-
-      const result = await client.metering.listMeters(queryParams);
-      expect(result.items).toEqual(mockedResponse.items);
-      expect(result.nextCursor).toBe('next-cursor');
-    });
-
-    test('should handle empty list', async () => {
-      const mockedResponse = {
-        items: [],
-      };
-
-      nock(mockBaseUrl)
-        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(200, mockedResponse);
-
-      const result = await client.metering.listMeters({});
-      expect(result.items).toEqual([]);
-      expect(result.items.length).toBe(0);
-    });
-
-    test('should propagate error responses', async () => {
-      nock(mockBaseUrl)
-        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
-        .matchHeader('cdf-version', '20230101-alpha')
-        .reply(500, { error: { message: 'Internal server error', code: 500 } });
-
-      await expect(client.metering.listMeters({})).rejects.toThrow();
-    });
-  });
-
-  describe('retrieveConsumptionDataByIds', () => {
-    test('should retrieve multiple meters and parse datapoint timestamps', async () => {
+  describe('retrieveConsumptionData', () => {
+    test('should retrieve single meter and parse datapoint timestamps', async () => {
       const mockedResponse = {
         items: [
           {
             meterId: 'atlas.monthly_ai_tokens',
             datapoints: [{ timestamp: epochMs, value: 10 }],
+          },
+        ],
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, (body) => {
+          return (
+            Array.isArray(body.items) &&
+            body.items.length === 1 &&
+            body.items[0].meterId === 'atlas.monthly_ai_tokens'
+          );
+        })
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.retrieveConsumptionData([
+        'atlas.monthly_ai_tokens',
+      ]);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].datapoints[0].timestamp).toEqual(
+        new Date(epochMs)
+      );
+      expect(result.items[0].datapoints[0].value).toBe(10);
+    });
+
+    test('should retrieve multiple meters and parse datapoint timestamps', async () => {
+      const mockedResponse = {
+        items: [
+          {
+            meterId: 'atlas.monthly_ai_tokens',
+            datapoints: [
+              { timestamp: epochMs, value: 10 },
+              { timestamp: epochMs + 1000, value: 20 },
+            ],
           },
           {
             meterId: 'files.storage_bytes',
@@ -317,22 +235,27 @@ describe('Metering API unit tests', () => {
       };
 
       nock(mockBaseUrl)
-        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, {
-          items: [
-            { meterId: 'atlas.monthly_ai_tokens' },
-            { meterId: 'files.storage_bytes' },
-          ],
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, (body) => {
+          return (
+            Array.isArray(body.items) &&
+            body.items.length === 2 &&
+            body.items[0].meterId === 'atlas.monthly_ai_tokens' &&
+            body.items[1].meterId === 'files.storage_bytes'
+          );
         })
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveConsumptionDataByIds([
+      const result = await client.metering.retrieveConsumptionData([
         'atlas.monthly_ai_tokens',
         'files.storage_bytes',
       ]);
       expect(result.items).toHaveLength(2);
       expect(result.items[0].datapoints[0].timestamp).toEqual(
         new Date(epochMs)
+      );
+      expect(result.items[0].datapoints[1].timestamp).toEqual(
+        new Date(epochMs + 1000)
       );
       expect(result.items[1].datapoints[0].timestamp).toEqual(
         new Date(epochMs + 1000)
@@ -345,15 +268,19 @@ describe('Metering API unit tests', () => {
       const mockedResponse = { items: [] };
 
       nock(mockBaseUrl)
-        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, {
-          items: [{ meterId: 'a' }],
-          start: 1000,
-          end: 2000,
-          numberOfDatapoints: 10,
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, (body) => {
+          return (
+            body.items?.length === 1 &&
+            body.items[0].meterId === 'a' &&
+            body.start === 1000 &&
+            body.end === 2000 &&
+            body.numberOfDatapoints === 10
+          );
         })
+        .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      await client.metering.retrieveConsumptionDataByIds(['a'], {
+      await client.metering.retrieveConsumptionData(['a'], {
         start: 1000,
         end: 2000,
         numberOfDatapoints: 10,
@@ -365,18 +292,17 @@ describe('Metering API unit tests', () => {
     test('should send cdf-version 20230101-alpha on metering requests', async () => {
       const meterId = 'atlas.monthly_ai_tokens';
       const mockedResponse = {
-        meterId,
-        datapoints: [],
+        items: [{ meterId, datapoints: [] }],
       };
 
       nock(mockBaseUrl)
-        .get(
-          /\/api\/v1\/projects\/.*\/metering\/meters\/atlas\.monthly_ai_tokens$/
-        )
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, (body) => {
+          return body.items?.length === 1 && body.items[0].meterId === meterId;
+        })
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      await client.metering.retrieveConsumptionData(meterId);
+      await client.metering.retrieveConsumptionData([meterId]);
     });
   });
 });

--- a/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2026 Cognite AS
 
-import type { MeterConsumptionAdvancedFilter } from 'alpha/src/types';
+import type { MeterConsumptionFilterQuery } from 'alpha/src/types';
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
@@ -17,7 +17,7 @@ describe('Metering API unit tests', () => {
     client = setupMockableClient();
   });
 
-  describe('retrieveByMeterId', () => {
+  describe('retrieveConsumptionData', () => {
     test('should retrieve consumption data for a single meter', async () => {
       const meterId = 'atlas.monthly_ai_tokens';
       const mockedResponse = {
@@ -32,7 +32,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveByMeterId(meterId);
+      const result = await client.metering.retrieveConsumptionData(meterId);
       expect(result.meterId).toEqual(mockedResponse.meterId);
       expect(result.datapoints).toEqual([]);
     });
@@ -49,7 +49,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveByMeterId(meterId);
+      const result = await client.metering.retrieveConsumptionData(meterId);
       expect(result.datapoints).toHaveLength(1);
       expect(result.datapoints[0].value).toBe(42.5);
       expect(result.datapoints[0].timestamp).toEqual(new Date(epochMs));
@@ -75,7 +75,10 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveByMeterId(meterId, query);
+      const result = await client.metering.retrieveConsumptionData(
+        meterId,
+        query
+      );
       expect(result.datapoints[0].timestamp).toEqual(new Date(epochMs));
     });
 
@@ -91,7 +94,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveByMeterId(meterId);
+      const result = await client.metering.retrieveConsumptionData(meterId);
       expect(result.meterId).toEqual(mockedResponse.meterId);
     });
 
@@ -104,14 +107,14 @@ describe('Metering API unit tests', () => {
         .reply(404, { error: { message: 'Meter not found', code: 404 } });
 
       await expect(
-        client.metering.retrieveByMeterId(meterId)
+        client.metering.retrieveConsumptionData(meterId)
       ).rejects.toThrow();
     });
   });
 
   describe('filterMeters', () => {
     test('should filter meters with prefix on meterId', async () => {
-      const filter: MeterConsumptionAdvancedFilter = {
+      const filter: MeterConsumptionFilterQuery = {
         filter: {
           prefix: {
             property: ['meterId'],
@@ -173,7 +176,7 @@ describe('Metering API unit tests', () => {
     });
 
     test('should handle empty filter results', async () => {
-      const filter: MeterConsumptionAdvancedFilter = {
+      const filter: MeterConsumptionFilterQuery = {
         filter: {
           prefix: {
             property: ['meterId'],
@@ -298,14 +301,8 @@ describe('Metering API unit tests', () => {
     });
   });
 
-  describe('retrieveByMeterIds', () => {
+  describe('retrieveConsumptionDataByIds', () => {
     test('should retrieve multiple meters and parse datapoint timestamps', async () => {
-      const request = {
-        items: [
-          { meterId: 'atlas.monthly_ai_tokens' },
-          { meterId: 'files.storage_bytes' },
-        ],
-      };
       const mockedResponse = {
         items: [
           {
@@ -320,11 +317,19 @@ describe('Metering API unit tests', () => {
       };
 
       nock(mockBaseUrl)
-        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, request)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, {
+          items: [
+            { meterId: 'atlas.monthly_ai_tokens' },
+            { meterId: 'files.storage_bytes' },
+          ],
+        })
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveByMeterIds(request);
+      const result = await client.metering.retrieveConsumptionDataByIds([
+        'atlas.monthly_ai_tokens',
+        'files.storage_bytes',
+      ]);
       expect(result.items).toHaveLength(2);
       expect(result.items[0].datapoints[0].timestamp).toEqual(
         new Date(epochMs)
@@ -334,6 +339,25 @@ describe('Metering API unit tests', () => {
       );
       expect(result.items[0].datapoints[0].value).toBe(10);
       expect(result.items[1].datapoints[0].value).toBe(20);
+    });
+
+    test('should merge optional historical params into the request body', async () => {
+      const mockedResponse = { items: [] };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, {
+          items: [{ meterId: 'a' }],
+          start: 1000,
+          end: 2000,
+          numberOfDatapoints: 10,
+        })
+        .reply(200, mockedResponse);
+
+      await client.metering.retrieveConsumptionDataByIds(['a'], {
+        start: 1000,
+        end: 2000,
+        numberOfDatapoints: 10,
+      });
     });
   });
 
@@ -352,7 +376,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      await client.metering.retrieveByMeterId(meterId);
+      await client.metering.retrieveConsumptionData(meterId);
     });
   });
 });

--- a/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
@@ -1,0 +1,358 @@
+// Copyright 2026 Cognite AS
+
+import type { MeterConsumptionAdvancedFilter } from 'alpha/src/types';
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+const epochMs = 1765203279461;
+
+describe('Metering API unit tests', () => {
+  let client: CogniteClientAlpha;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    client = setupMockableClient();
+  });
+
+  describe('retrieveByMeterId', () => {
+    test('should retrieve consumption data for a single meter', async () => {
+      const meterId = 'atlas.monthly_ai_tokens';
+      const mockedResponse = {
+        meterId: 'atlas.monthly_ai_tokens',
+        datapoints: [],
+      };
+
+      nock(mockBaseUrl)
+        .get(
+          /\/api\/v1\/projects\/.*\/metering\/meters\/atlas\.monthly_ai_tokens$/
+        )
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.retrieveByMeterId(meterId);
+      expect(result.meterId).toEqual(mockedResponse.meterId);
+      expect(result.datapoints).toEqual([]);
+    });
+
+    test('should convert datapoint timestamps from epoch ms to Date', async () => {
+      const meterId = 'files.storage_bytes';
+      const mockedResponse = {
+        meterId: 'files.storage_bytes',
+        datapoints: [{ timestamp: epochMs, value: 42.5 }],
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/metering\/meters\/files\.storage_bytes$/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.retrieveByMeterId(meterId);
+      expect(result.datapoints).toHaveLength(1);
+      expect(result.datapoints[0].value).toBe(42.5);
+      expect(result.datapoints[0].timestamp).toEqual(new Date(epochMs));
+    });
+
+    test('should pass optional range query params', async () => {
+      const meterId = 'atlas.monthly_ai_tokens';
+      const query = {
+        start: 1000,
+        end: 2000,
+        numberOfDatapoints: 3,
+      };
+      const mockedResponse = {
+        meterId,
+        datapoints: [{ timestamp: epochMs, value: 1 }],
+      };
+
+      nock(mockBaseUrl)
+        .get(
+          /\/api\/v1\/projects\/.*\/metering\/meters\/atlas\.monthly_ai_tokens$/
+        )
+        .query(query)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.retrieveByMeterId(meterId, query);
+      expect(result.datapoints[0].timestamp).toEqual(new Date(epochMs));
+    });
+
+    test('should URL-encode special characters in meterId', async () => {
+      const meterId = 'service/meter_name';
+      const mockedResponse = {
+        meterId: 'service/meter_name',
+        datapoints: [],
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/metering\/meters\/service%2Fmeter_name$/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.retrieveByMeterId(meterId);
+      expect(result.meterId).toEqual(mockedResponse.meterId);
+    });
+
+    test('should reject when meter is not found', async () => {
+      const meterId = 'non.existent_meter';
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/metering\/meters\/non\.existent_meter$/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(404, { error: { message: 'Meter not found', code: 404 } });
+
+      await expect(
+        client.metering.retrieveByMeterId(meterId)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('filterMeters', () => {
+    test('should filter meters with prefix on meterId', async () => {
+      const filter: MeterConsumptionAdvancedFilter = {
+        filter: {
+          prefix: {
+            property: ['meterId'],
+            value: 'atlas.',
+          },
+        },
+        limit: 100,
+      };
+      const mockedResponse = {
+        items: [
+          {
+            meterId: 'atlas.monthly_ai_tokens',
+            datapoints: [],
+          },
+          {
+            meterId: 'atlas.monthly_ai_prompts',
+            datapoints: [],
+          },
+        ],
+        nextCursor: 'cursor-123',
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/list/, (body) => {
+          return (
+            body.filter?.prefix?.property?.includes('meterId') &&
+            body.filter?.prefix?.value === 'atlas.' &&
+            body.limit === 100
+          );
+        })
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.filterMeters(filter);
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.nextCursor).toBe('cursor-123');
+      expect(result.items.length).toBe(2);
+    });
+
+    test('should filter meters with empty body', async () => {
+      const filter = {};
+      const mockedResponse = {
+        items: [
+          {
+            meterId: 'files.storage_bytes',
+            datapoints: [],
+          },
+        ],
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/list/, filter)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.filterMeters(filter);
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.items.length).toBe(1);
+    });
+
+    test('should handle empty filter results', async () => {
+      const filter: MeterConsumptionAdvancedFilter = {
+        filter: {
+          prefix: {
+            property: ['meterId'],
+            value: 'no_such_prefix_',
+          },
+        },
+      };
+      const mockedResponse = {
+        items: [],
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/list/, (body) => {
+          return (
+            body.filter?.prefix?.property?.includes('meterId') &&
+            body.filter?.prefix?.value === 'no_such_prefix_'
+          );
+        })
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.filterMeters(filter);
+      expect(result.items).toEqual([]);
+      expect(result.items.length).toBe(0);
+    });
+
+    test('should handle pagination with cursor', async () => {
+      const filter = {
+        filter: {},
+        cursor: 'cursor-123',
+        limit: 50,
+      };
+      const mockedResponse = {
+        items: [
+          {
+            meterId: 'functions.concurrent_executions',
+            datapoints: [{ timestamp: epochMs, value: 2 }],
+          },
+        ],
+        nextCursor: 'cursor-456',
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/list/, filter)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.filterMeters(filter);
+      expect(result.items[0].meterId).toBe('functions.concurrent_executions');
+      expect(result.items[0].datapoints[0].timestamp).toEqual(
+        new Date(epochMs)
+      );
+      expect(result.nextCursor).toBe('cursor-456');
+    });
+  });
+
+  describe('listMeters', () => {
+    test('should list meters without query params', async () => {
+      const mockedResponse = {
+        items: [
+          { meterId: 'atlas.monthly_ai_tokens', datapoints: [] },
+          { meterId: 'files.storage_bytes', datapoints: [] },
+        ],
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.listMeters({});
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.items.length).toBe(2);
+    });
+
+    test('should list meters with query params', async () => {
+      const queryParams = {
+        limit: 100,
+        cursor: 'initial-cursor',
+        start: 1,
+        end: 2,
+        numberOfDatapoints: 5,
+      };
+      const mockedResponse = {
+        items: [{ meterId: 'atlas.monthly_ai_tokens', datapoints: [] }],
+        nextCursor: 'next-cursor',
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
+        .query(queryParams)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.listMeters(queryParams);
+      expect(result.items).toEqual(mockedResponse.items);
+      expect(result.nextCursor).toBe('next-cursor');
+    });
+
+    test('should handle empty list', async () => {
+      const mockedResponse = {
+        items: [],
+      };
+
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.listMeters({});
+      expect(result.items).toEqual([]);
+      expect(result.items.length).toBe(0);
+    });
+
+    test('should propagate error responses', async () => {
+      nock(mockBaseUrl)
+        .get(/\/api\/v1\/projects\/.*\/metering\/meters$/)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(500, { error: { message: 'Internal server error', code: 500 } });
+
+      await expect(client.metering.listMeters({})).rejects.toThrow();
+    });
+  });
+
+  describe('retrieveByMeterIds', () => {
+    test('should retrieve multiple meters and parse datapoint timestamps', async () => {
+      const request = {
+        items: [
+          { meterId: 'atlas.monthly_ai_tokens' },
+          { meterId: 'files.storage_bytes' },
+        ],
+      };
+      const mockedResponse = {
+        items: [
+          {
+            meterId: 'atlas.monthly_ai_tokens',
+            datapoints: [{ timestamp: epochMs, value: 10 }],
+          },
+          {
+            meterId: 'files.storage_bytes',
+            datapoints: [{ timestamp: epochMs + 1000, value: 20 }],
+          },
+        ],
+      };
+
+      nock(mockBaseUrl)
+        .post(/\/api\/v1\/projects\/.*\/metering\/meters\/byids$/, request)
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      const result = await client.metering.retrieveByMeterIds(request);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].datapoints[0].timestamp).toEqual(
+        new Date(epochMs)
+      );
+      expect(result.items[1].datapoints[0].timestamp).toEqual(
+        new Date(epochMs + 1000)
+      );
+      expect(result.items[0].datapoints[0].value).toBe(10);
+      expect(result.items[1].datapoints[0].value).toBe(20);
+    });
+  });
+
+  describe('headers', () => {
+    test('should send cdf-version 20230101-alpha on metering requests', async () => {
+      const meterId = 'atlas.monthly_ai_tokens';
+      const mockedResponse = {
+        meterId,
+        datapoints: [],
+      };
+
+      nock(mockBaseUrl)
+        .get(
+          /\/api\/v1\/projects\/.*\/metering\/meters\/atlas\.monthly_ai_tokens$/
+        )
+        .matchHeader('cdf-version', '20230101-alpha')
+        .reply(200, mockedResponse);
+
+      await client.metering.retrieveByMeterId(meterId);
+    });
+  });
+});

--- a/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/meteringApi.unit.spec.ts
@@ -17,7 +17,7 @@ describe('Metering API unit tests', () => {
     client = setupMockableClient();
   });
 
-  describe('retrieveMeters', () => {
+  describe('listMeters', () => {
     test('should filter meters with prefix on meterId', async () => {
       const filter: MeterConsumptionFilterQuery = {
         filter: {
@@ -53,7 +53,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveMeters(filter);
+      const result = await client.metering.listMeters(filter);
       expect(result.items).toEqual(mockedResponse.items);
       expect(result.nextCursor).toBe('cursor-123');
       expect(result.items.length).toBe(2);
@@ -75,7 +75,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveMeters(filter);
+      const result = await client.metering.listMeters(filter);
       expect(result.items).toEqual(mockedResponse.items);
       expect(result.items.length).toBe(1);
     });
@@ -103,7 +103,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveMeters(filter);
+      const result = await client.metering.listMeters(filter);
       expect(result.items).toEqual([]);
       expect(result.items.length).toBe(0);
     });
@@ -143,7 +143,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveMeters(filter);
+      const result = await client.metering.listMeters(filter);
       expect(result.items[0].meterId).toBe('atlas.monthly_ai_tokens');
       expect(result.items[0].datapoints[0].timestamp).toEqual(
         new Date(epochMs)
@@ -176,7 +176,7 @@ describe('Metering API unit tests', () => {
         .matchHeader('cdf-version', '20230101-alpha')
         .reply(200, mockedResponse);
 
-      const result = await client.metering.retrieveMeters(filter);
+      const result = await client.metering.listMeters(filter);
       expect(result.items[0].meterId).toBe('functions.concurrent_executions');
       expect(result.items[0].datapoints[0].timestamp).toEqual(
         new Date(epochMs)

--- a/packages/alpha/src/api/limits/limitsApi.ts
+++ b/packages/alpha/src/api/limits/limitsApi.ts
@@ -1,8 +1,4 @@
-import {
-  BaseResourceAPI,
-  type CursorResponse,
-  type FilterQuery,
-} from '@cognite/sdk-core';
+import { BaseResourceAPI, type FilterQuery } from '@cognite/sdk-core';
 import type {
   CursorAndAsyncIterator,
   LimitAdvanceFilter,
@@ -10,9 +6,13 @@ import type {
 } from '../../types';
 
 export class LimitsAPI extends BaseResourceAPI<LimitsValue> {
-  private header = {
-    'cdf-version': '20230101-alpha',
-  };
+  protected get listGetUrl() {
+    return this.url('values');
+  }
+
+  protected get listPostUrl() {
+    return this.url('values/list');
+  }
 
   /**
    * [Retrieve a single limit by ID](https://api-docs.cognite.com/20230101-alpha/tag/Limits/operation/fetchLimitById)
@@ -22,9 +22,7 @@ export class LimitsAPI extends BaseResourceAPI<LimitsValue> {
    */
   public retrieveByLimitId = async (limitId: string): Promise<LimitsValue> => {
     const path = this.url(`values/${encodeURIComponent(limitId)}`);
-    const response = await this.get<LimitsValue>(path, {
-      headers: this.header,
-    });
+    const response = await this.get<LimitsValue>(path);
     return this.addToMapAndReturn(response.data, response);
   };
 
@@ -37,52 +35,18 @@ export class LimitsAPI extends BaseResourceAPI<LimitsValue> {
   public retrieveByAdvancedFilter = (
     filter?: LimitAdvanceFilter
   ): CursorAndAsyncIterator<LimitsValue> => {
-    const path = this.url('values/list');
-
-    const endpointCaller = async (query?: LimitAdvanceFilter) => {
-      const requestBody = query || filter || {};
-      const response = await this.post<CursorResponse<LimitsValue[]>>(path, {
-        data: requestBody,
-        headers: this.header,
-      });
-      return {
-        ...response,
-        data: {
-          items: response.data.items || [],
-          nextCursor: response.data?.nextCursor,
-        },
-      };
-    };
-
-    return this.listEndpoint(endpointCaller, filter);
+    return this.listEndpoint(this.callListEndpointWithPost, filter);
   };
 
   /**
    * [Retrieve a list of all limits](https://api-docs.cognite.com/20230101-alpha/tag/Limits/operation/listLimits)
    *
-   * @param queryparams - The query parameters to apply to the limits.
+   * @param query - The query parameters to apply to the limits.
    * @returns The list of limits.
    */
   public getAllLimits = (
-    queryparams?: FilterQuery
+    query?: FilterQuery
   ): CursorAndAsyncIterator<LimitsValue> => {
-    const path = this.url('values');
-
-    const endpointCaller = async (query?: FilterQuery) => {
-      const queryParams = query || queryparams || {};
-      const response = await this.get<CursorResponse<LimitsValue[]>>(path, {
-        params: queryParams,
-        headers: this.header,
-      });
-      return {
-        ...response,
-        data: {
-          items: response.data.items || [],
-          nextCursor: response.data?.nextCursor,
-        },
-      };
-    };
-
-    return this.listEndpoint(endpointCaller, queryparams);
+    return this.listEndpoint(this.callListEndpointWithGet, query);
   };
 }

--- a/packages/alpha/src/api/limits/limitsApi.ts
+++ b/packages/alpha/src/api/limits/limitsApi.ts
@@ -1,7 +1,7 @@
 import { BaseResourceAPI, type FilterQuery } from '@cognite/sdk-core';
 import type {
   CursorAndAsyncIterator,
-  LimitAdvanceFilter,
+  LimitsFilterQuery,
   LimitsValue,
 } from '../../types';
 
@@ -33,7 +33,7 @@ export class LimitsAPI extends BaseResourceAPI<LimitsValue> {
    * @returns The list of limits.
    */
   public retrieveByAdvancedFilter = (
-    filter?: LimitAdvanceFilter
+    filter?: LimitsFilterQuery
   ): CursorAndAsyncIterator<LimitsValue> => {
     return this.listEndpoint(this.callListEndpointWithPost, filter);
   };

--- a/packages/alpha/src/api/metering/meteringApi.ts
+++ b/packages/alpha/src/api/metering/meteringApi.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 Cognite AS
+
+import { BaseResourceAPI, type CursorResponse } from '@cognite/sdk-core';
+import type {
+  CursorAndAsyncIterator,
+  Datapoint,
+  MeterConsumptionAdvancedFilter,
+  MeterConsumptionByIdsRequest,
+  MeterConsumptionByIdsResponse,
+  MeterConsumptionListParams,
+  MeterConsumptionRangeParams,
+  MeterReading,
+} from '../../types';
+
+export class MeteringAPI extends BaseResourceAPI<MeterReading> {
+  private header = {
+    'cdf-version': '20230101-alpha',
+  };
+
+  /**
+   * @hidden
+   */
+  protected getDateProps() {
+    return this.pickDateProps<Datapoint>(
+      ['items', 'datapoints'],
+      ['timestamp']
+    );
+  }
+
+  /**
+   * [Retrieve consumption data by its id](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataById)
+   *
+   * Without `start` and `numberOfDatapoints`, returns meter metadata. With them (and optional `end`), returns averaged historical datapoints.
+   *
+   * @param meterId - Meter id, e.g. `atlas.monthly_ai_tokens`.
+   * @param params - Optional time range and bucket count (epoch ms).
+   */
+  public retrieveByMeterId = async (
+    meterId: string,
+    params?: MeterConsumptionRangeParams
+  ): Promise<MeterReading> => {
+    const path = this.url(`meters/${encodeURIComponent(meterId)}`);
+    const response = await this.get<MeterReading>(path, {
+      params,
+      headers: this.header,
+    });
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [List all meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/listConsumptionData)
+   *
+   * @param queryparams - Cursor, limit, and optional historical range (epoch ms).
+   */
+  public listMeters = (
+    queryparams?: MeterConsumptionListParams
+  ): CursorAndAsyncIterator<MeterReading> => {
+    const path = this.url('meters');
+
+    const endpointCaller = async (query?: MeterConsumptionListParams) => {
+      const queryParams = query || queryparams || {};
+      const response = await this.get<CursorResponse<MeterReading[]>>(path, {
+        params: queryParams,
+        headers: this.header,
+      });
+      return {
+        ...response,
+        data: {
+          items: response.data.items || [],
+          nextCursor: response.data?.nextCursor,
+        },
+      };
+    };
+
+    return this.listEndpoint(endpointCaller, queryparams);
+  };
+
+  /**
+   * [Filter meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/listConsumptionDataAdvanced)
+   *
+   * Only the `prefix` filter operator is supported (e.g. on `meterId`).
+   *
+   * @param filter - Filter, cursor, limit, and optional historical range.
+   */
+  public filterMeters = (
+    filter?: MeterConsumptionAdvancedFilter
+  ): CursorAndAsyncIterator<MeterReading> => {
+    const path = this.url('meters/list');
+
+    const endpointCaller = async (query?: MeterConsumptionAdvancedFilter) => {
+      const requestBody = query || filter || {};
+      const response = await this.post<CursorResponse<MeterReading[]>>(path, {
+        data: requestBody,
+        headers: this.header,
+      });
+      return {
+        ...response,
+        data: {
+          items: response.data.items || [],
+          nextCursor: response.data?.nextCursor,
+        },
+      };
+    };
+
+    return this.listEndpoint(endpointCaller, filter);
+  };
+
+  /**
+   * [Retrieve multiple consumption data by their ids](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataByIds)
+   *
+   * @param request - Meter ids and optional historical range (epoch ms).
+   */
+  public retrieveByMeterIds = async (
+    request: MeterConsumptionByIdsRequest
+  ): Promise<MeterConsumptionByIdsResponse> => {
+    const path = this.url('meters/byids');
+    const response = await this.post<MeterConsumptionByIdsResponse>(path, {
+      data: request,
+      headers: this.header,
+    });
+    return this.addToMapAndReturn(response.data, response);
+  };
+}

--- a/packages/alpha/src/api/metering/meteringApi.ts
+++ b/packages/alpha/src/api/metering/meteringApi.ts
@@ -1,27 +1,33 @@
 // Copyright 2026 Cognite AS
 
-import { BaseResourceAPI, type CursorResponse } from '@cognite/sdk-core';
+import { BaseResourceAPI, type ItemsResponse } from '@cognite/sdk-core';
 import type {
   CursorAndAsyncIterator,
-  Datapoint,
-  MeterConsumptionAdvancedFilter,
-  MeterConsumptionByIdsRequest,
-  MeterConsumptionByIdsResponse,
+  MeterConsumptionFilterQuery,
   MeterConsumptionListParams,
   MeterConsumptionRangeParams,
   MeterReading,
+  MeteringDatapoint,
 } from '../../types';
 
 export class MeteringAPI extends BaseResourceAPI<MeterReading> {
-  private header = {
-    'cdf-version': '20230101-alpha',
-  };
+  protected get listGetUrl() {
+    return this.url('meters');
+  }
+
+  protected get listPostUrl() {
+    return this.url('meters/list');
+  }
+
+  protected get byIdsUrl() {
+    return this.url('meters/byids');
+  }
 
   /**
    * @hidden
    */
   protected getDateProps() {
-    return this.pickDateProps<Datapoint>(
+    return this.pickDateProps<MeteringDatapoint>(
       ['items', 'datapoints'],
       ['timestamp']
     );
@@ -30,19 +36,20 @@ export class MeteringAPI extends BaseResourceAPI<MeterReading> {
   /**
    * [Retrieve consumption data by its id](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataById)
    *
+   * Returns a **meter reading** for the meter (consumption snapshot). Naming uses “consumption” to match the Metering API operations (`fetchConsumptionData*`).
+   *
    * Without `start` and `numberOfDatapoints`, returns meter metadata. With them (and optional `end`), returns averaged historical datapoints.
    *
    * @param meterId - Meter id, e.g. `atlas.monthly_ai_tokens`.
    * @param params - Optional time range and bucket count (epoch ms).
    */
-  public retrieveByMeterId = async (
+  public retrieveConsumptionData = async (
     meterId: string,
     params?: MeterConsumptionRangeParams
   ): Promise<MeterReading> => {
     const path = this.url(`meters/${encodeURIComponent(meterId)}`);
     const response = await this.get<MeterReading>(path, {
       params,
-      headers: this.header,
     });
     return this.addToMapAndReturn(response.data, response);
   };
@@ -50,29 +57,12 @@ export class MeteringAPI extends BaseResourceAPI<MeterReading> {
   /**
    * [List all meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/listConsumptionData)
    *
-   * @param queryparams - Cursor, limit, and optional historical range (epoch ms).
+   * @param query - Cursor, limit, and optional historical range (epoch ms).
    */
   public listMeters = (
-    queryparams?: MeterConsumptionListParams
+    query?: MeterConsumptionListParams
   ): CursorAndAsyncIterator<MeterReading> => {
-    const path = this.url('meters');
-
-    const endpointCaller = async (query?: MeterConsumptionListParams) => {
-      const queryParams = query || queryparams || {};
-      const response = await this.get<CursorResponse<MeterReading[]>>(path, {
-        params: queryParams,
-        headers: this.header,
-      });
-      return {
-        ...response,
-        data: {
-          items: response.data.items || [],
-          nextCursor: response.data?.nextCursor,
-        },
-      };
-    };
-
-    return this.listEndpoint(endpointCaller, queryparams);
+    return this.listEndpoint(this.callListEndpointWithGet, query);
   };
 
   /**
@@ -80,44 +70,34 @@ export class MeteringAPI extends BaseResourceAPI<MeterReading> {
    *
    * Only the `prefix` filter operator is supported (e.g. on `meterId`).
    *
-   * @param filter - Filter, cursor, limit, and optional historical range.
+   * @param query - Filter, cursor, limit, and optional historical range.
    */
   public filterMeters = (
-    filter?: MeterConsumptionAdvancedFilter
+    query?: MeterConsumptionFilterQuery
   ): CursorAndAsyncIterator<MeterReading> => {
-    const path = this.url('meters/list');
-
-    const endpointCaller = async (query?: MeterConsumptionAdvancedFilter) => {
-      const requestBody = query || filter || {};
-      const response = await this.post<CursorResponse<MeterReading[]>>(path, {
-        data: requestBody,
-        headers: this.header,
-      });
-      return {
-        ...response,
-        data: {
-          items: response.data.items || [],
-          nextCursor: response.data?.nextCursor,
-        },
-      };
-    };
-
-    return this.listEndpoint(endpointCaller, filter);
+    return this.listEndpoint(this.callListEndpointWithPost, query);
   };
 
   /**
-   * [Retrieve multiple consumption data by their ids](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataByIds)
+   * [Retrieve consumption data for multiple meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataByIds)
    *
-   * @param request - Meter ids and optional historical range (epoch ms).
+   * Response shape matches the API: `{ items: MeterReading[] }`.
+   *
+   * @param meterIds - Meter ids to fetch.
+   * @param params - Optional time range and bucket count (epoch ms).
    */
-  public retrieveByMeterIds = async (
-    request: MeterConsumptionByIdsRequest
-  ): Promise<MeterConsumptionByIdsResponse> => {
-    const path = this.url('meters/byids');
-    const response = await this.post<MeterConsumptionByIdsResponse>(path, {
-      data: request,
-      headers: this.header,
-    });
-    return this.addToMapAndReturn(response.data, response);
+  public retrieveConsumptionDataByIds = async (
+    meterIds: string[],
+    params?: MeterConsumptionRangeParams
+  ): Promise<ItemsResponse<MeterReading>> => {
+    const items = await this.retrieveEndpoint<
+      MeterConsumptionRangeParams,
+      { meterId: string }
+    >(
+      meterIds.map((meterId) => ({ meterId })),
+      params,
+      this.byIdsUrl
+    );
+    return { items };
   };
 }

--- a/packages/alpha/src/api/metering/meteringApi.ts
+++ b/packages/alpha/src/api/metering/meteringApi.ts
@@ -4,17 +4,12 @@ import { BaseResourceAPI, type ItemsResponse } from '@cognite/sdk-core';
 import type {
   CursorAndAsyncIterator,
   MeterConsumptionFilterQuery,
-  MeterConsumptionListParams,
   MeterConsumptionRangeParams,
   MeterReading,
   MeteringDatapoint,
 } from '../../types';
 
 export class MeteringAPI extends BaseResourceAPI<MeterReading> {
-  protected get listGetUrl() {
-    return this.url('meters');
-  }
-
   protected get listPostUrl() {
     return this.url('meters/list');
   }
@@ -34,45 +29,13 @@ export class MeteringAPI extends BaseResourceAPI<MeterReading> {
   }
 
   /**
-   * [Retrieve consumption data by its id](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataById)
-   *
-   * Returns a **meter reading** for the meter (consumption snapshot). Naming uses “consumption” to match the Metering API operations (`fetchConsumptionData*`).
-   *
-   * Without `start` and `numberOfDatapoints`, returns meter metadata. With them (and optional `end`), returns averaged historical datapoints.
-   *
-   * @param meterId - Meter id, e.g. `atlas.monthly_ai_tokens`.
-   * @param params - Optional time range and bucket count (epoch ms).
-   */
-  public retrieveConsumptionData = async (
-    meterId: string,
-    params?: MeterConsumptionRangeParams
-  ): Promise<MeterReading> => {
-    const path = this.url(`meters/${encodeURIComponent(meterId)}`);
-    const response = await this.get<MeterReading>(path, {
-      params,
-    });
-    return this.addToMapAndReturn(response.data, response);
-  };
-
-  /**
-   * [List all meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/listConsumptionData)
-   *
-   * @param query - Cursor, limit, and optional historical range (epoch ms).
-   */
-  public listMeters = (
-    query?: MeterConsumptionListParams
-  ): CursorAndAsyncIterator<MeterReading> => {
-    return this.listEndpoint(this.callListEndpointWithGet, query);
-  };
-
-  /**
    * [Filter meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/listConsumptionDataAdvanced)
    *
    * Only the `prefix` filter operator is supported (e.g. on `meterId`).
-   *
+   * This method would be used to list all meters or filter meters by prefix.
    * @param query - Filter, cursor, limit, and optional historical range.
    */
-  public filterMeters = (
+  public retrieveMeters = (
     query?: MeterConsumptionFilterQuery
   ): CursorAndAsyncIterator<MeterReading> => {
     return this.listEndpoint(this.callListEndpointWithPost, query);
@@ -82,11 +45,11 @@ export class MeteringAPI extends BaseResourceAPI<MeterReading> {
    * [Retrieve consumption data for multiple meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataByIds)
    *
    * Response shape matches the API: `{ items: MeterReading[] }`.
-   *
+   * This method would be used to retrieve consumption data for single or multiple meters.
    * @param meterIds - Meter ids to fetch.
    * @param params - Optional time range and bucket count (epoch ms).
    */
-  public retrieveConsumptionDataByIds = async (
+  public retrieveConsumptionData = async (
     meterIds: string[],
     params?: MeterConsumptionRangeParams
   ): Promise<ItemsResponse<MeterReading>> => {

--- a/packages/alpha/src/api/metering/meteringApi.ts
+++ b/packages/alpha/src/api/metering/meteringApi.ts
@@ -31,11 +31,10 @@ export class MeteringAPI extends BaseResourceAPI<MeterReading> {
   /**
    * [Filter meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/listConsumptionDataAdvanced)
    *
-   * Only the `prefix` filter operator is supported (e.g. on `meterId`).
-   * This method would be used to list all meters or filter meters by prefix.
-   * @param query - Filter, cursor, limit, and optional historical range.
+   * List meters matching the filter
+   * @param query - Filter, cursor, limit, and optional time range.
    */
-  public retrieveMeters = (
+  public listMeters = (
     query?: MeterConsumptionFilterQuery
   ): CursorAndAsyncIterator<MeterReading> => {
     return this.listEndpoint(this.callListEndpointWithPost, query);
@@ -45,7 +44,6 @@ export class MeteringAPI extends BaseResourceAPI<MeterReading> {
    * [Retrieve consumption data for multiple meters](https://api-docs.cognite.com/20230101-alpha/tag/Metering/operation/fetchConsumptionDataByIds)
    *
    * Response shape matches the API: `{ items: MeterReading[] }`.
-   * This method would be used to retrieve consumption data for single or multiple meters.
    * @param meterIds - Meter ids to fetch.
    * @param params - Optional time range and bucket count (epoch ms).
    */

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -26,7 +26,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
   protected initAPIs() {
     super.initAPIs();
 
-    this.httpClient.setDefaultHeader('cdf-version', 'alpha');
+    this.httpClient.setDefaultHeader('cdf-version', '20230101-alpha');
 
     this.simulatorsApi = this.apiFactory(SimulatorsAPI, 'simulators');
     this.limitsApi = this.apiFactory(LimitsAPI, 'limits');

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -3,14 +3,20 @@ import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
 import { accessApi } from '@cognite/sdk-core';
 import { version } from '../package.json';
 import { LimitsAPI } from './api/limits/limitsApi';
+import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
 
 export default class CogniteClientAlpha extends CogniteClientStable {
   private simulatorsApi?: SimulatorsAPI;
   private limitsApi?: LimitsAPI;
+  private meteringApi?: MeteringAPI;
 
   public get limits() {
     return accessApi(this.limitsApi);
+  }
+
+  public get metering() {
+    return accessApi(this.meteringApi);
   }
 
   public get simulators() {
@@ -24,6 +30,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
 
     this.simulatorsApi = this.apiFactory(SimulatorsAPI, 'simulators');
     this.limitsApi = this.apiFactory(LimitsAPI, 'limits');
+    this.meteringApi = this.apiFactory(MeteringAPI, 'metering');
   }
 
   protected get version() {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -621,7 +621,7 @@ export interface LimitsValue {
   value: number;
 }
 
-export interface MeteringLimitsPrefixFilter {
+export interface MeteringLimitsFilter {
   prefix?: {
     property: string[];
     value: string;
@@ -629,7 +629,7 @@ export interface MeteringLimitsPrefixFilter {
 }
 
 export interface LimitsFilterQuery extends FilterQuery {
-  filter?: MeteringLimitsPrefixFilter;
+  filter?: MeteringLimitsFilter;
 }
 
 export interface MeteringDatapoint {
@@ -653,5 +653,5 @@ export interface MeterConsumptionRangeParams {
 export interface MeterConsumptionFilterQuery
   extends FilterQuery,
     MeterConsumptionRangeParams {
-  filter?: MeteringLimitsPrefixFilter;
+  filter?: MeteringLimitsFilter;
 }

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -628,7 +628,7 @@ export interface MeteringLimitsPrefixFilter {
   };
 }
 
-export interface LimitAdvanceFilter extends FilterQuery {
+export interface LimitsFilterQuery extends FilterQuery {
   filter?: MeteringLimitsPrefixFilter;
 }
 
@@ -648,10 +648,6 @@ export interface MeterConsumptionRangeParams {
   end?: number;
   numberOfDatapoints?: number;
 }
-
-/** GET /metering/meters — cursor, limit, and optional historical range. */
-export type MeterConsumptionListParams = FilterQuery &
-  MeterConsumptionRangeParams;
 
 /** POST /metering/meters/list — cursor, limit, optional range, and prefix filter on `meterId`. */
 export interface MeterConsumptionFilterQuery

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -631,3 +631,41 @@ export interface FilterObject {
     value: string;
   };
 }
+
+export interface Datapoint {
+  timestamp: Date;
+  value: number;
+}
+
+export interface MeterReading {
+  meterId: string;
+  datapoints: Datapoint[];
+}
+
+/** Epoch ms range + averaged bucket count (see Metering API). */
+export interface MeterConsumptionRangeParams {
+  start?: number;
+  end?: number;
+  numberOfDatapoints?: number;
+}
+
+/** GET /metering/meters — cursor, limit, and optional historical range. */
+export type MeterConsumptionListParams = FilterQuery &
+  MeterConsumptionRangeParams;
+
+/** POST /metering/meters/list — prefix filter on `meterId` only. */
+export interface MeterConsumptionAdvancedFilter
+  extends FilterQuery,
+    MeterConsumptionRangeParams {
+  filter?: FilterObject;
+}
+
+/** POST /metering/meters/byids request body. */
+export interface MeterConsumptionByIdsRequest
+  extends MeterConsumptionRangeParams {
+  items: { meterId: string }[];
+}
+
+export interface MeterConsumptionByIdsResponse {
+  items: MeterReading[];
+}

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -621,25 +621,25 @@ export interface LimitsValue {
   value: number;
 }
 
-export interface LimitAdvanceFilter extends FilterQuery {
-  filter?: FilterObject;
-}
-
-export interface FilterObject {
+export interface MeteringLimitsPrefixFilter {
   prefix?: {
     property: string[];
     value: string;
   };
 }
 
-export interface Datapoint {
+export interface LimitAdvanceFilter extends FilterQuery {
+  filter?: MeteringLimitsPrefixFilter;
+}
+
+export interface MeteringDatapoint {
   timestamp: Date;
   value: number;
 }
 
 export interface MeterReading {
   meterId: string;
-  datapoints: Datapoint[];
+  datapoints: MeteringDatapoint[];
 }
 
 /** Epoch ms range + averaged bucket count (see Metering API). */
@@ -653,19 +653,9 @@ export interface MeterConsumptionRangeParams {
 export type MeterConsumptionListParams = FilterQuery &
   MeterConsumptionRangeParams;
 
-/** POST /metering/meters/list — prefix filter on `meterId` only. */
-export interface MeterConsumptionAdvancedFilter
+/** POST /metering/meters/list — cursor, limit, optional range, and prefix filter on `meterId`. */
+export interface MeterConsumptionFilterQuery
   extends FilterQuery,
     MeterConsumptionRangeParams {
-  filter?: FilterObject;
-}
-
-/** POST /metering/meters/byids request body. */
-export interface MeterConsumptionByIdsRequest
-  extends MeterConsumptionRangeParams {
-  items: { meterId: string }[];
-}
-
-export interface MeterConsumptionByIdsResponse {
-  items: MeterReading[];
+  filter?: MeteringLimitsPrefixFilter;
 }


### PR DESCRIPTION
MUT-1430: This PR adds SDK support for the Metering service API in the alpha package with four endpoints:

`retrieveMeters` — Filter meters with advanced filtering (POST /metering/meters/list). Only the prefix operator is supported (e.g. on meterId). This could be use for fetching all the meterIds when filter attribute is not provided.
`retrieveConsumptionData` — Fetch multiple meters by id (POST /metering/meters/byids). Takes meterIds[] and optional range param and builds the items body which uses retrieveEndpoint for chunked requests and returns { items: MeterReading[] }, also used for fetching ConsumptionData for single meterId
filterMeters use listEndpoint for pagination (CursorAndAsyncIterator) and metadata handling consistent with other alpha resources.

This change also refactors the alpha Limits client: limitsApi.ts follows the same BaseResourceAPI pattern as other resources (custom listGetUrl / listPostUrl for /limits/values and /limits/values/list), and the public types (LimitsValue, LimitAdvanceFilter, MeteringLimitsPrefixFilter) are aligned with the alpha Limits API docs.

Changes:

- CogniteClientAlpha sets cdf-version: 20230101-alpha as a default header on the HTTP client in initAPIs (applies to alpha APIs using that client, not only Metering).
- getDateProps on MeteringAPI — parse timestamp on MeteringDatapoint under items / datapoints so responses match typed Date fields.
- TypeScript types: MeteringDatapoint, MeterReading, MeterConsumptionRangeParams, MeterConsumptionListParams, MeterConsumptionFilterQuery and shared MeteringLimitsPrefixFilter with Limits where the filter shape matches.
- Integrate MeteringAPI and LimitsAPI into CogniteClientAlpha as client.metering and client.limits.
- Unit tests: meteringApi.unit.spec.ts (Metering), limitsApi.unit.spec.ts (Limits).
- Limits API: model as BaseResourceAPI<LimitsValue> with listGetUrl → values, listPostUrl → values/list and retrieveByLimitId (GET …/values/{limitId}), getAllLimits (GET …/values + listEndpoint), retrieveByAdvancedFilter (POST …/values/list + listEndpoint).
- Introduce / align LimitsValue, LimitAdvanceFilter, and shared MeteringLimitsPrefixFilter for the advanced list filter shape (prefix on property paths).