### PR TITLE
feat(timeseries): add support for data point subscriptions

### DIFF
--- a/packages/stable/src/__tests__/api/dataPointSubscriptions.int.spec.ts
+++ b/packages/stable/src/__tests__/api/dataPointSubscriptions.int.spec.ts
@@ -1,0 +1,156 @@
+// Copyright 2026 Cognite AS
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type CogniteClient from '../../cogniteClient';
+import {
+  randomInt,
+  runTestWithRetryWhenFailing,
+  setupLoggedInClient,
+} from '../testUtils';
+
+describe('Data point subscriptions integration test', () => {
+  let client: CogniteClient;
+  let timeseriesExternalId: string;
+  let timeseriesId: number;
+  const subscriptionExplicitExtId = `sdk_dp_sub_explicit_${randomInt()}`;
+  const subscriptionFilterExtId = `sdk_dp_sub_filter_${randomInt()}`;
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+    timeseriesExternalId = `sdk_dp_sub_ts_${randomInt()}`;
+    const [ts] = await client.timeseries.create([
+      {
+        name: 'sdk_datapoint_subscription_ts',
+        externalId: timeseriesExternalId,
+        isString: false,
+      },
+    ]);
+    timeseriesId = ts.id;
+  }, 25_000);
+
+  afterAll(async () => {
+    await client.timeseries.subscriptions
+      .delete({
+        items: [{ externalId: subscriptionExplicitExtId }],
+        ignoreUnknownIds: true,
+      })
+      .catch(() => undefined);
+    await client.timeseries.subscriptions
+      .delete({
+        items: [{ externalId: subscriptionFilterExtId }],
+        ignoreUnknownIds: true,
+      })
+      .catch(() => undefined);
+    await client.timeseries.delete([{ id: timeseriesId }]);
+  });
+
+  test('create, list, retrieve, filter create, update, members, data, delete', async () => {
+    const [createdExplicit] = await client.timeseries.subscriptions.create([
+      {
+        externalId: subscriptionExplicitExtId,
+        partitionCount: 1,
+        timeSeriesIds: [timeseriesExternalId],
+      },
+    ]);
+    expect(createdExplicit.externalId).toBe(subscriptionExplicitExtId);
+    expect(createdExplicit.partitionCount).toBe(1);
+    expect(createdExplicit.createdTime).toBeInstanceOf(Date);
+
+    const listed = await client.timeseries.subscriptions.list({ limit: 100 });
+    expect(
+      listed.items.some((s) => s.externalId === subscriptionExplicitExtId)
+    ).toBe(true);
+
+    const [retrieved] = await client.timeseries.subscriptions.retrieve({
+      items: [{ externalId: subscriptionExplicitExtId }],
+    });
+    expect(retrieved.externalId).toBe(subscriptionExplicitExtId);
+
+    const [createdFilter] = await client.timeseries.subscriptions.create([
+      {
+        externalId: subscriptionFilterExtId,
+        partitionCount: 1,
+        filter: {
+          equals: {
+            property: ['externalId'],
+            value: timeseriesExternalId,
+          },
+        },
+      },
+    ]);
+    expect(createdFilter.externalId).toBe(subscriptionFilterExtId);
+    expect(createdFilter.filter).toBeDefined();
+
+    const [updated] = await client.timeseries.subscriptions.update([
+      {
+        externalId: subscriptionExplicitExtId,
+        update: {
+          name: { set: `updated_${randomInt()}` },
+        },
+      },
+    ]);
+    expect(updated.name).toBeDefined();
+
+    const members = await client.timeseries.subscriptions.listMembers({
+      externalId: subscriptionExplicitExtId,
+      limit: 100,
+    });
+    expect(
+      members.items.some((m) => m.externalId === timeseriesExternalId)
+    ).toBe(true);
+
+    const initial = await client.timeseries.subscriptions.listData({
+      externalId: subscriptionExplicitExtId,
+      partitions: [{ index: 0 }],
+      limit: 10,
+      initializeCursors: 'now',
+      pollTimeoutSeconds: 0,
+    });
+    expect(initial.hasNext).toBeDefined();
+    expect(Array.isArray(initial.updates)).toBe(true);
+    expect(initial.partitions.length).toBeGreaterThanOrEqual(1);
+    expect(initial.partitions[0].nextCursor).toBeDefined();
+
+    const datapointTimestamp = Date.now();
+    const datapointValue = randomInt();
+    await client.datapoints.insert([
+      {
+        externalId: timeseriesExternalId,
+        datapoints: [{ timestamp: datapointTimestamp, value: datapointValue }],
+      },
+    ]);
+
+    let partitions = initial.partitions.map(({ index, nextCursor }) => ({
+      index,
+      cursor: nextCursor,
+    }));
+    let observedValue: number | string | undefined;
+    await runTestWithRetryWhenFailing(async () => {
+      const next = await client.timeseries.subscriptions.listData({
+        externalId: subscriptionExplicitExtId,
+        partitions,
+        limit: 100,
+        pollTimeoutSeconds: 5,
+      });
+      partitions = next.partitions.map(({ index, nextCursor }) => ({
+        index,
+        cursor: nextCursor,
+      }));
+      for (const update of next.updates) {
+        for (const upsert of update.upserts ?? []) {
+          if (
+            upsert.timestamp instanceof Date &&
+            upsert.timestamp.getTime() === datapointTimestamp
+          ) {
+            observedValue = upsert.value;
+          }
+        }
+      }
+      expect(observedValue).toBe(datapointValue);
+    });
+
+    await client.timeseries.subscriptions.delete({
+      items: [{ externalId: subscriptionExplicitExtId }],
+    });
+  });
+});

--- a/packages/stable/src/__tests__/api/dataPointSubscriptions.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/dataPointSubscriptions.unit.spec.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 Cognite AS
+
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { CogniteClient } from '../..';
+import { mockBaseUrl, setupMockableClient } from '../testUtils';
+
+const CHUNK_SIZE = 1000;
+const ITEM_COUNT = 1500;
+
+const subscriptionIds = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+  externalId: `sub_${i}`,
+}));
+
+function subscriptionItems(offset: number, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    externalId: `sub_${offset + i}`,
+    partitionCount: 1,
+    createdTime: new Date(),
+    lastUpdatedTime: new Date(),
+  }));
+}
+
+function mockChunkedPost(
+  path: RegExp,
+  reply: (offset: number, count: number) => object,
+  matchBody?: (length: number) => (body: { items: unknown[] }) => boolean
+) {
+  const match =
+    matchBody ??
+    ((length: number) => (body: { items: unknown[] }) => body.items.length === length);
+  return [
+    nock(mockBaseUrl)
+      .post(path, match(CHUNK_SIZE))
+      .once()
+      .reply(200, reply(0, CHUNK_SIZE)),
+    nock(mockBaseUrl)
+      .post(path, match(ITEM_COUNT - CHUNK_SIZE))
+      .once()
+      .reply(200, reply(CHUNK_SIZE, ITEM_COUNT - CHUNK_SIZE)),
+  ];
+}
+
+describe('Data point subscriptions unit test', () => {
+  let client: CogniteClient;
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test.each([
+    {
+      label: 'create',
+      path: /\/timeseries\/subscriptions$/,
+      run: () =>
+        client.timeseries.subscriptions.create(
+          subscriptionIds.map(({ externalId }) => ({
+            externalId,
+            partitionCount: 1,
+            timeSeriesIds: ['ts_1'],
+          }))
+        ),
+      reply: (offset: number, count: number) => ({
+        items: subscriptionItems(offset, count),
+      }),
+    },
+    {
+      label: 'retrieve',
+      path: /\/timeseries\/subscriptions\/byids/,
+      run: () =>
+        client.timeseries.subscriptions.retrieve({ items: subscriptionIds }),
+      reply: (offset: number, count: number) => ({
+        items: subscriptionItems(offset, count),
+      }),
+    },
+    {
+      label: 'update',
+      path: /\/timeseries\/subscriptions\/update/,
+      run: () =>
+        client.timeseries.subscriptions.update(
+          subscriptionIds.map(({ externalId }) => ({
+            externalId,
+            update: { name: { set: externalId } },
+          }))
+        ),
+      reply: (offset: number, count: number) => ({
+        items: subscriptionItems(offset, count),
+      }),
+    },
+    {
+      label: 'delete',
+      path: /\/timeseries\/subscriptions\/delete/,
+      run: () =>
+        client.timeseries.subscriptions.delete({
+          items: subscriptionIds,
+          ignoreUnknownIds: true,
+        }),
+      reply: () => ({}),
+      matchBody: (length: number) => (body: { items: unknown[]; ignoreUnknownIds?: boolean }) =>
+        body.items.length === length && body.ignoreUnknownIds === true,
+    },
+  ])('$label sends two chunked requests (1000 + 500 items)', async ({
+    path,
+    run,
+    reply,
+    matchBody,
+  }) => {
+    const scopes = mockChunkedPost(path, reply, matchBody);
+    const result = await run();
+    expect(scopes.every((scope) => scope.isDone())).toBe(true);
+    if (result) {
+      expect(result).toHaveLength(ITEM_COUNT);
+    }
+  });
+});

--- a/packages/stable/src/__tests__/api/dataPointSubscriptions.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/dataPointSubscriptions.unit.spec.ts
@@ -28,7 +28,8 @@ function mockChunkedPost(
 ) {
   const match =
     matchBody ??
-    ((length: number) => (body: { items: unknown[] }) => body.items.length === length);
+    ((length: number) => (body: { items: unknown[] }) =>
+      body.items.length === length);
   return [
     nock(mockBaseUrl)
       .post(path, match(CHUNK_SIZE))
@@ -97,20 +98,20 @@ describe('Data point subscriptions unit test', () => {
           ignoreUnknownIds: true,
         }),
       reply: () => ({}),
-      matchBody: (length: number) => (body: { items: unknown[]; ignoreUnknownIds?: boolean }) =>
-        body.items.length === length && body.ignoreUnknownIds === true,
+      matchBody:
+        (length: number) =>
+        (body: { items: unknown[]; ignoreUnknownIds?: boolean }) =>
+          body.items.length === length && body.ignoreUnknownIds === true,
     },
-  ])('$label sends two chunked requests (1000 + 500 items)', async ({
-    path,
-    run,
-    reply,
-    matchBody,
-  }) => {
-    const scopes = mockChunkedPost(path, reply, matchBody);
-    const result = await run();
-    expect(scopes.every((scope) => scope.isDone())).toBe(true);
-    if (result) {
-      expect(result).toHaveLength(ITEM_COUNT);
+  ])(
+    '$label sends two chunked requests (1000 + 500 items)',
+    async ({ path, run, reply, matchBody }) => {
+      const scopes = mockChunkedPost(path, reply, matchBody);
+      const result = await run();
+      expect(scopes.every((scope) => scope.isDone())).toBe(true);
+      if (result) {
+        expect(result).toHaveLength(ITEM_COUNT);
+      }
     }
-  });
+  );
 });

--- a/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
@@ -16,21 +16,6 @@ import type {
   DataPointSubscriptionsDeleteQuery,
 } from './types';
 
-function parseSubscriptionListDataDates(
-  data: DataPointSubscriptionListDataResponse
-): DataPointSubscriptionListDataResponse {
-  return cloneDeepWith(data, (value, key) => {
-    if (
-      (key === 'timestamp' ||
-        key === 'inclusiveBegin' ||
-        key === 'exclusiveEnd') &&
-      (typeof value === 'number' || typeof value === 'string')
-    ) {
-      return new Date(value);
-    }
-  });
-}
-
 export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscription> {
   /**
    * @hidden
@@ -48,19 +33,10 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
    * ]);
    * ```
    */
-  public create = async (
+  public create = (
     items: DataPointSubscriptionCreate[]
   ): Promise<DataPointSubscription[]> => {
-    const responses = await Promise.all(
-      items.map((item) =>
-        this.post<{ items: DataPointSubscription[] }>(this.url(), {
-          data: { items: [item] },
-        })
-      )
-    );
-    return responses.flatMap((response) =>
-      this.addToMapAndReturn(response.data.items, response)
-    );
+    return this.createEndpoint(items, this.url());
   };
 
   /**
@@ -89,19 +65,12 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
    * });
    * ```
    */
-  public retrieve = async (
+  public retrieve = (
     query: DataPointSubscriptionByIdsQuery
   ): Promise<DataPointSubscription[]> => {
-    const { items, ...rest } = query;
-    const responses = await Promise.all(
-      items.map((item) =>
-        this.post<{ items: DataPointSubscription[] }>(this.url('byids'), {
-          data: { items: [item], ...rest },
-        })
-      )
-    );
-    return responses.flatMap((response) =>
-      this.addToMapAndReturn(response.data.items, response)
+    const { items, ...params } = query;
+    return this.callEndpointWithMergeAndTransform(items, (request) =>
+      this.callRetrieveEndpoint(request, this.url('byids'), params)
     );
   };
 
@@ -114,19 +83,10 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
    * ]);
    * ```
    */
-  public update = async (
+  public update = (
     items: DataPointSubscriptionUpdate[]
   ): Promise<DataPointSubscription[]> => {
-    const responses = await Promise.all(
-      items.map((item) =>
-        this.post<{ items: DataPointSubscription[] }>(this.url('update'), {
-          data: { items: [item] },
-        })
-      )
-    );
-    return responses.flatMap((response) =>
-      this.addToMapAndReturn(response.data.items, response)
-    );
+    return this.updateEndpoint(items, this.url('update'));
   };
 
   /**
@@ -142,13 +102,7 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
     query: DataPointSubscriptionsDeleteQuery
   ): Promise<void> => {
     const { items, ignoreUnknownIds } = query;
-    await Promise.all(
-      items.map((item) =>
-        this.post(this.url('delete'), {
-          data: { items: [item], ignoreUnknownIds },
-        })
-      )
-    );
+    await this.callDeleteEndpoint(items, { ignoreUnknownIds }, this.url('delete'));
   };
 
   /**
@@ -195,4 +149,19 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
     const parsed = parseSubscriptionListDataDates(response.data);
     return this.addToMapAndReturn(parsed, response);
   };
+}
+
+function parseSubscriptionListDataDates(
+  data: DataPointSubscriptionListDataResponse
+): DataPointSubscriptionListDataResponse {
+  return cloneDeepWith(data, (value, key) => {
+    if (
+      (key === 'timestamp' ||
+        key === 'inclusiveBegin' ||
+        key === 'exclusiveEnd') &&
+      (typeof value === 'number' || typeof value === 'string')
+    ) {
+      return new Date(value);
+    }
+  });
 }

--- a/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
@@ -102,7 +102,11 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
     query: DataPointSubscriptionsDeleteQuery
   ): Promise<void> => {
     const { items, ignoreUnknownIds } = query;
-    await this.callDeleteEndpoint(items, { ignoreUnknownIds }, this.url('delete'));
+    await this.callDeleteEndpoint(
+      items,
+      { ignoreUnknownIds },
+      this.url('delete')
+    );
   };
 
   /**

--- a/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
@@ -1,6 +1,10 @@
 // Copyright 2026 Cognite AS
 
-import { BaseResourceAPI } from '@cognite/sdk-core';
+import {
+  BaseResourceAPI,
+  type CursorAndAsyncIterator,
+  type CursorResponse,
+} from '@cognite/sdk-core';
 import cloneDeepWith from 'lodash/cloneDeepWith';
 import type {
   DataPointSubscription,
@@ -9,9 +13,8 @@ import type {
   DataPointSubscriptionListDataQuery,
   DataPointSubscriptionListDataResponse,
   DataPointSubscriptionListQuery,
-  DataPointSubscriptionListResponse,
+  DataPointSubscriptionMember,
   DataPointSubscriptionMembersListQuery,
-  DataPointSubscriptionMembersListResponse,
   DataPointSubscriptionUpdate,
   DataPointSubscriptionsDeleteQuery,
 } from './types';
@@ -46,14 +49,10 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
    * const subscriptions = await client.timeseries.subscriptions.list({ limit: 100 });
    * ```
    */
-  public list = async (
+  public list = (
     query?: DataPointSubscriptionListQuery
-  ): Promise<DataPointSubscriptionListResponse> => {
-    const response = await this.get<DataPointSubscriptionListResponse>(
-      this.url(),
-      { params: query }
-    );
-    return this.addToMapAndReturn(response.data, response);
+  ): CursorAndAsyncIterator<DataPointSubscription> => {
+    return super.listEndpoint(this.callListEndpointWithGet, query);
   };
 
   /**
@@ -119,14 +118,19 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
    * });
    * ```
    */
-  public listMembers = async (
-    query: DataPointSubscriptionMembersListQuery
-  ): Promise<DataPointSubscriptionMembersListResponse> => {
-    const response = await this.get<DataPointSubscriptionMembersListResponse>(
+  private callListMembersEndpointWithGet = async (
+    scope?: DataPointSubscriptionMembersListQuery
+  ) => {
+    return this.get<CursorResponse<DataPointSubscriptionMember[]>>(
       this.url('members'),
-      { params: query }
+      { params: scope }
     );
-    return this.addToMapAndReturn(response.data, response);
+  };
+
+  public listMembers = (
+    query: DataPointSubscriptionMembersListQuery
+  ): CursorAndAsyncIterator<DataPointSubscriptionMember> => {
+    return this.cursorBasedEndpoint(this.callListMembersEndpointWithGet, query);
   };
 
   /**

--- a/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
@@ -1,0 +1,164 @@
+// Copyright 2026 Cognite AS
+
+import {
+  BaseResourceAPI,
+  type CDFHttpClient,
+  type MetadataMap,
+} from '@cognite/sdk-core';
+import cloneDeepWith from 'lodash/cloneDeepWith';
+import type {
+  DataPointSubscription,
+  DataPointSubscriptionByIdsQuery,
+  DataPointSubscriptionListDataQuery,
+  DataPointSubscriptionListDataResponse,
+  DataPointSubscriptionListQuery,
+  DataPointSubscriptionListResponse,
+  DataPointSubscriptionMembersListQuery,
+  DataPointSubscriptionMembersListResponse,
+  DataPointSubscriptionUpdate,
+  DataPointSubscriptionsDeleteQuery,
+  DataPointSubscriptionCreate,
+} from './types';
+
+function parseSubscriptionListDataDates(
+  data: DataPointSubscriptionListDataResponse
+): DataPointSubscriptionListDataResponse {
+  return cloneDeepWith(data, (value, key) => {
+    if (
+      (key === 'timestamp' ||
+        key === 'inclusiveBegin' ||
+        key === 'exclusiveEnd') &&
+      (typeof value === 'number' || typeof value === 'string')
+    ) {
+      return new Date(value);
+    }
+  });
+}
+
+export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscription> {
+  /** @hidden */
+  constructor(...args: [string, CDFHttpClient, MetadataMap]) {
+    super(...args);
+  }
+
+  /**
+   * @hidden
+   */
+  protected getDateProps() {
+    return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
+  }
+
+  /**
+   * [Create data point subscriptions](https://docs.cognite.com/api/v1/#operation/postSubscriptions)
+   */
+  public create = async (
+    items: DataPointSubscriptionCreate[]
+  ): Promise<DataPointSubscription[]> => {
+    const responses = await Promise.all(
+      items.map((item) =>
+        this.post<{ items: DataPointSubscription[] }>(this.url(), {
+          data: { items: [item] },
+        })
+      )
+    );
+    return responses.flatMap((response) =>
+      this.addToMapAndReturn(response.data.items, response)
+    );
+  };
+
+  /**
+   * [List data point subscriptions](https://docs.cognite.com/api/v1/#operation/listSubscriptions)
+   */
+  public list = async (
+    query?: DataPointSubscriptionListQuery
+  ): Promise<DataPointSubscriptionListResponse> => {
+    const response = await this.get<DataPointSubscriptionListResponse>(
+      this.url(),
+      { params: query }
+    );
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [Retrieve data point subscriptions](https://docs.cognite.com/api/v1/#operation/getSubscriptionsByIds)
+   */
+  public retrieve = async (
+    query: DataPointSubscriptionByIdsQuery
+  ): Promise<DataPointSubscription[]> => {
+    const { items, ...rest } = query;
+    const responses = await Promise.all(
+      items.map((item) =>
+        this.post<{ items: DataPointSubscription[] }>(this.url('byids'), {
+          data: { items: [item], ...rest },
+        })
+      )
+    );
+    return responses.flatMap((response) =>
+      this.addToMapAndReturn(response.data.items, response)
+    );
+  };
+
+  /**
+   * [Update data point subscriptions](https://docs.cognite.com/api/v1/#operation/updateSubscriptions)
+   */
+  public update = async (
+    items: DataPointSubscriptionUpdate[]
+  ): Promise<DataPointSubscription[]> => {
+    const responses = await Promise.all(
+      items.map((item) =>
+        this.post<{ items: DataPointSubscription[] }>(this.url('update'), {
+          data: { items: [item] },
+        })
+      )
+    );
+    return responses.flatMap((response) =>
+      this.addToMapAndReturn(response.data.items, response)
+    );
+  };
+
+  /**
+   * [Delete data point subscriptions](https://docs.cognite.com/api/v1/#operation/deleteSubscriptions)
+   */
+  public delete = async (
+    query: DataPointSubscriptionsDeleteQuery
+  ): Promise<void> => {
+    const { items, ignoreUnknownIds } = query;
+    await Promise.all(
+      items.map((item) =>
+        this.post(this.url('delete'), {
+          data: { items: [item], ignoreUnknownIds },
+        })
+      )
+    );
+  };
+
+  /**
+   * [List data point subscription members](https://docs.cognite.com/api/v1/#operation/listSubscriptionMembers)
+   */
+  public listMembers = async (
+    query: DataPointSubscriptionMembersListQuery
+  ): Promise<DataPointSubscriptionMembersListResponse> => {
+    const response =
+      await this.get<DataPointSubscriptionMembersListResponse>(
+        this.url('members'),
+        { params: query }
+      );
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [List data point subscription data](https://docs.cognite.com/api/v1/#operation/listSubscriptionData)
+   */
+  public listData = async (
+    query: DataPointSubscriptionListDataQuery
+  ): Promise<DataPointSubscriptionListDataResponse> => {
+    const response = await this.post<DataPointSubscriptionListDataResponse>(
+      this.url('data/list'),
+      {
+        data: query,
+      }
+    );
+    const parsed = parseSubscriptionListDataDates(response.data);
+    return this.addToMapAndReturn(parsed, response);
+  };
+}

--- a/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
@@ -1,14 +1,11 @@
 // Copyright 2026 Cognite AS
 
-import {
-  BaseResourceAPI,
-  type CDFHttpClient,
-  type MetadataMap,
-} from '@cognite/sdk-core';
+import { BaseResourceAPI } from '@cognite/sdk-core';
 import cloneDeepWith from 'lodash/cloneDeepWith';
 import type {
   DataPointSubscription,
   DataPointSubscriptionByIdsQuery,
+  DataPointSubscriptionCreate,
   DataPointSubscriptionListDataQuery,
   DataPointSubscriptionListDataResponse,
   DataPointSubscriptionListQuery,
@@ -17,7 +14,6 @@ import type {
   DataPointSubscriptionMembersListResponse,
   DataPointSubscriptionUpdate,
   DataPointSubscriptionsDeleteQuery,
-  DataPointSubscriptionCreate,
 } from './types';
 
 function parseSubscriptionListDataDates(
@@ -36,11 +32,6 @@ function parseSubscriptionListDataDates(
 }
 
 export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscription> {
-  /** @hidden */
-  constructor(...args: [string, CDFHttpClient, MetadataMap]) {
-    super(...args);
-  }
-
   /**
    * @hidden
    */
@@ -50,6 +41,12 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
 
   /**
    * [Create data point subscriptions](https://docs.cognite.com/api/v1/#operation/postSubscriptions)
+   *
+   * ```js
+   * const subscriptions = await client.timeseries.subscriptions.create([
+   *   { externalId: 'my_subscription', partitionCount: 1, timeSeriesIds: ['ts_external_id'] },
+   * ]);
+   * ```
    */
   public create = async (
     items: DataPointSubscriptionCreate[]
@@ -68,6 +65,10 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
 
   /**
    * [List data point subscriptions](https://docs.cognite.com/api/v1/#operation/listSubscriptions)
+   *
+   * ```js
+   * const subscriptions = await client.timeseries.subscriptions.list({ limit: 100 });
+   * ```
    */
   public list = async (
     query?: DataPointSubscriptionListQuery
@@ -81,6 +82,12 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
 
   /**
    * [Retrieve data point subscriptions](https://docs.cognite.com/api/v1/#operation/getSubscriptionsByIds)
+   *
+   * ```js
+   * const subscriptions = await client.timeseries.subscriptions.retrieve({
+   *   items: [{ externalId: 'my_subscription' }],
+   * });
+   * ```
    */
   public retrieve = async (
     query: DataPointSubscriptionByIdsQuery
@@ -100,6 +107,12 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
 
   /**
    * [Update data point subscriptions](https://docs.cognite.com/api/v1/#operation/updateSubscriptions)
+   *
+   * ```js
+   * const updated = await client.timeseries.subscriptions.update([
+   *   { externalId: 'my_subscription', update: { name: { set: 'new name' } } },
+   * ]);
+   * ```
    */
   public update = async (
     items: DataPointSubscriptionUpdate[]
@@ -118,6 +131,12 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
 
   /**
    * [Delete data point subscriptions](https://docs.cognite.com/api/v1/#operation/deleteSubscriptions)
+   *
+   * ```js
+   * await client.timeseries.subscriptions.delete({
+   *   items: [{ externalId: 'my_subscription' }],
+   * });
+   * ```
    */
   public delete = async (
     query: DataPointSubscriptionsDeleteQuery
@@ -134,20 +153,35 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
 
   /**
    * [List data point subscription members](https://docs.cognite.com/api/v1/#operation/listSubscriptionMembers)
+   *
+   * ```js
+   * const members = await client.timeseries.subscriptions.listMembers({
+   *   externalId: 'my_subscription',
+   *   limit: 100,
+   * });
+   * ```
    */
   public listMembers = async (
     query: DataPointSubscriptionMembersListQuery
   ): Promise<DataPointSubscriptionMembersListResponse> => {
-    const response =
-      await this.get<DataPointSubscriptionMembersListResponse>(
-        this.url('members'),
-        { params: query }
-      );
+    const response = await this.get<DataPointSubscriptionMembersListResponse>(
+      this.url('members'),
+      { params: query }
+    );
     return this.addToMapAndReturn(response.data, response);
   };
 
   /**
    * [List data point subscription data](https://docs.cognite.com/api/v1/#operation/listSubscriptionData)
+   *
+   * ```js
+   * const data = await client.timeseries.subscriptions.listData({
+   *   externalId: 'my_subscription',
+   *   partitions: [{ index: 0 }],
+   *   limit: 100,
+   *   initializeCursors: 'now',
+   * });
+   * ```
    */
   public listData = async (
     query: DataPointSubscriptionListDataQuery

--- a/packages/stable/src/api/timeSeries/subscriptions/types.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/types.ts
@@ -7,15 +7,15 @@ import type {
   Cursor,
 } from '@cognite/sdk-core';
 import type {
-  DatapointsDeleteRange,
-  DoubleDatapoint,
-  StringDatapoint,
-} from '../../dataPoints/types';
-import type {
   IgnoreUnknownIds,
   NullableSinglePatchLong,
   NullableSinglePatchString,
 } from '../../../types/common';
+import type {
+  DatapointsDeleteRange,
+  DoubleDatapoint,
+  StringDatapoint,
+} from '../../dataPoints/types';
 import type { TimeSeriesType } from '../types';
 
 // =====================================================

--- a/packages/stable/src/api/timeSeries/subscriptions/types.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/types.ts
@@ -1,0 +1,238 @@
+// Copyright 2026 Cognite AS
+
+import type {
+  CogniteExternalId,
+  CogniteInstanceId,
+  CogniteInternalId,
+  Cursor,
+} from '@cognite/sdk-core';
+import type {
+  DatapointsDeleteRange,
+  DoubleDatapoint,
+  StringDatapoint,
+} from '../../dataPoints/types';
+import type {
+  IgnoreUnknownIds,
+  NullableSinglePatchLong,
+  NullableSinglePatchString,
+} from '../../../types/common';
+import type { TimeSeriesType } from '../types';
+
+// =====================================================
+// Subscription filter DSL
+// =====================================================
+
+export type SubscriptionFilterProperty = [string] | [string, string];
+
+export type SubscriptionFilterScalar = string | number | boolean;
+
+export interface SubscriptionEqualsFilter {
+  equals: {
+    property: SubscriptionFilterProperty;
+    value: SubscriptionFilterScalar;
+  };
+}
+
+export interface SubscriptionInFilter {
+  in: {
+    property: SubscriptionFilterProperty;
+    values: SubscriptionFilterScalar[];
+  };
+}
+
+export interface SubscriptionRangeFilter {
+  range: {
+    property: SubscriptionFilterProperty;
+    gte?: string | number;
+    gt?: string | number;
+    lte?: string | number;
+    lt?: string | number;
+  };
+}
+
+export interface SubscriptionPrefixFilter {
+  prefix: {
+    property: SubscriptionFilterProperty;
+    value: string;
+  };
+}
+
+export interface SubscriptionExistsFilter {
+  exists: {
+    property: SubscriptionFilterProperty;
+  };
+}
+
+export interface SubscriptionContainsAnyFilter {
+  containsAny: {
+    property: SubscriptionFilterProperty;
+    values: SubscriptionFilterScalar[];
+  };
+}
+
+export interface SubscriptionContainsAllFilter {
+  containsAll: {
+    property: SubscriptionFilterProperty;
+    values: SubscriptionFilterScalar[];
+  };
+}
+
+export type SubscriptionLeafFilter =
+  | SubscriptionEqualsFilter
+  | SubscriptionInFilter
+  | SubscriptionRangeFilter
+  | SubscriptionPrefixFilter
+  | SubscriptionExistsFilter
+  | SubscriptionContainsAnyFilter
+  | SubscriptionContainsAllFilter;
+
+export type SubscriptionBoolFilter =
+  | { and: SubscriptionFilterLanguage[] }
+  | { or: SubscriptionFilterLanguage[] }
+  | { not: SubscriptionFilterLanguage };
+
+export type SubscriptionFilterLanguage =
+  | SubscriptionBoolFilter
+  | SubscriptionLeafFilter;
+
+// =====================================================
+// Create / read / update / delete
+// =====================================================
+
+export interface DataPointSubscriptionCreateBase {
+  externalId: CogniteExternalId;
+  name?: string;
+  description?: string;
+  dataSetId?: CogniteInternalId;
+  partitionCount: number;
+}
+
+export type DataPointSubscriptionCreate =
+  | (DataPointSubscriptionCreateBase & {
+      timeSeriesIds: CogniteExternalId[];
+      instanceIds?: undefined;
+      filter?: undefined;
+    })
+  | (DataPointSubscriptionCreateBase & {
+      instanceIds: CogniteInstanceId[];
+      timeSeriesIds?: undefined;
+      filter?: undefined;
+    })
+  | (DataPointSubscriptionCreateBase & {
+      filter: SubscriptionFilterLanguage;
+      timeSeriesIds?: undefined;
+      instanceIds?: undefined;
+    });
+
+export interface DataPointSubscription {
+  externalId: CogniteExternalId;
+  name?: string;
+  description?: string;
+  dataSetId?: CogniteInternalId;
+  partitionCount: number;
+  timeSeriesCount?: number;
+  filter?: SubscriptionFilterLanguage;
+  createdTime: Date;
+  lastUpdatedTime: Date;
+}
+
+export interface DataPointSubscriptionMember {
+  externalId?: CogniteExternalId;
+  id?: CogniteInternalId;
+  instanceId?: CogniteInstanceId;
+}
+
+export interface DataPointSubscriptionListQuery extends Cursor {
+  limit?: number;
+}
+
+export interface DataPointSubscriptionListResponse {
+  items: DataPointSubscription[];
+  nextCursor?: string;
+}
+
+export interface DataPointSubscriptionMembersListQuery extends Cursor {
+  externalId: CogniteExternalId;
+  limit?: number;
+}
+
+export interface DataPointSubscriptionMembersListResponse {
+  items: DataPointSubscriptionMember[];
+  nextCursor?: string;
+}
+
+export type DataPointSubscriptionTimeSeriesIdsUpdate =
+  | { add: CogniteExternalId[]; remove: CogniteExternalId[] }
+  | { set: CogniteExternalId[] };
+
+export type DataPointSubscriptionInstanceIdsUpdate =
+  | { add: CogniteInstanceId[]; remove: CogniteInstanceId[] }
+  | { set: CogniteInstanceId[] };
+
+export interface DataPointSubscriptionUpdateBody {
+  timeSeriesIds?: DataPointSubscriptionTimeSeriesIdsUpdate;
+  instanceIds?: DataPointSubscriptionInstanceIdsUpdate;
+  name?: NullableSinglePatchString;
+  description?: NullableSinglePatchString;
+  dataSetId?: NullableSinglePatchLong;
+  filter?: { set: SubscriptionFilterLanguage };
+}
+
+export interface DataPointSubscriptionUpdate {
+  externalId: CogniteExternalId;
+  update: DataPointSubscriptionUpdateBody;
+}
+
+export interface DataPointSubscriptionByIdsQuery extends IgnoreUnknownIds {
+  items: { externalId: CogniteExternalId }[];
+}
+
+export interface DataPointSubscriptionsDeleteQuery extends IgnoreUnknownIds {
+  items: { externalId: CogniteExternalId }[];
+}
+
+// =====================================================
+// List subscription data
+// =====================================================
+
+export interface DataPointSubscriptionPartitionCursor {
+  index: number;
+  cursor?: string;
+}
+
+export interface DataPointSubscriptionListDataQuery {
+  externalId?: CogniteExternalId;
+  partitions: DataPointSubscriptionPartitionCursor[];
+  limit?: number;
+  initializeCursors?: string;
+  pollTimeoutSeconds?: number;
+  includeStatus?: boolean;
+  ignoreBadDataPoints?: boolean;
+  treatUncertainAsBad?: boolean;
+}
+
+export interface GetTimeSeriesForSubscription {
+  id: CogniteInternalId;
+  externalId?: CogniteExternalId;
+  instanceId?: CogniteInstanceId;
+  isString: boolean;
+  type: TimeSeriesType;
+}
+
+export type SubscriptionDataUpsert = DoubleDatapoint | StringDatapoint;
+
+export interface DataPointSubscriptionDataUpdate {
+  timeSeries?: GetTimeSeriesForSubscription;
+  upserts?: SubscriptionDataUpsert[];
+  deletes?: DatapointsDeleteRange[];
+}
+
+export interface DataPointSubscriptionListDataResponse {
+  updates: DataPointSubscriptionDataUpdate[];
+  subscriptionChanges?: {
+    added?: GetTimeSeriesForSubscription[];
+    removed?: GetTimeSeriesForSubscription[];
+  };
+  partitions: { index: number; nextCursor: string }[];
+  hasNext: boolean;
+}

--- a/packages/stable/src/api/timeSeries/timeSeriesApi.ts
+++ b/packages/stable/src/api/timeSeries/timeSeriesApi.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Cognite AS
+// Copyright 2020-2026 Cognite AS
 
 import {
   BaseResourceAPI,
@@ -8,6 +8,7 @@ import {
   type MetadataMap,
 } from '@cognite/sdk-core';
 import type { IdEither, IgnoreUnknownIds } from '../../types';
+import { DataPointSubscriptionsAPI } from './subscriptions/dataPointSubscriptionsApi';
 import { SyntheticTimeSeriesAPI } from './syntheticTimeSeriesApi';
 import type {
   SyntheticQuery,
@@ -22,6 +23,7 @@ import type {
 
 export class TimeSeriesAPI extends BaseResourceAPI<TimeSeries> {
   private syntheticTimeseriesApi: SyntheticTimeSeriesAPI;
+  private readonly dataPointSubscriptionsApi: DataPointSubscriptionsAPI;
 
   /** @hidden */
   constructor(resourcePath: string, ...args: [CDFHttpClient, MetadataMap]) {
@@ -30,6 +32,17 @@ export class TimeSeriesAPI extends BaseResourceAPI<TimeSeries> {
       this.url('synthetic'),
       ...args
     );
+    this.dataPointSubscriptionsApi = new DataPointSubscriptionsAPI(
+      this.url('subscriptions'),
+      ...args
+    );
+  }
+
+  /**
+   * [Data point subscriptions](https://docs.cognite.com/api/v1/#tag/Data-point-subscriptions)
+   */
+  public get subscriptions() {
+    return this.dataPointSubscriptionsApi;
   }
 
   /**

--- a/packages/stable/src/index.ts
+++ b/packages/stable/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Cognite AS
+// Copyright 2020-2026 Cognite AS
 
 export {
   HttpError,
@@ -42,6 +42,7 @@ export { SecurityCategoriesAPI } from './api/securityCategories/securityCategori
 export { SequenceRowsAPI } from './api/sequences/sequenceRowsApi';
 export { SequencesAPI } from './api/sequences/sequencesApi';
 export { SyntheticTimeSeriesAPI } from './api/timeSeries/syntheticTimeSeriesApi';
+export { DataPointSubscriptionsAPI } from './api/timeSeries/subscriptions/dataPointSubscriptionsApi';
 export { TimeSeriesAPI } from './api/timeSeries/timeSeriesApi';
 export { FunctionsAPI } from './api/functions/functionsApi';
 export * from './api/templates';

--- a/packages/stable/src/retryValidator.ts
+++ b/packages/stable/src/retryValidator.ts
@@ -23,6 +23,7 @@ const ENDPOINTS_TO_RETRY: EndpointList = {
     '/timeseries/data/latest',
     '/timeseries/data/delete',
     '/timeseries/synthetic/query',
+    '/timeseries/subscriptions/data/list',
   ],
 };
 

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -63,6 +63,7 @@ export * from './api/streams/types';
 export * from './api/records/types';
 export * from './api/sessions/types';
 export * from './api/timeSeries/types';
+export * from './api/timeSeries/subscriptions/types';
 export * from './api/dataPoints/types';
 export * from './api/functions/types';
 


### PR DESCRIPTION
This PR adds support for **data point subscriptions**, which enables app developers to build real-time, browser-based experiences on top of CDF time series — dashboards, operator views, trend charts, alerting UIs — that efficiently receive only the deltas (inserted points, deleted ranges, and time series entering or leaving the feed), so the UI updates as soon as new data is ingested in CDF.