### PR TITLE
feat(alpha): add 'queued' status to simulation runs

### DIFF
--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -187,9 +187,10 @@ export interface SimulationRunCreate {
   queue?: boolean;
 }
 
-export type SimulationRunStatus = 'ready' | 'running' | 'success' | 'failure';
+export type SimulationRunStatus = 'queued' | 'ready' | 'running' | 'success' | 'failure';
 
 export const SimulationRunStatus = {
+  queued: 'queued' as SimulationRunStatus,
   ready: 'ready' as SimulationRunStatus,
   running: 'running' as SimulationRunStatus,
   success: 'success' as SimulationRunStatus,

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -187,7 +187,12 @@ export interface SimulationRunCreate {
   queue?: boolean;
 }
 
-export type SimulationRunStatus = 'queued' | 'ready' | 'running' | 'success' | 'failure';
+export type SimulationRunStatus =
+  | 'queued'
+  | 'ready'
+  | 'running'
+  | 'success'
+  | 'failure';
 
 export const SimulationRunStatus = {
   queued: 'queued' as SimulationRunStatus,


### PR DESCRIPTION
As a part of simulation run load balancer, `queued` status is introduced. When this feature is enabled simulation runs will be created in `queued` status when disabled `ready` status.

- Extends SimulationRunStatus with a new status value `queued`

[POFSP-1540](https://cognitedata.atlassian.net/browse/POFSP-1540)

[POFSP-1540]: https://cognitedata.atlassian.net/browse/POFSP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ