### PR TITLE
chore: add developer enablement (dune) team as default code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @cognitedata/javascript-sdk-maintainers
+* @cognitedata/javascript-sdk-maintainers @cognitedata/dune
 
 /packages/alpha @cognitedata/simulator-integration
 /packages/beta @cognitedata/simulator-integration


### PR DESCRIPTION
This change designates the Developer Enablement (Dune) team as a default code owner.