### PR TITLE
feat(beta): add datapoints.insertWithUnitConversion for client-side unit conversion on write

### DIFF
--- a/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
+++ b/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
@@ -22,11 +22,17 @@ const baseUnit = (overrides: Partial<Unit>): Unit => ({
 });
 
 describe('convertBetweenUnitConversions', () => {
-  it('converts via shared base representation', () => {
-    const src = { multiplier: 2, offset: 10 };
-    const dst = { multiplier: 4, offset: 0 };
-    // base = 5*2+10 = 20, dst = (20-0)/4 = 5
-    expect(convertBetweenUnitConversions(5, src, dst)).toBe(5);
+  it('converts °F to °C', () => {
+    const fahrenheit = { multiplier: 5 / 9, offset: 459.67 };
+    const celsius = { multiplier: 1, offset: 273.15 };
+    expect(convertBetweenUnitConversions(212, fahrenheit, celsius)).toBeCloseTo(
+      100,
+      9
+    );
+    expect(convertBetweenUnitConversions(32, fahrenheit, celsius)).toBeCloseTo(
+      0,
+      9
+    );
   });
 
   it('returns same value when factors match', () => {

--- a/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
+++ b/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
@@ -39,6 +39,11 @@ describe('convertBetweenUnitConversions', () => {
     const c = { multiplier: 1, offset: 0 };
     expect(convertBetweenUnitConversions(3.5, c, c)).toBe(3.5);
   });
+
+  it('returns same value for non-trivial same unit (early return)', () => {
+    const degF = { multiplier: 5 / 9, offset: 459.67 };
+    expect(convertBetweenUnitConversions(72, degF, degF)).toBe(72);
+  });
 });
 
 describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
@@ -289,6 +294,44 @@ describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
         },
       ])
     ).rejects.toThrow(/string datapoint/);
+  });
+
+  it('passes through values unchanged when sourceUnit equals stored unit', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      {
+        id: 1,
+        isString: false,
+        unitExternalId: 'q:unit',
+      } satisfies Partial<TimeSeries> as TimeSeries,
+    ]);
+    const unitsRetrieve = vi.fn().mockResolvedValue([
+      baseUnit({
+        externalId: 'q:unit',
+        quantity: 'Q',
+        conversion: { multiplier: 2, offset: 3 },
+      }),
+    ]);
+
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: unitsRetrieve },
+    });
+    const insertSpy = vi.spyOn(api, 'insert').mockResolvedValue({});
+
+    await api.insertWithUnitConversion([
+      {
+        id: 1,
+        sourceUnit: 'q:unit',
+        datapoints: [{ timestamp: 1, value: 42 }],
+      },
+    ]);
+
+    expect(insertSpy).toHaveBeenCalledWith([
+      {
+        id: 1,
+        datapoints: [{ timestamp: 1, value: 42 }],
+      },
+    ]);
   });
 
   it('throws when source unit is missing from catalog response', async () => {

--- a/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
+++ b/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
@@ -4,10 +4,7 @@ import type { TimeSeries, TimeSeriesAPI, Unit, UnitsAPI } from '@cognite/sdk';
 import type { CDFHttpClient } from '@cognite/sdk-core';
 import { CogniteError, MetadataMap } from '@cognite/sdk-core';
 import { describe, expect, it, vi } from 'vitest';
-import {
-  BetaDataPointsAPI,
-  convertBetweenUnitConversions,
-} from '../../api/dataPoints/dataPointsApi';
+import { BetaDataPointsAPI } from '../../api/dataPoints/dataPointsApi';
 import type { DatapointsInsertWithUnitItem } from '../../api/dataPoints/types';
 
 const baseUnit = (overrides: Partial<Unit>): Unit => ({
@@ -21,30 +18,12 @@ const baseUnit = (overrides: Partial<Unit>): Unit => ({
   ...overrides,
 });
 
-describe('convertBetweenUnitConversions', () => {
-  it('converts °F to °C', () => {
-    const fahrenheit = { multiplier: 5 / 9, offset: 459.67 };
-    const celsius = { multiplier: 1, offset: 273.15 };
-    expect(convertBetweenUnitConversions(212, fahrenheit, celsius)).toBeCloseTo(
-      100,
-      9
-    );
-    expect(convertBetweenUnitConversions(32, fahrenheit, celsius)).toBeCloseTo(
-      0,
-      9
-    );
-  });
-
-  it('returns same value when factors match', () => {
-    const c = { multiplier: 1, offset: 0 };
-    expect(convertBetweenUnitConversions(3.5, c, c)).toBe(3.5);
-  });
-
-  it('returns same value for non-trivial same unit (early return)', () => {
-    const degF = { multiplier: 5 / 9, offset: 459.67 };
-    expect(convertBetweenUnitConversions(72, degF, degF)).toBe(72);
-  });
-});
+const numericTs = (overrides: Partial<TimeSeries>): TimeSeries =>
+  ({
+    isString: false,
+    type: 'numeric',
+    ...overrides,
+  }) as TimeSeries;
 
 describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
   const map = new MetadataMap();
@@ -73,93 +52,32 @@ describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
     );
   }
 
-  it('dedupes timeseries.retrieve for repeated ids', async () => {
-    const retrieve = vi.fn().mockResolvedValue([
-      {
-        id: 1,
-        isString: false,
-        unitExternalId: 'q:dst',
-        externalId: 'ts-a',
-      } satisfies Partial<TimeSeries> as TimeSeries,
-    ]);
-    const unitsRetrieve = vi
-      .fn()
-      .mockImplementation(async (ids: { externalId: string }[]) => {
-        const extIds = new Set(ids.map((i) => i.externalId));
-        const out: Unit[] = [];
-        if (extIds.has('q:src')) {
-          out.push(
-            baseUnit({
-              externalId: 'q:src',
-              quantity: 'Q',
-              conversion: { multiplier: 2, offset: 0 },
-            })
-          );
-        }
-        if (extIds.has('q:dst')) {
-          out.push(
-            baseUnit({
-              externalId: 'q:dst',
-              quantity: 'Q',
-              conversion: { multiplier: 10, offset: 0 },
-            })
-          );
-        }
-        return out;
-      });
-
+  it('does not call insert for empty items', async () => {
+    const retrieve = vi.fn();
     const api = makeApi({
       timeSeries: { retrieve },
-      units: { retrieve: unitsRetrieve },
+      units: { retrieve: vi.fn() },
     });
-    const insertSpy = vi.spyOn(api, 'insert').mockResolvedValue({});
+    const insertSpy = vi.spyOn(api, 'insert');
 
-    const items: DatapointsInsertWithUnitItem[] = [
-      {
-        id: 1,
-        sourceUnit: 'q:src',
-        datapoints: [{ timestamp: 1, value: 5 }],
-      },
-      {
-        id: 1,
-        sourceUnit: 'q:src',
-        datapoints: [{ timestamp: 2, value: 5 }],
-      },
-    ];
-
-    await api.insertWithUnitConversion(items);
-
-    expect(retrieve).toHaveBeenCalledTimes(1);
-    expect(retrieve).toHaveBeenCalledWith([{ id: 1 }], {
-      ignoreUnknownIds: false,
-    });
-    expect(unitsRetrieve).toHaveBeenCalledTimes(1);
-    expect(insertSpy).toHaveBeenCalledWith([
-      {
-        id: 1,
-        datapoints: [{ timestamp: 1, value: 1 }],
-      },
-      {
-        id: 1,
-        datapoints: [{ timestamp: 2, value: 1 }],
-      },
-    ]);
+    await expect(api.insertWithUnitConversion([])).resolves.toEqual({});
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(insertSpy).not.toHaveBeenCalled();
   });
 
-  it('dedupes retrieve ids for id vs externalId of same series', async () => {
+  it('converts values and dedupes timeseries.retrieve for repeated ids', async () => {
     const retrieve = vi.fn().mockResolvedValue([
-      {
-        id: 42,
-        externalId: 'same-ts',
-        isString: false,
+      numericTs({
+        id: 1,
         unitExternalId: 'q:dst',
-      } satisfies Partial<TimeSeries> as TimeSeries,
+        externalId: 'ts-a',
+      }),
     ]);
     const unitsRetrieve = vi.fn().mockResolvedValue([
       baseUnit({
         externalId: 'q:src',
         quantity: 'Q',
-        conversion: { multiplier: 1, offset: 0 },
+        conversion: { multiplier: 2, offset: 0 },
       }),
       baseUnit({
         externalId: 'q:dst',
@@ -172,48 +90,106 @@ describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
       timeSeries: { retrieve },
       units: { retrieve: unitsRetrieve },
     });
+    const insertSpy = vi.spyOn(api, 'insert').mockResolvedValue({});
+
+    const items: DatapointsInsertWithUnitItem[] = [
+      {
+        id: 1,
+        unit: { externalId: 'q:src' },
+        datapoints: [{ timestamp: 1, value: 5 }],
+      },
+      {
+        id: 1,
+        unit: { externalId: 'q:src' },
+        datapoints: [{ timestamp: 2, value: 5 }],
+      },
+    ];
+
+    await api.insertWithUnitConversion(items);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(retrieve).toHaveBeenCalledWith([{ id: 1 }], {
+      ignoreUnknownIds: false,
+    });
+    expect(unitsRetrieve).toHaveBeenCalledTimes(1);
+    expect(insertSpy).toHaveBeenCalledWith([
+      { id: 1, datapoints: [{ timestamp: 1, value: 1 }] },
+      { id: 1, datapoints: [{ timestamp: 2, value: 1 }] },
+    ]);
+  });
+
+  it('dedupes retrieve ids for id vs externalId of same series', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      numericTs({
+        id: 42,
+        externalId: 'same-ts',
+        unitExternalId: 'q:dst',
+      }),
+    ]);
+    const unitsRetrieve = vi
+      .fn()
+      .mockResolvedValue([
+        baseUnit({ externalId: 'q:src', quantity: 'Q' }),
+        baseUnit({ externalId: 'q:dst', quantity: 'Q' }),
+      ]);
+
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: unitsRetrieve },
+    });
     vi.spyOn(api, 'insert').mockResolvedValue({});
 
     await api.insertWithUnitConversion([
       {
         id: 42,
-        sourceUnit: 'q:src',
+        unit: { externalId: 'q:src' },
         datapoints: [{ timestamp: 1, value: 100 }],
       },
       {
         externalId: 'same-ts',
-        sourceUnit: 'q:src',
+        unit: { externalId: 'q:src' },
         datapoints: [{ timestamp: 2, value: 100 }],
       },
     ]);
 
     expect(retrieve).toHaveBeenCalledTimes(1);
-    const arg = retrieve.mock.calls[0][0] as {
-      id?: number;
-      externalId?: string;
-    }[];
-    expect(arg).toHaveLength(2);
     expect(unitsRetrieve).toHaveBeenCalledTimes(1);
   });
 
-  it('throws when time series has no unitExternalId', async () => {
-    const retrieve = vi.fn().mockResolvedValue([
-      {
-        id: 7,
-        isString: false,
-      } satisfies Partial<TimeSeries> as TimeSeries,
-    ]);
+  it('throws when time series type is not numeric', async () => {
+    const retrieve = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 7, isString: true, type: 'string' } as TimeSeries,
+      ]);
     const api = makeApi({
       timeSeries: { retrieve },
       units: { retrieve: vi.fn().mockResolvedValue([]) },
     });
-    vi.spyOn(api, 'insert');
 
     await expect(
       api.insertWithUnitConversion([
         {
           id: 7,
-          sourceUnit: 'q:src',
+          unit: { externalId: 'q:src' },
+          datapoints: [{ timestamp: 1, value: 1 }],
+        },
+      ])
+    ).rejects.toThrow(/only supports numeric time series/);
+  });
+
+  it('throws when time series has no unitExternalId', async () => {
+    const retrieve = vi.fn().mockResolvedValue([numericTs({ id: 7 })]);
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: vi.fn().mockResolvedValue([]) },
+    });
+
+    await expect(
+      api.insertWithUnitConversion([
+        {
+          id: 7,
+          unit: { externalId: 'q:src' },
           datapoints: [{ timestamp: 1, value: 1 }],
         },
       ])
@@ -221,89 +197,35 @@ describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
   });
 
   it('throws on quantity mismatch', async () => {
-    const retrieve = vi.fn().mockResolvedValue([
-      {
-        id: 1,
-        isString: false,
-        unitExternalId: 'temp:dst',
-      } satisfies Partial<TimeSeries> as TimeSeries,
-    ]);
-    const unitsRetrieve = vi.fn().mockResolvedValue([
-      baseUnit({
-        externalId: 'press:src',
-        quantity: 'Pressure',
-        conversion: { multiplier: 1, offset: 0 },
-      }),
-      baseUnit({
-        externalId: 'temp:dst',
-        quantity: 'Temperature',
-        conversion: { multiplier: 1, offset: 0 },
-      }),
-    ]);
-
+    const retrieve = vi
+      .fn()
+      .mockResolvedValue([numericTs({ id: 1, unitExternalId: 'temp:dst' })]);
+    const unitsRetrieve = vi
+      .fn()
+      .mockResolvedValue([
+        baseUnit({ externalId: 'press:src', quantity: 'Pressure' }),
+        baseUnit({ externalId: 'temp:dst', quantity: 'Temperature' }),
+      ]);
     const api = makeApi({
       timeSeries: { retrieve },
       units: { retrieve: unitsRetrieve },
     });
-    vi.spyOn(api, 'insert');
 
     await expect(
       api.insertWithUnitConversion([
         {
           id: 1,
-          sourceUnit: 'press:src',
+          unit: { externalId: 'press:src' },
           datapoints: [{ timestamp: 1, value: 1 }],
         },
       ])
     ).rejects.toThrow(/Incompatible units/);
   });
 
-  it('throws on string datapoint value', async () => {
-    const retrieve = vi.fn().mockResolvedValue([
-      {
-        id: 1,
-        isString: false,
-        unitExternalId: 'q:dst',
-      } satisfies Partial<TimeSeries> as TimeSeries,
-    ]);
-    const unitsRetrieve = vi.fn().mockResolvedValue([
-      baseUnit({
-        externalId: 'q:src',
-        quantity: 'Q',
-        conversion: { multiplier: 1, offset: 0 },
-      }),
-      baseUnit({
-        externalId: 'q:dst',
-        quantity: 'Q',
-        conversion: { multiplier: 1, offset: 0 },
-      }),
-    ]);
-
-    const api = makeApi({
-      timeSeries: { retrieve },
-      units: { retrieve: unitsRetrieve },
-    });
-    vi.spyOn(api, 'insert');
-
-    await expect(
-      api.insertWithUnitConversion([
-        {
-          id: 1,
-          sourceUnit: 'q:src',
-          datapoints: [{ timestamp: 1, value: 'x' }],
-        },
-      ])
-    ).rejects.toThrow(/string datapoint/);
-  });
-
-  it('passes through values unchanged when sourceUnit equals stored unit', async () => {
-    const retrieve = vi.fn().mockResolvedValue([
-      {
-        id: 1,
-        isString: false,
-        unitExternalId: 'q:unit',
-      } satisfies Partial<TimeSeries> as TimeSeries,
-    ]);
+  it('passes through values unchanged when unit.externalId equals stored unit', async () => {
+    const retrieve = vi
+      .fn()
+      .mockResolvedValue([numericTs({ id: 1, unitExternalId: 'q:unit' })]);
     const unitsRetrieve = vi.fn().mockResolvedValue([
       baseUnit({
         externalId: 'q:unit',
@@ -321,49 +243,13 @@ describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
     await api.insertWithUnitConversion([
       {
         id: 1,
-        sourceUnit: 'q:unit',
+        unit: { externalId: 'q:unit' },
         datapoints: [{ timestamp: 1, value: 42 }],
       },
     ]);
 
     expect(insertSpy).toHaveBeenCalledWith([
-      {
-        id: 1,
-        datapoints: [{ timestamp: 1, value: 42 }],
-      },
+      { id: 1, datapoints: [{ timestamp: 1, value: 42 }] },
     ]);
-  });
-
-  it('throws when source unit is missing from catalog response', async () => {
-    const retrieve = vi.fn().mockResolvedValue([
-      {
-        id: 1,
-        isString: false,
-        unitExternalId: 'q:dst',
-      } satisfies Partial<TimeSeries> as TimeSeries,
-    ]);
-    const unitsRetrieve = vi.fn().mockResolvedValue([
-      baseUnit({
-        externalId: 'q:dst',
-        quantity: 'Q',
-        conversion: { multiplier: 1, offset: 0 },
-      }),
-    ]);
-
-    const api = makeApi({
-      timeSeries: { retrieve },
-      units: { retrieve: unitsRetrieve },
-    });
-    vi.spyOn(api, 'insert');
-
-    await expect(
-      api.insertWithUnitConversion([
-        {
-          id: 1,
-          sourceUnit: 'q:src',
-          datapoints: [{ timestamp: 1, value: 1 }],
-        },
-      ])
-    ).rejects.toThrow(/Unknown unit externalId/);
   });
 });

--- a/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
+++ b/packages/beta/src/__tests__/api/betaDataPointsApi.unit.spec.ts
@@ -1,0 +1,320 @@
+// Copyright 2026 Cognite AS
+
+import type { TimeSeries, TimeSeriesAPI, Unit, UnitsAPI } from '@cognite/sdk';
+import type { CDFHttpClient } from '@cognite/sdk-core';
+import { CogniteError, MetadataMap } from '@cognite/sdk-core';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BetaDataPointsAPI,
+  convertBetweenUnitConversions,
+} from '../../api/dataPoints/dataPointsApi';
+import type { DatapointsInsertWithUnitItem } from '../../api/dataPoints/types';
+
+const baseUnit = (overrides: Partial<Unit>): Unit => ({
+  externalId: 'q:base',
+  name: 'BASE',
+  longName: 'base',
+  symbol: 'b',
+  aliasNames: [],
+  quantity: 'Q',
+  conversion: { multiplier: 1, offset: 0 },
+  ...overrides,
+});
+
+describe('convertBetweenUnitConversions', () => {
+  it('converts via shared base representation', () => {
+    const src = { multiplier: 2, offset: 10 };
+    const dst = { multiplier: 4, offset: 0 };
+    // base = 5*2+10 = 20, dst = (20-0)/4 = 5
+    expect(convertBetweenUnitConversions(5, src, dst)).toBe(5);
+  });
+
+  it('returns same value when factors match', () => {
+    const c = { multiplier: 1, offset: 0 };
+    expect(convertBetweenUnitConversions(3.5, c, c)).toBe(3.5);
+  });
+});
+
+describe('BetaDataPointsAPI.insertWithUnitConversion', () => {
+  const map = new MetadataMap();
+  const noop = async () =>
+    ({ data: {}, headers: {}, status: 200 }) as Awaited<
+      ReturnType<CDFHttpClient['get']>
+    >;
+  const http = {
+    get: vi.fn(noop),
+    post: vi.fn(noop),
+    patch: vi.fn(noop),
+    put: vi.fn(noop),
+    delete: vi.fn(noop),
+  } as unknown as CDFHttpClient;
+
+  function makeApi(mocks: {
+    timeSeries: Pick<TimeSeriesAPI, 'retrieve'>;
+    units: Pick<UnitsAPI, 'retrieve'>;
+  }) {
+    return new BetaDataPointsAPI(
+      'https://example/api/v1/projects/p/timeseries/data',
+      http,
+      map,
+      mocks.timeSeries as TimeSeriesAPI,
+      mocks.units as UnitsAPI
+    );
+  }
+
+  it('dedupes timeseries.retrieve for repeated ids', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      {
+        id: 1,
+        isString: false,
+        unitExternalId: 'q:dst',
+        externalId: 'ts-a',
+      } satisfies Partial<TimeSeries> as TimeSeries,
+    ]);
+    const unitsRetrieve = vi
+      .fn()
+      .mockImplementation(async (ids: { externalId: string }[]) => {
+        const extIds = new Set(ids.map((i) => i.externalId));
+        const out: Unit[] = [];
+        if (extIds.has('q:src')) {
+          out.push(
+            baseUnit({
+              externalId: 'q:src',
+              quantity: 'Q',
+              conversion: { multiplier: 2, offset: 0 },
+            })
+          );
+        }
+        if (extIds.has('q:dst')) {
+          out.push(
+            baseUnit({
+              externalId: 'q:dst',
+              quantity: 'Q',
+              conversion: { multiplier: 10, offset: 0 },
+            })
+          );
+        }
+        return out;
+      });
+
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: unitsRetrieve },
+    });
+    const insertSpy = vi.spyOn(api, 'insert').mockResolvedValue({});
+
+    const items: DatapointsInsertWithUnitItem[] = [
+      {
+        id: 1,
+        sourceUnit: 'q:src',
+        datapoints: [{ timestamp: 1, value: 5 }],
+      },
+      {
+        id: 1,
+        sourceUnit: 'q:src',
+        datapoints: [{ timestamp: 2, value: 5 }],
+      },
+    ];
+
+    await api.insertWithUnitConversion(items);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(retrieve).toHaveBeenCalledWith([{ id: 1 }], {
+      ignoreUnknownIds: false,
+    });
+    expect(unitsRetrieve).toHaveBeenCalledTimes(1);
+    expect(insertSpy).toHaveBeenCalledWith([
+      {
+        id: 1,
+        datapoints: [{ timestamp: 1, value: 1 }],
+      },
+      {
+        id: 1,
+        datapoints: [{ timestamp: 2, value: 1 }],
+      },
+    ]);
+  });
+
+  it('dedupes retrieve ids for id vs externalId of same series', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      {
+        id: 42,
+        externalId: 'same-ts',
+        isString: false,
+        unitExternalId: 'q:dst',
+      } satisfies Partial<TimeSeries> as TimeSeries,
+    ]);
+    const unitsRetrieve = vi.fn().mockResolvedValue([
+      baseUnit({
+        externalId: 'q:src',
+        quantity: 'Q',
+        conversion: { multiplier: 1, offset: 0 },
+      }),
+      baseUnit({
+        externalId: 'q:dst',
+        quantity: 'Q',
+        conversion: { multiplier: 10, offset: 0 },
+      }),
+    ]);
+
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: unitsRetrieve },
+    });
+    vi.spyOn(api, 'insert').mockResolvedValue({});
+
+    await api.insertWithUnitConversion([
+      {
+        id: 42,
+        sourceUnit: 'q:src',
+        datapoints: [{ timestamp: 1, value: 100 }],
+      },
+      {
+        externalId: 'same-ts',
+        sourceUnit: 'q:src',
+        datapoints: [{ timestamp: 2, value: 100 }],
+      },
+    ]);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    const arg = retrieve.mock.calls[0][0] as {
+      id?: number;
+      externalId?: string;
+    }[];
+    expect(arg).toHaveLength(2);
+    expect(unitsRetrieve).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when time series has no unitExternalId', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      {
+        id: 7,
+        isString: false,
+      } satisfies Partial<TimeSeries> as TimeSeries,
+    ]);
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: vi.fn().mockResolvedValue([]) },
+    });
+    vi.spyOn(api, 'insert');
+
+    await expect(
+      api.insertWithUnitConversion([
+        {
+          id: 7,
+          sourceUnit: 'q:src',
+          datapoints: [{ timestamp: 1, value: 1 }],
+        },
+      ])
+    ).rejects.toThrow(CogniteError);
+  });
+
+  it('throws on quantity mismatch', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      {
+        id: 1,
+        isString: false,
+        unitExternalId: 'temp:dst',
+      } satisfies Partial<TimeSeries> as TimeSeries,
+    ]);
+    const unitsRetrieve = vi.fn().mockResolvedValue([
+      baseUnit({
+        externalId: 'press:src',
+        quantity: 'Pressure',
+        conversion: { multiplier: 1, offset: 0 },
+      }),
+      baseUnit({
+        externalId: 'temp:dst',
+        quantity: 'Temperature',
+        conversion: { multiplier: 1, offset: 0 },
+      }),
+    ]);
+
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: unitsRetrieve },
+    });
+    vi.spyOn(api, 'insert');
+
+    await expect(
+      api.insertWithUnitConversion([
+        {
+          id: 1,
+          sourceUnit: 'press:src',
+          datapoints: [{ timestamp: 1, value: 1 }],
+        },
+      ])
+    ).rejects.toThrow(/Incompatible units/);
+  });
+
+  it('throws on string datapoint value', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      {
+        id: 1,
+        isString: false,
+        unitExternalId: 'q:dst',
+      } satisfies Partial<TimeSeries> as TimeSeries,
+    ]);
+    const unitsRetrieve = vi.fn().mockResolvedValue([
+      baseUnit({
+        externalId: 'q:src',
+        quantity: 'Q',
+        conversion: { multiplier: 1, offset: 0 },
+      }),
+      baseUnit({
+        externalId: 'q:dst',
+        quantity: 'Q',
+        conversion: { multiplier: 1, offset: 0 },
+      }),
+    ]);
+
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: unitsRetrieve },
+    });
+    vi.spyOn(api, 'insert');
+
+    await expect(
+      api.insertWithUnitConversion([
+        {
+          id: 1,
+          sourceUnit: 'q:src',
+          datapoints: [{ timestamp: 1, value: 'x' }],
+        },
+      ])
+    ).rejects.toThrow(/string datapoint/);
+  });
+
+  it('throws when source unit is missing from catalog response', async () => {
+    const retrieve = vi.fn().mockResolvedValue([
+      {
+        id: 1,
+        isString: false,
+        unitExternalId: 'q:dst',
+      } satisfies Partial<TimeSeries> as TimeSeries,
+    ]);
+    const unitsRetrieve = vi.fn().mockResolvedValue([
+      baseUnit({
+        externalId: 'q:dst',
+        quantity: 'Q',
+        conversion: { multiplier: 1, offset: 0 },
+      }),
+    ]);
+
+    const api = makeApi({
+      timeSeries: { retrieve },
+      units: { retrieve: unitsRetrieve },
+    });
+    vi.spyOn(api, 'insert');
+
+    await expect(
+      api.insertWithUnitConversion([
+        {
+          id: 1,
+          sourceUnit: 'q:src',
+          datapoints: [{ timestamp: 1, value: 1 }],
+        },
+      ])
+    ).rejects.toThrow(/Unknown unit externalId/);
+  });
+});

--- a/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
+++ b/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
@@ -55,6 +55,29 @@ describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
               5
             );
           });
+
+          // Round-trip: server-side conversion back to °F should yield the
+          // original input value within float tolerance.
+          await runTestWithRetryWhenFailing(async () => {
+            const res = (await client.datapoints.retrieve({
+              items: [
+                {
+                  id: tsId,
+                  start: new Date(timestamp - 60_000),
+                  end: new Date(timestamp + 60_000),
+                  targetUnit: 'temperature:deg_f',
+                },
+              ],
+            })) as Datapoints[];
+
+            expect(res.length).toBe(1);
+            expect(res[0].unitExternalId).toBe('temperature:deg_f');
+            expect(res[0].datapoints.length).toBeGreaterThan(0);
+            expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
+              212,
+              5
+            );
+          });
         } finally {
           await client.timeseries.delete([{ id: tsId }]);
         }

--- a/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
+++ b/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 Cognite AS
+
+import type { Datapoints, DoubleDatapoint } from '@cognite/sdk';
+import { describe, expect, test } from 'vitest';
+import { randomInt } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClient from '../../cogniteClient';
+import { setupLoggedInClient } from '../testUtils';
+
+describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
+  'datapoints insertWithUnitConversion (beta)',
+  () => {
+    test('converts °F to stored °C before insert', async () => {
+      const client: CogniteClient = setupLoggedInClient();
+      const externalId = `beta_unit_write_${randomInt()}`;
+      const [created] = await client.timeseries.create([
+        {
+          name: 'beta insertWithUnitConversion',
+          externalId,
+          unitExternalId: 'temperature:deg_c',
+        },
+      ]);
+
+      const tsId = created.id;
+      const timestamp = Date.now();
+
+      try {
+        await client.datapoints.insertWithUnitConversion([
+          {
+            id: tsId,
+            sourceUnit: 'temperature:deg_f',
+            datapoints: [{ timestamp, value: 212 }],
+          },
+        ]);
+
+        const res = (await client.datapoints.retrieve({
+          items: [
+            {
+              id: tsId,
+              start: new Date(timestamp - 60_000),
+              end: new Date(timestamp + 60_000),
+            },
+          ],
+        })) as Datapoints[];
+
+        expect(res.length).toBe(1);
+        expect(res[0].datapoints.length).toBeGreaterThan(0);
+        expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
+          100,
+          5
+        );
+      } finally {
+        await client.timeseries.delete([{ id: tsId }]);
+      }
+    });
+  }
+);

--- a/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
+++ b/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
@@ -30,7 +30,7 @@ describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
         await client.datapoints.insertWithUnitConversion([
           {
             id: tsId,
-            sourceUnit: 'temperature:deg_f',
+            unit: { externalId: 'temperature:deg_f' },
             datapoints: [{ timestamp, value: 212 }],
           },
         ]);

--- a/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
+++ b/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2026 Cognite AS
 
-import type { Datapoints, DoubleDatapoint } from '@cognite/sdk';
+import type { DoubleDatapoint, DoubleDatapoints } from '@cognite/sdk';
 import { describe, expect, test } from 'vitest';
 import {
   randomInt,
@@ -44,7 +44,7 @@ describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
                 end: new Date(timestamp + 60_000),
               },
             ],
-          })) as Datapoints[];
+          })) as DoubleDatapoints[];
 
           expect(res.length).toBe(1);
           expect(res[0].datapoints.length).toBeGreaterThan(0);
@@ -66,7 +66,7 @@ describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
                 targetUnit: 'temperature:deg_f',
               },
             ],
-          })) as Datapoints[];
+          })) as DoubleDatapoints[];
 
           expect(res.length).toBe(1);
           expect(res[0].unitExternalId).toBe('temperature:deg_f');

--- a/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
+++ b/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
@@ -2,7 +2,10 @@
 
 import type { Datapoints, DoubleDatapoint } from '@cognite/sdk';
 import { describe, expect, test } from 'vitest';
-import { randomInt } from '../../../../core/src/__tests__/testUtils';
+import {
+  randomInt,
+  runTestWithRetryWhenFailing,
+} from '../../../../core/src/__tests__/testUtils';
 import type CogniteClient from '../../cogniteClient';
 import { setupLoggedInClient } from '../testUtils';
 
@@ -32,22 +35,24 @@ describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
           },
         ]);
 
-        const res = (await client.datapoints.retrieve({
-          items: [
-            {
-              id: tsId,
-              start: new Date(timestamp - 60_000),
-              end: new Date(timestamp + 60_000),
-            },
-          ],
-        })) as Datapoints[];
+        await runTestWithRetryWhenFailing(async () => {
+          const res = (await client.datapoints.retrieve({
+            items: [
+              {
+                id: tsId,
+                start: new Date(timestamp - 60_000),
+                end: new Date(timestamp + 60_000),
+              },
+            ],
+          })) as Datapoints[];
 
-        expect(res.length).toBe(1);
-        expect(res[0].datapoints.length).toBeGreaterThan(0);
-        expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
-          100,
-          5
-        );
+          expect(res.length).toBe(1);
+          expect(res[0].datapoints.length).toBeGreaterThan(0);
+          expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
+            100,
+            5
+          );
+        });
       } finally {
         await client.timeseries.delete([{ id: tsId }]);
       }

--- a/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
+++ b/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
@@ -12,77 +12,73 @@ import { setupLoggedInClient } from '../testUtils';
 describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
   'datapoints insertWithUnitConversion (beta)',
   () => {
-    test(
-      'converts °F to stored °C before insert',
-      async () => {
-        const client: CogniteClient = setupLoggedInClient();
-        const externalId = `beta_unit_write_${randomInt()}`;
-        const [created] = await client.timeseries.create([
+    test('converts °F to stored °C before insert', async () => {
+      const client: CogniteClient = setupLoggedInClient();
+      const externalId = `beta_unit_write_${randomInt()}`;
+      const [created] = await client.timeseries.create([
+        {
+          name: 'beta insertWithUnitConversion',
+          externalId,
+          unitExternalId: 'temperature:deg_c',
+        },
+      ]);
+
+      const tsId = created.id;
+      const timestamp = Date.now();
+
+      try {
+        await client.datapoints.insertWithUnitConversion([
           {
-            name: 'beta insertWithUnitConversion',
-            externalId,
-            unitExternalId: 'temperature:deg_c',
+            id: tsId,
+            sourceUnit: 'temperature:deg_f',
+            datapoints: [{ timestamp, value: 212 }],
           },
         ]);
 
-        const tsId = created.id;
-        const timestamp = Date.now();
+        await runTestWithRetryWhenFailing(async () => {
+          const res = (await client.datapoints.retrieve({
+            items: [
+              {
+                id: tsId,
+                start: new Date(timestamp - 60_000),
+                end: new Date(timestamp + 60_000),
+              },
+            ],
+          })) as Datapoints[];
 
-        try {
-          await client.datapoints.insertWithUnitConversion([
-            {
-              id: tsId,
-              sourceUnit: 'temperature:deg_f',
-              datapoints: [{ timestamp, value: 212 }],
-            },
-          ]);
+          expect(res.length).toBe(1);
+          expect(res[0].datapoints.length).toBeGreaterThan(0);
+          expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
+            100,
+            5
+          );
+        });
 
-          await runTestWithRetryWhenFailing(async () => {
-            const res = (await client.datapoints.retrieve({
-              items: [
-                {
-                  id: tsId,
-                  start: new Date(timestamp - 60_000),
-                  end: new Date(timestamp + 60_000),
-                },
-              ],
-            })) as Datapoints[];
+        // Round-trip: server-side conversion back to °F should yield the
+        // original input value within float tolerance.
+        await runTestWithRetryWhenFailing(async () => {
+          const res = (await client.datapoints.retrieve({
+            items: [
+              {
+                id: tsId,
+                start: new Date(timestamp - 60_000),
+                end: new Date(timestamp + 60_000),
+                targetUnit: 'temperature:deg_f',
+              },
+            ],
+          })) as Datapoints[];
 
-            expect(res.length).toBe(1);
-            expect(res[0].datapoints.length).toBeGreaterThan(0);
-            expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
-              100,
-              5
-            );
-          });
-
-          // Round-trip: server-side conversion back to °F should yield the
-          // original input value within float tolerance.
-          await runTestWithRetryWhenFailing(async () => {
-            const res = (await client.datapoints.retrieve({
-              items: [
-                {
-                  id: tsId,
-                  start: new Date(timestamp - 60_000),
-                  end: new Date(timestamp + 60_000),
-                  targetUnit: 'temperature:deg_f',
-                },
-              ],
-            })) as Datapoints[];
-
-            expect(res.length).toBe(1);
-            expect(res[0].unitExternalId).toBe('temperature:deg_f');
-            expect(res[0].datapoints.length).toBeGreaterThan(0);
-            expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
-              212,
-              5
-            );
-          });
-        } finally {
-          await client.timeseries.delete([{ id: tsId }]);
-        }
-      },
-      3 * 60 * 1000
-    );
+          expect(res.length).toBe(1);
+          expect(res[0].unitExternalId).toBe('temperature:deg_f');
+          expect(res[0].datapoints.length).toBeGreaterThan(0);
+          expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
+            212,
+            5
+          );
+        });
+      } finally {
+        await client.timeseries.delete([{ id: tsId }]);
+      }
+    });
   }
 );

--- a/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
+++ b/packages/beta/src/__tests__/api/datapointsInsertWithUnitConversion.int.spec.ts
@@ -12,50 +12,54 @@ import { setupLoggedInClient } from '../testUtils';
 describe.skipIf(!process.env.COGNITE_PROJECT || !process.env.COGNITE_BASE_URL)(
   'datapoints insertWithUnitConversion (beta)',
   () => {
-    test('converts °F to stored °C before insert', async () => {
-      const client: CogniteClient = setupLoggedInClient();
-      const externalId = `beta_unit_write_${randomInt()}`;
-      const [created] = await client.timeseries.create([
-        {
-          name: 'beta insertWithUnitConversion',
-          externalId,
-          unitExternalId: 'temperature:deg_c',
-        },
-      ]);
-
-      const tsId = created.id;
-      const timestamp = Date.now();
-
-      try {
-        await client.datapoints.insertWithUnitConversion([
+    test(
+      'converts °F to stored °C before insert',
+      async () => {
+        const client: CogniteClient = setupLoggedInClient();
+        const externalId = `beta_unit_write_${randomInt()}`;
+        const [created] = await client.timeseries.create([
           {
-            id: tsId,
-            sourceUnit: 'temperature:deg_f',
-            datapoints: [{ timestamp, value: 212 }],
+            name: 'beta insertWithUnitConversion',
+            externalId,
+            unitExternalId: 'temperature:deg_c',
           },
         ]);
 
-        await runTestWithRetryWhenFailing(async () => {
-          const res = (await client.datapoints.retrieve({
-            items: [
-              {
-                id: tsId,
-                start: new Date(timestamp - 60_000),
-                end: new Date(timestamp + 60_000),
-              },
-            ],
-          })) as Datapoints[];
+        const tsId = created.id;
+        const timestamp = Date.now();
 
-          expect(res.length).toBe(1);
-          expect(res[0].datapoints.length).toBeGreaterThan(0);
-          expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
-            100,
-            5
-          );
-        });
-      } finally {
-        await client.timeseries.delete([{ id: tsId }]);
-      }
-    });
+        try {
+          await client.datapoints.insertWithUnitConversion([
+            {
+              id: tsId,
+              sourceUnit: 'temperature:deg_f',
+              datapoints: [{ timestamp, value: 212 }],
+            },
+          ]);
+
+          await runTestWithRetryWhenFailing(async () => {
+            const res = (await client.datapoints.retrieve({
+              items: [
+                {
+                  id: tsId,
+                  start: new Date(timestamp - 60_000),
+                  end: new Date(timestamp + 60_000),
+                },
+              ],
+            })) as Datapoints[];
+
+            expect(res.length).toBe(1);
+            expect(res[0].datapoints.length).toBeGreaterThan(0);
+            expect((res[0].datapoints[0] as DoubleDatapoint).value).toBeCloseTo(
+              100,
+              5
+            );
+          });
+        } finally {
+          await client.timeseries.delete([{ id: tsId }]);
+        }
+      },
+      3 * 60 * 1000
+    );
   }
 );

--- a/packages/beta/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/beta/src/api/dataPoints/dataPointsApi.ts
@@ -19,6 +19,17 @@ import type {
 import { CogniteError } from '@cognite/sdk-core';
 import type { DatapointsInsertWithUnitItem } from './types';
 
+const CONVERSION_SIG_DIGITS = 12;
+
+function roundToSigDigits(value: number, digits: number): number {
+  if (value === 0) return 0;
+  const factor = Math.pow(
+    10,
+    digits - Math.floor(Math.log10(Math.abs(value))) - 1
+  );
+  return Math.round(value * factor) / factor;
+}
+
 /** @hidden */
 export function convertBetweenUnitConversions(
   value: number,
@@ -29,7 +40,10 @@ export function convertBetweenUnitConversions(
     return value;
   }
   const base = (value + src.offset) * src.multiplier;
-  return base / dst.multiplier - dst.offset;
+  return roundToSigDigits(
+    base / dst.multiplier - dst.offset,
+    CONVERSION_SIG_DIGITS
+  );
 }
 
 function timeSeriesLookupKeys(ts: TimeSeries): string[] {
@@ -68,20 +82,10 @@ function toRetrieveId(
   return { instanceId: item.instanceId };
 }
 
-function idsEqual(a: IdEitherWithInstance, b: IdEitherWithInstance): boolean {
-  if ('id' in a && 'id' in b) {
-    return a.id === b.id;
-  }
-  if ('externalId' in a && 'externalId' in b) {
-    return a.externalId === b.externalId;
-  }
-  if ('instanceId' in a && 'instanceId' in b) {
-    return (
-      a.instanceId.space === b.instanceId.space &&
-      a.instanceId.externalId === b.instanceId.externalId
-    );
-  }
-  return false;
+function retrieveIdKey(id: IdEitherWithInstance): string {
+  if ('id' in id) return `id:${id.id}`;
+  if ('externalId' in id) return `ext:${id.externalId}`;
+  return `inst:${id.instanceId.space}:${id.instanceId.externalId}`;
 }
 
 /**
@@ -172,21 +176,9 @@ export class BetaDataPointsAPI extends DataPointsAPI {
     const result: DatapointsInsertItem[] = [];
     for (const item of items) {
       const key = insertItemLookupKey(item);
-      const targetUnitExternalId = unitByTsKey.get(key);
-      if (targetUnitExternalId == null) {
-        throw new CogniteError(
-          `Time series unit not resolved for insert item (key=${key})`,
-          400
-        );
-      }
-      const srcUnit = unitByExternalId.get(item.sourceUnit);
-      const dstUnit = unitByExternalId.get(targetUnitExternalId);
-      if (srcUnit == null || dstUnit == null) {
-        throw new CogniteError(
-          'Internal error: unit missing after catalog validation',
-          500
-        );
-      }
+      const targetUnitExternalId = unitByTsKey.get(key)!;
+      const srcUnit = unitByExternalId.get(item.sourceUnit)!;
+      const dstUnit = unitByExternalId.get(targetUnitExternalId)!;
 
       if (srcUnit.quantity !== dstUnit.quantity) {
         throw new CogniteError(
@@ -226,11 +218,10 @@ export class BetaDataPointsAPI extends DataPointsAPI {
 function dedupeRetrieveIds(
   ids: IdEitherWithInstance[]
 ): IdEitherWithInstance[] {
-  const out: IdEitherWithInstance[] = [];
+  const seen = new Map<string, IdEitherWithInstance>();
   for (const id of ids) {
-    if (!out.some((existing) => idsEqual(existing, id))) {
-      out.push(id);
-    }
+    const key = retrieveIdKey(id);
+    if (!seen.has(key)) seen.set(key, id);
   }
-  return out;
+  return [...seen.values()];
 }

--- a/packages/beta/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/beta/src/api/dataPoints/dataPointsApi.ts
@@ -28,8 +28,8 @@ export function convertBetweenUnitConversions(
   if (src.multiplier === dst.multiplier && src.offset === dst.offset) {
     return value;
   }
-  const base = value * src.multiplier + src.offset;
-  return (base - dst.offset) / dst.multiplier;
+  const base = (value + src.offset) * src.multiplier;
+  return base / dst.multiplier - dst.offset;
 }
 
 function timeSeriesLookupKeys(ts: TimeSeries): string[] {
@@ -101,7 +101,7 @@ export class BetaDataPointsAPI extends DataPointsAPI {
   /**
    * Insert datapoints after converting numeric values from `sourceUnit` to each time
    * series' stored `unitExternalId` (resolved via {@link TimeSeriesAPI.retrieve}).
-   * Fetches unit definitions with {@link UnitsAPI.retrieve} (deduped, batched by the SDK).
+   * Fetches unit definitions with {@link UnitsAPI.retrieve}.
    * String datapoint values are not supported.
    */
   public insertWithUnitConversion = async (

--- a/packages/beta/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/beta/src/api/dataPoints/dataPointsApi.ts
@@ -23,10 +23,7 @@ const CONVERSION_SIG_DIGITS = 12;
 
 function roundToSigDigits(value: number, digits: number): number {
   if (value === 0) return 0;
-  const factor = Math.pow(
-    10,
-    digits - Math.floor(Math.log10(Math.abs(value))) - 1
-  );
+  const factor = 10 ** (digits - Math.floor(Math.log10(Math.abs(value))) - 1);
   return Math.round(value * factor) / factor;
 }
 
@@ -176,9 +173,9 @@ export class BetaDataPointsAPI extends DataPointsAPI {
     const result: DatapointsInsertItem[] = [];
     for (const item of items) {
       const key = insertItemLookupKey(item);
-      const targetUnitExternalId = unitByTsKey.get(key)!;
-      const srcUnit = unitByExternalId.get(item.sourceUnit)!;
-      const dstUnit = unitByExternalId.get(targetUnitExternalId)!;
+      const targetUnitExternalId = unitByTsKey.get(key) as CogniteExternalId;
+      const srcUnit = unitByExternalId.get(item.sourceUnit) as Unit;
+      const dstUnit = unitByExternalId.get(targetUnitExternalId) as Unit;
 
       if (srcUnit.quantity !== dstUnit.quantity) {
         throw new CogniteError(

--- a/packages/beta/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/beta/src/api/dataPoints/dataPointsApi.ts
@@ -1,0 +1,236 @@
+// Copyright 2026 Cognite AS
+
+import { DataPointsAPI } from '@cognite/sdk';
+import type {
+  DatapointWrite,
+  DatapointsInsertItem,
+  TimeSeries,
+  TimeSeriesAPI,
+  Unit,
+  UnitConversion,
+  UnitsAPI,
+} from '@cognite/sdk';
+import type {
+  CDFHttpClient,
+  CogniteExternalId,
+  IdEitherWithInstance,
+  MetadataMap,
+} from '@cognite/sdk-core';
+import { CogniteError } from '@cognite/sdk-core';
+import type { DatapointsInsertWithUnitItem } from './types';
+
+/** @hidden */
+export function convertBetweenUnitConversions(
+  value: number,
+  src: UnitConversion,
+  dst: UnitConversion
+): number {
+  if (src.multiplier === dst.multiplier && src.offset === dst.offset) {
+    return value;
+  }
+  const base = value * src.multiplier + src.offset;
+  return (base - dst.offset) / dst.multiplier;
+}
+
+function timeSeriesLookupKeys(ts: TimeSeries): string[] {
+  const keys: string[] = [];
+  if (ts.id != null) {
+    keys.push(`id:${ts.id}`);
+  }
+  if (ts.externalId != null && ts.externalId !== '') {
+    keys.push(`ext:${ts.externalId}`);
+  }
+  if (ts.instanceId != null) {
+    keys.push(`inst:${ts.instanceId.space}:${ts.instanceId.externalId}`);
+  }
+  return keys;
+}
+
+function insertItemLookupKey(item: DatapointsInsertWithUnitItem): string {
+  if ('id' in item) {
+    return `id:${item.id}`;
+  }
+  if ('externalId' in item) {
+    return `ext:${item.externalId}`;
+  }
+  return `inst:${item.instanceId.space}:${item.instanceId.externalId}`;
+}
+
+function toRetrieveId(
+  item: DatapointsInsertWithUnitItem
+): IdEitherWithInstance {
+  if ('id' in item) {
+    return { id: item.id };
+  }
+  if ('externalId' in item) {
+    return { externalId: item.externalId };
+  }
+  return { instanceId: item.instanceId };
+}
+
+function idsEqual(a: IdEitherWithInstance, b: IdEitherWithInstance): boolean {
+  if ('id' in a && 'id' in b) {
+    return a.id === b.id;
+  }
+  if ('externalId' in a && 'externalId' in b) {
+    return a.externalId === b.externalId;
+  }
+  if ('instanceId' in a && 'instanceId' in b) {
+    return (
+      a.instanceId.space === b.instanceId.space &&
+      a.instanceId.externalId === b.instanceId.externalId
+    );
+  }
+  return false;
+}
+
+/**
+ * Beta extension of {@link DataPointsAPI} with unit-aware insert.
+ */
+export class BetaDataPointsAPI extends DataPointsAPI {
+  constructor(
+    resourcePath: string,
+    httpClient: CDFHttpClient,
+    map: MetadataMap,
+    private readonly timeSeriesApi: TimeSeriesAPI,
+    private readonly unitsApi: UnitsAPI
+  ) {
+    super(resourcePath, httpClient, map);
+  }
+
+  /**
+   * Insert datapoints after converting numeric values from `sourceUnit` to each time
+   * series' stored `unitExternalId` (resolved via {@link TimeSeriesAPI.retrieve}).
+   * Fetches unit definitions with {@link UnitsAPI.retrieve} (deduped, batched by the SDK).
+   * String datapoint values are not supported.
+   */
+  public insertWithUnitConversion = async (
+    items: DatapointsInsertWithUnitItem[]
+  ): Promise<object> => {
+    const converted = await this.convertInsertItemsWithUnit(items);
+    return this.insert(converted);
+  };
+
+  private async convertInsertItemsWithUnit(
+    items: DatapointsInsertWithUnitItem[]
+  ): Promise<DatapointsInsertItem[]> {
+    if (items.length === 0) {
+      return [];
+    }
+
+    const retrieveIds = dedupeRetrieveIds(items.map(toRetrieveId));
+    const timeSeriesList = await this.timeSeriesApi.retrieve(retrieveIds, {
+      ignoreUnknownIds: false,
+    });
+
+    const unitByTsKey = new Map<string, CogniteExternalId>();
+    for (const ts of timeSeriesList) {
+      const unitExternalId = ts.unitExternalId;
+      if (unitExternalId == null || unitExternalId === '') {
+        throw new CogniteError(
+          `Time series is missing unitExternalId (required for insertWithUnitConversion). Time series id=${ts.id}, externalId=${ts.externalId ?? 'n/a'}`,
+          400
+        );
+      }
+      for (const key of timeSeriesLookupKeys(ts)) {
+        unitByTsKey.set(key, unitExternalId);
+      }
+    }
+
+    const unitExternalIdsToLoad = new Set<string>();
+    for (const item of items) {
+      const key = insertItemLookupKey(item);
+      const targetUnit = unitByTsKey.get(key);
+      if (targetUnit == null) {
+        throw new CogniteError(
+          `Time series not found in retrieve response for insert item (key=${key})`,
+          400
+        );
+      }
+      unitExternalIdsToLoad.add(item.sourceUnit);
+      unitExternalIdsToLoad.add(targetUnit);
+    }
+
+    const unitIds = [...unitExternalIdsToLoad].map((externalId) => ({
+      externalId,
+    }));
+    const unitsList = await this.unitsApi.retrieve(unitIds);
+    const unitByExternalId = new Map<string, Unit>();
+    for (const u of unitsList) {
+      unitByExternalId.set(u.externalId, u);
+    }
+
+    for (const extId of unitExternalIdsToLoad) {
+      if (!unitByExternalId.has(extId)) {
+        throw new CogniteError(
+          `Unknown unit externalId in unit catalog: ${extId}`,
+          400
+        );
+      }
+    }
+
+    const result: DatapointsInsertItem[] = [];
+    for (const item of items) {
+      const key = insertItemLookupKey(item);
+      const targetUnitExternalId = unitByTsKey.get(key);
+      if (targetUnitExternalId == null) {
+        throw new CogniteError(
+          `Time series unit not resolved for insert item (key=${key})`,
+          400
+        );
+      }
+      const srcUnit = unitByExternalId.get(item.sourceUnit);
+      const dstUnit = unitByExternalId.get(targetUnitExternalId);
+      if (srcUnit == null || dstUnit == null) {
+        throw new CogniteError(
+          'Internal error: unit missing after catalog validation',
+          500
+        );
+      }
+
+      if (srcUnit.quantity !== dstUnit.quantity) {
+        throw new CogniteError(
+          `Incompatible units for conversion: sourceUnit=${item.sourceUnit} (quantity=${srcUnit.quantity}) vs time series unit=${targetUnitExternalId} (quantity=${dstUnit.quantity})`,
+          400
+        );
+      }
+
+      const convertedDatapoints: DatapointWrite[] = item.datapoints.map(
+        (dp: DatapointWrite) => {
+          if (typeof dp.value === 'string') {
+            throw new CogniteError(
+              'insertWithUnitConversion does not support string datapoint values',
+              400
+            );
+          }
+          const newValue = convertBetweenUnitConversions(
+            dp.value,
+            srcUnit.conversion,
+            dstUnit.conversion
+          );
+          return { ...dp, value: newValue };
+        }
+      );
+
+      const { sourceUnit: _ignored, ...rest } = item;
+      result.push({
+        ...rest,
+        datapoints: convertedDatapoints,
+      } as DatapointsInsertItem);
+    }
+
+    return result;
+  }
+}
+
+function dedupeRetrieveIds(
+  ids: IdEitherWithInstance[]
+): IdEitherWithInstance[] {
+  const out: IdEitherWithInstance[] = [];
+  for (const id of ids) {
+    if (!out.some((existing) => idsEqual(existing, id))) {
+      out.push(id);
+    }
+  }
+  return out;
+}

--- a/packages/beta/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/beta/src/api/dataPoints/dataPointsApi.ts
@@ -19,28 +19,13 @@ import type {
 import { CogniteError } from '@cognite/sdk-core';
 import type { DatapointsInsertWithUnitItem } from './types';
 
-const CONVERSION_SIG_DIGITS = 12;
-
-function roundToSigDigits(value: number, digits: number): number {
-  if (value === 0) return 0;
-  const factor = 10 ** (digits - Math.floor(Math.log10(Math.abs(value))) - 1);
-  return Math.round(value * factor) / factor;
-}
-
-/** @hidden */
-export function convertBetweenUnitConversions(
+function convertBetweenUnitConversions(
   value: number,
   src: UnitConversion,
   dst: UnitConversion
 ): number {
-  if (src.multiplier === dst.multiplier && src.offset === dst.offset) {
-    return value;
-  }
   const base = (value + src.offset) * src.multiplier;
-  return roundToSigDigits(
-    base / dst.multiplier - dst.offset,
-    CONVERSION_SIG_DIGITS
-  );
+  return base / dst.multiplier - dst.offset;
 }
 
 function timeSeriesLookupKeys(ts: TimeSeries): string[] {
@@ -85,9 +70,18 @@ function retrieveIdKey(id: IdEitherWithInstance): string {
   return `inst:${id.instanceId.space}:${id.instanceId.externalId}`;
 }
 
-/**
- * Beta extension of {@link DataPointsAPI} with unit-aware insert.
- */
+function dedupeRetrieveIds(
+  ids: IdEitherWithInstance[]
+): IdEitherWithInstance[] {
+  const seen = new Map<string, IdEitherWithInstance>();
+  for (const id of ids) {
+    const key = retrieveIdKey(id);
+    if (!seen.has(key)) seen.set(key, id);
+  }
+  return [...seen.values()];
+}
+
+/** Beta extension of {@link DataPointsAPI} with unit-aware insert. */
 export class BetaDataPointsAPI extends DataPointsAPI {
   constructor(
     resourcePath: string,
@@ -100,14 +94,15 @@ export class BetaDataPointsAPI extends DataPointsAPI {
   }
 
   /**
-   * Insert datapoints after converting numeric values from `sourceUnit` to each time
-   * series' stored `unitExternalId` (resolved via {@link TimeSeriesAPI.retrieve}).
-   * Fetches unit definitions with {@link UnitsAPI.retrieve}.
-   * String datapoint values are not supported.
+   * Insert datapoints, converting numeric values from `unit.externalId` to each time
+   * series' stored `unitExternalId` before posting. Only numeric time series are supported.
    */
   public insertWithUnitConversion = async (
     items: DatapointsInsertWithUnitItem[]
   ): Promise<object> => {
+    if (items.length === 0) {
+      return {};
+    }
     const converted = await this.convertInsertItemsWithUnit(items);
     return this.insert(converted);
   };
@@ -115,10 +110,6 @@ export class BetaDataPointsAPI extends DataPointsAPI {
   private async convertInsertItemsWithUnit(
     items: DatapointsInsertWithUnitItem[]
   ): Promise<DatapointsInsertItem[]> {
-    if (items.length === 0) {
-      return [];
-    }
-
     const retrieveIds = dedupeRetrieveIds(items.map(toRetrieveId));
     const timeSeriesList = await this.timeSeriesApi.retrieve(retrieveIds, {
       ignoreUnknownIds: false,
@@ -126,6 +117,12 @@ export class BetaDataPointsAPI extends DataPointsAPI {
 
     const unitByTsKey = new Map<string, CogniteExternalId>();
     for (const ts of timeSeriesList) {
+      if (ts.type !== 'numeric') {
+        throw new CogniteError(
+          `insertWithUnitConversion only supports numeric time series (type=${ts.type ?? 'unknown'}). Time series id=${ts.id}, externalId=${ts.externalId ?? 'n/a'}`,
+          400
+        );
+      }
       const unitExternalId = ts.unitExternalId;
       if (unitExternalId == null || unitExternalId === '') {
         throw new CogniteError(
@@ -148,60 +145,51 @@ export class BetaDataPointsAPI extends DataPointsAPI {
           400
         );
       }
-      unitExternalIdsToLoad.add(item.sourceUnit);
+      unitExternalIdsToLoad.add(item.unit.externalId);
       unitExternalIdsToLoad.add(targetUnit);
     }
 
-    const unitIds = [...unitExternalIdsToLoad].map((externalId) => ({
-      externalId,
-    }));
-    const unitsList = await this.unitsApi.retrieve(unitIds);
+    const unitsList = await this.unitsApi.retrieve(
+      [...unitExternalIdsToLoad].map((externalId) => ({ externalId }))
+    );
     const unitByExternalId = new Map<string, Unit>();
     for (const u of unitsList) {
       unitByExternalId.set(u.externalId, u);
-    }
-
-    for (const extId of unitExternalIdsToLoad) {
-      if (!unitByExternalId.has(extId)) {
-        throw new CogniteError(
-          `Unknown unit externalId in unit catalog: ${extId}`,
-          400
-        );
-      }
     }
 
     const result: DatapointsInsertItem[] = [];
     for (const item of items) {
       const key = insertItemLookupKey(item);
       const targetUnitExternalId = unitByTsKey.get(key) as CogniteExternalId;
-      const srcUnit = unitByExternalId.get(item.sourceUnit) as Unit;
+      const sourceUnitExternalId = item.unit.externalId;
+      const sameUnit = sourceUnitExternalId === targetUnitExternalId;
+      const srcUnit = unitByExternalId.get(sourceUnitExternalId) as Unit;
       const dstUnit = unitByExternalId.get(targetUnitExternalId) as Unit;
 
       if (srcUnit.quantity !== dstUnit.quantity) {
         throw new CogniteError(
-          `Incompatible units for conversion: sourceUnit=${item.sourceUnit} (quantity=${srcUnit.quantity}) vs time series unit=${targetUnitExternalId} (quantity=${dstUnit.quantity})`,
+          `Incompatible units for conversion: unit.externalId=${sourceUnitExternalId} (quantity=${srcUnit.quantity}) vs time series unit=${targetUnitExternalId} (quantity=${dstUnit.quantity})`,
           400
         );
       }
 
       const convertedDatapoints: DatapointWrite[] = item.datapoints.map(
         (dp: DatapointWrite) => {
-          if (typeof dp.value === 'string') {
-            throw new CogniteError(
-              'insertWithUnitConversion does not support string datapoint values',
-              400
-            );
+          if (typeof dp.value === 'string' || sameUnit) {
+            return dp;
           }
-          const newValue = convertBetweenUnitConversions(
-            dp.value,
-            srcUnit.conversion,
-            dstUnit.conversion
-          );
-          return { ...dp, value: newValue };
+          return {
+            ...dp,
+            value: convertBetweenUnitConversions(
+              dp.value,
+              srcUnit.conversion,
+              dstUnit.conversion
+            ),
+          };
         }
       );
 
-      const { sourceUnit: _ignored, ...rest } = item;
+      const { unit: _ignored, ...rest } = item;
       result.push({
         ...rest,
         datapoints: convertedDatapoints,
@@ -210,15 +198,4 @@ export class BetaDataPointsAPI extends DataPointsAPI {
 
     return result;
   }
-}
-
-function dedupeRetrieveIds(
-  ids: IdEitherWithInstance[]
-): IdEitherWithInstance[] {
-  const seen = new Map<string, IdEitherWithInstance>();
-  for (const id of ids) {
-    const key = retrieveIdKey(id);
-    if (!seen.has(key)) seen.set(key, id);
-  }
-  return [...seen.values()];
 }

--- a/packages/beta/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/beta/src/api/dataPoints/dataPointsApi.ts
@@ -19,6 +19,82 @@ import type {
 import { CogniteError } from '@cognite/sdk-core';
 import type { DatapointsInsertWithUnitItem } from './types';
 
+type Identifier =
+  | { kind: 'id'; id: number }
+  | { kind: 'ext'; externalId: string }
+  | { kind: 'inst'; space: string; externalId: string };
+
+function identifierKey(i: Identifier): string {
+  switch (i.kind) {
+    case 'id':
+      return `id:${i.id}`;
+    case 'ext':
+      return `ext:${i.externalId}`;
+    case 'inst':
+      return `inst:${i.space}:${i.externalId}`;
+  }
+}
+
+function identifierToRetrieveId(i: Identifier): IdEitherWithInstance {
+  switch (i.kind) {
+    case 'id':
+      return { id: i.id };
+    case 'ext':
+      return { externalId: i.externalId };
+    case 'inst':
+      return { instanceId: { space: i.space, externalId: i.externalId } };
+  }
+}
+
+function toIdentifier(id: IdEitherWithInstance): Identifier {
+  if ('id' in id) return { kind: 'id', id: id.id };
+  if ('externalId' in id) return { kind: 'ext', externalId: id.externalId };
+  return {
+    kind: 'inst',
+    space: id.instanceId.space,
+    externalId: id.instanceId.externalId,
+  };
+}
+
+function itemIdentifier(item: DatapointsInsertWithUnitItem): Identifier {
+  if ('id' in item) return { kind: 'id', id: item.id };
+  if ('externalId' in item) return { kind: 'ext', externalId: item.externalId };
+  return {
+    kind: 'inst',
+    space: item.instanceId.space,
+    externalId: item.instanceId.externalId,
+  };
+}
+
+function* timeSeriesIdentifiers(ts: TimeSeries): Iterable<Identifier> {
+  if (ts.id != null) yield { kind: 'id', id: ts.id };
+  if (ts.externalId != null && ts.externalId !== '') {
+    yield { kind: 'ext', externalId: ts.externalId };
+  }
+  if (ts.instanceId != null) {
+    yield {
+      kind: 'inst',
+      space: ts.instanceId.space,
+      externalId: ts.instanceId.externalId,
+    };
+  }
+}
+
+function dedupeRetrieveIds(
+  ids: IdEitherWithInstance[]
+): IdEitherWithInstance[] {
+  const seen = new Map<string, IdEitherWithInstance>();
+  for (const id of ids) {
+    const key = identifierKey(toIdentifier(id));
+    if (!seen.has(key)) seen.set(key, id);
+  }
+  return [...seen.values()];
+}
+
+function fail(message: string): never {
+  throw new CogniteError(message, 400);
+}
+
 function convertBetweenUnitConversions(
   value: number,
   src: UnitConversion,
@@ -28,57 +104,14 @@ function convertBetweenUnitConversions(
   return base / dst.multiplier - dst.offset;
 }
 
-function timeSeriesLookupKeys(ts: TimeSeries): string[] {
-  const keys: string[] = [];
-  if (ts.id != null) {
-    keys.push(`id:${ts.id}`);
-  }
-  if (ts.externalId != null && ts.externalId !== '') {
-    keys.push(`ext:${ts.externalId}`);
-  }
-  if (ts.instanceId != null) {
-    keys.push(`inst:${ts.instanceId.space}:${ts.instanceId.externalId}`);
-  }
-  return keys;
-}
-
-function insertItemLookupKey(item: DatapointsInsertWithUnitItem): string {
-  if ('id' in item) {
-    return `id:${item.id}`;
-  }
-  if ('externalId' in item) {
-    return `ext:${item.externalId}`;
-  }
-  return `inst:${item.instanceId.space}:${item.instanceId.externalId}`;
-}
-
-function toRetrieveId(
-  item: DatapointsInsertWithUnitItem
-): IdEitherWithInstance {
-  if ('id' in item) {
-    return { id: item.id };
-  }
-  if ('externalId' in item) {
-    return { externalId: item.externalId };
-  }
-  return { instanceId: item.instanceId };
-}
-
-function retrieveIdKey(id: IdEitherWithInstance): string {
-  if ('id' in id) return `id:${id.id}`;
-  if ('externalId' in id) return `ext:${id.externalId}`;
-  return `inst:${id.instanceId.space}:${id.instanceId.externalId}`;
-}
-
-function dedupeRetrieveIds(
-  ids: IdEitherWithInstance[]
-): IdEitherWithInstance[] {
-  const seen = new Map<string, IdEitherWithInstance>();
-  for (const id of ids) {
-    const key = retrieveIdKey(id);
-    if (!seen.has(key)) seen.set(key, id);
-  }
-  return [...seen.values()];
+function convertDatapoint(
+  dp: DatapointWrite,
+  sameUnit: boolean,
+  src: UnitConversion,
+  dst: UnitConversion
+): DatapointWrite {
+  if (typeof dp.value === 'string' || sameUnit) return dp;
+  return { ...dp, value: convertBetweenUnitConversions(dp.value, src, dst) };
 }
 
 /** Beta extension of {@link DataPointsAPI} with unit-aware insert. */
@@ -110,7 +143,19 @@ export class BetaDataPointsAPI extends DataPointsAPI {
   private async convertInsertItemsWithUnit(
     items: DatapointsInsertWithUnitItem[]
   ): Promise<DatapointsInsertItem[]> {
-    const retrieveIds = dedupeRetrieveIds(items.map(toRetrieveId));
+    const unitByTsKey = await this.resolveTargetUnits(items);
+    const unitByExternalId = await this.loadUnitCatalog(items, unitByTsKey);
+    return items.map((item) =>
+      this.convertItem(item, unitByTsKey, unitByExternalId)
+    );
+  }
+
+  private async resolveTargetUnits(
+    items: DatapointsInsertWithUnitItem[]
+  ): Promise<Map<string, CogniteExternalId>> {
+    const retrieveIds = dedupeRetrieveIds(
+      items.map((item) => identifierToRetrieveId(itemIdentifier(item)))
+    );
     const timeSeriesList = await this.timeSeriesApi.retrieve(retrieveIds, {
       ignoreUnknownIds: false,
     });
@@ -118,31 +163,34 @@ export class BetaDataPointsAPI extends DataPointsAPI {
     const unitByTsKey = new Map<string, CogniteExternalId>();
     for (const ts of timeSeriesList) {
       if (ts.type !== 'numeric') {
-        throw new CogniteError(
-          `insertWithUnitConversion only supports numeric time series (type=${ts.type ?? 'unknown'}). Time series id=${ts.id}, externalId=${ts.externalId ?? 'n/a'}`,
-          400
+        fail(
+          `insertWithUnitConversion only supports numeric time series (type=${ts.type ?? 'unknown'}). Time series id=${ts.id}, externalId=${ts.externalId ?? 'n/a'}`
         );
       }
       const unitExternalId = ts.unitExternalId;
       if (unitExternalId == null || unitExternalId === '') {
-        throw new CogniteError(
-          `Time series is missing unitExternalId (required for insertWithUnitConversion). Time series id=${ts.id}, externalId=${ts.externalId ?? 'n/a'}`,
-          400
+        fail(
+          `Time series is missing unitExternalId (required for insertWithUnitConversion). Time series id=${ts.id}, externalId=${ts.externalId ?? 'n/a'}`
         );
       }
-      for (const key of timeSeriesLookupKeys(ts)) {
-        unitByTsKey.set(key, unitExternalId);
+      for (const id of timeSeriesIdentifiers(ts)) {
+        unitByTsKey.set(identifierKey(id), unitExternalId);
       }
     }
+    return unitByTsKey;
+  }
 
+  private async loadUnitCatalog(
+    items: DatapointsInsertWithUnitItem[],
+    unitByTsKey: Map<string, CogniteExternalId>
+  ): Promise<Map<string, Unit>> {
     const unitExternalIdsToLoad = new Set<string>();
     for (const item of items) {
-      const key = insertItemLookupKey(item);
+      const key = identifierKey(itemIdentifier(item));
       const targetUnit = unitByTsKey.get(key);
       if (targetUnit == null) {
-        throw new CogniteError(
-          `Time series not found in retrieve response for insert item (key=${key})`,
-          400
+        fail(
+          `Time series not found in retrieve response for insert item (key=${key})`
         );
       }
       unitExternalIdsToLoad.add(item.unit.externalId);
@@ -156,46 +204,35 @@ export class BetaDataPointsAPI extends DataPointsAPI {
     for (const u of unitsList) {
       unitByExternalId.set(u.externalId, u);
     }
+    return unitByExternalId;
+  }
 
-    const result: DatapointsInsertItem[] = [];
-    for (const item of items) {
-      const key = insertItemLookupKey(item);
-      const targetUnitExternalId = unitByTsKey.get(key) as CogniteExternalId;
-      const sourceUnitExternalId = item.unit.externalId;
-      const sameUnit = sourceUnitExternalId === targetUnitExternalId;
-      const srcUnit = unitByExternalId.get(sourceUnitExternalId) as Unit;
-      const dstUnit = unitByExternalId.get(targetUnitExternalId) as Unit;
+  private convertItem(
+    item: DatapointsInsertWithUnitItem,
+    unitByTsKey: Map<string, CogniteExternalId>,
+    unitByExternalId: Map<string, Unit>
+  ): DatapointsInsertItem {
+    const key = identifierKey(itemIdentifier(item));
+    const targetUnitExternalId = unitByTsKey.get(key) as CogniteExternalId;
+    const sourceUnitExternalId = item.unit.externalId;
+    const sameUnit = sourceUnitExternalId === targetUnitExternalId;
+    const srcUnit = unitByExternalId.get(sourceUnitExternalId) as Unit;
+    const dstUnit = unitByExternalId.get(targetUnitExternalId) as Unit;
 
-      if (srcUnit.quantity !== dstUnit.quantity) {
-        throw new CogniteError(
-          `Incompatible units for conversion: unit.externalId=${sourceUnitExternalId} (quantity=${srcUnit.quantity}) vs time series unit=${targetUnitExternalId} (quantity=${dstUnit.quantity})`,
-          400
-        );
-      }
-
-      const convertedDatapoints: DatapointWrite[] = item.datapoints.map(
-        (dp: DatapointWrite) => {
-          if (typeof dp.value === 'string' || sameUnit) {
-            return dp;
-          }
-          return {
-            ...dp,
-            value: convertBetweenUnitConversions(
-              dp.value,
-              srcUnit.conversion,
-              dstUnit.conversion
-            ),
-          };
-        }
+    if (srcUnit.quantity !== dstUnit.quantity) {
+      fail(
+        `Incompatible units for conversion: unit.externalId=${sourceUnitExternalId} (quantity=${srcUnit.quantity}) vs time series unit=${targetUnitExternalId} (quantity=${dstUnit.quantity})`
       );
-
-      const { unit: _ignored, ...rest } = item;
-      result.push({
-        ...rest,
-        datapoints: convertedDatapoints,
-      } as DatapointsInsertItem);
     }
 
-    return result;
+    const convertedDatapoints = item.datapoints.map((dp) =>
+      convertDatapoint(dp, sameUnit, srcUnit.conversion, dstUnit.conversion)
+    );
+
+    const { unit: _ignored, ...rest } = item;
+    return {
+      ...rest,
+      datapoints: convertedDatapoints,
+    } as DatapointsInsertItem;
   }
 }

--- a/packages/beta/src/api/dataPoints/types.ts
+++ b/packages/beta/src/api/dataPoints/types.ts
@@ -8,8 +8,7 @@ import type {
 import type { CogniteExternalId } from '@cognite/sdk-core';
 
 /**
- * Unit catalog reference for supplied datapoint values (same shape as unit references
- * elsewhere in CDF APIs, e.g. `RecordUnitReference`). Stripped before the insert request is sent.
+ * Unit catalog reference for supplied datapoint values
  */
 export interface WithInsertUnit {
   unit: {

--- a/packages/beta/src/api/dataPoints/types.ts
+++ b/packages/beta/src/api/dataPoints/types.ts
@@ -8,19 +8,21 @@ import type {
 import type { CogniteExternalId } from '@cognite/sdk-core';
 
 /**
- * Unit catalog externalId of the supplied datapoint values (e.g. `"temperature:deg_f"`).
- * Must belong to the same quantity as the time series' stored `unitExternalId`.
+ * Unit catalog reference for supplied datapoint values (same shape as unit references
+ * elsewhere in CDF APIs, e.g. `RecordUnitReference`). Stripped before the insert request is sent.
  */
-export interface WithSourceUnit {
-  sourceUnit: CogniteExternalId;
+export interface WithInsertUnit {
+  unit: {
+    externalId: CogniteExternalId;
+  };
 }
 
 /**
  * Insert payload for {@link BetaDataPointsAPI.insertWithUnitConversion}: same shape as
- * stable insert items, with a required `sourceUnit` for client-side conversion to the
+ * stable insert items, with a required `unit.externalId` for client-side conversion to the
  * time series' stored unit before posting.
  */
 export type DatapointsInsertWithUnitItem =
-  | (DatapointsInsertById & WithSourceUnit)
-  | (DatapointsInsertByExternalId & WithSourceUnit)
-  | (DatapointsInsertByInstanceId & WithSourceUnit);
+  | (DatapointsInsertById & WithInsertUnit)
+  | (DatapointsInsertByExternalId & WithInsertUnit)
+  | (DatapointsInsertByInstanceId & WithInsertUnit);

--- a/packages/beta/src/api/dataPoints/types.ts
+++ b/packages/beta/src/api/dataPoints/types.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 Cognite AS
+
+import type {
+  DatapointsInsertByExternalId,
+  DatapointsInsertById,
+  DatapointsInsertByInstanceId,
+} from '@cognite/sdk';
+import type { CogniteExternalId } from '@cognite/sdk-core';
+
+/**
+ * Unit catalog externalId of the supplied datapoint values (e.g. `"temperature:deg_f"`).
+ * Must belong to the same quantity as the time series' stored `unitExternalId`.
+ */
+export interface WithSourceUnit {
+  sourceUnit: CogniteExternalId;
+}
+
+/**
+ * Insert payload for {@link BetaDataPointsAPI.insertWithUnitConversion}: same shape as
+ * stable insert items, with a required `sourceUnit` for client-side conversion to the
+ * time series' stored unit before posting.
+ */
+export type DatapointsInsertWithUnitItem =
+  | (DatapointsInsertById & WithSourceUnit)
+  | (DatapointsInsertByExternalId & WithSourceUnit)
+  | (DatapointsInsertByInstanceId & WithSourceUnit);

--- a/packages/beta/src/cogniteClient.ts
+++ b/packages/beta/src/cogniteClient.ts
@@ -4,6 +4,7 @@ import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
 import { accessApi } from '@cognite/sdk-core';
 import { version } from '../package.json';
 import { AlertsAPI } from './api/alerts/alertsApi';
+import { BetaDataPointsAPI } from './api/dataPoints/dataPointsApi';
 import { MonitoringTasksAPI } from './api/monitoringTasks/monitoringTasksApi';
 
 class CogniteClientCleaned extends CogniteClientStable {
@@ -31,9 +32,17 @@ export default class CogniteClient extends CogniteClientCleaned {
   private alertsApi?: AlertsAPI;
   private monitoringTasksApi?: MonitoringTasksAPI;
 
+  /** @hidden Narrowed in beta to expose {@link BetaDataPointsAPI.insertWithUnitConversion}. */
+  protected declare dataPointsApi?: BetaDataPointsAPI;
+
   public get alerts() {
     return accessApi(this.alertsApi);
   }
+
+  public override get datapoints() {
+    return accessApi(this.dataPointsApi);
+  }
+
   public get files() {
     return accessApi(this.filesApi);
   }
@@ -50,6 +59,14 @@ export default class CogniteClient extends CogniteClientCleaned {
     super.initAPIs();
 
     this.httpClient.setDefaultHeader('cdf-version', 'beta');
+
+    this.dataPointsApi = new BetaDataPointsAPI(
+      `${this.projectUrl}/timeseries/data`,
+      this.httpClient,
+      this.metadataMap,
+      this.timeseries,
+      this.units
+    );
 
     this.alertsApi = this.apiFactory(AlertsAPI, 'alerts');
     this.monitoringTasksApi = this.apiFactory(

--- a/packages/beta/src/index.ts
+++ b/packages/beta/src/index.ts
@@ -6,9 +6,6 @@ export * from './types';
 
 export type {
   DatapointsInsertWithUnitItem,
-  WithSourceUnit,
+  WithInsertUnit,
 } from './api/dataPoints/types';
-export {
-  BetaDataPointsAPI,
-  convertBetweenUnitConversions,
-} from './api/dataPoints/dataPointsApi';
+export { BetaDataPointsAPI } from './api/dataPoints/dataPointsApi';

--- a/packages/beta/src/index.ts
+++ b/packages/beta/src/index.ts
@@ -3,3 +3,12 @@
 export * from '@cognite/sdk';
 export { default as CogniteClient } from './cogniteClient';
 export * from './types';
+
+export type {
+  DatapointsInsertWithUnitItem,
+  WithSourceUnit,
+} from './api/dataPoints/types';
+export {
+  BetaDataPointsAPI,
+  convertBetweenUnitConversions,
+} from './api/dataPoints/dataPointsApi';


### PR DESCRIPTION
Adds a beta-only method for inserting time series datapoints when values are expressed in a different unit than the time series stored `unitExternalId`. Values are converted in the SDK before calling the existing datapoints insert endpoint, so stable `insert()` behavior and types stay unchanged.

## Motivation
https://hub.cognite.com/ideas/cognite-infield-measurement-units-1148?tid=1148&fid=None

CDF supports unit conversion on datapoint read (`targetUnit` / `targetUnitSystem`), but not on write. This is not a problem for the vast majority of use cases when data comes straight from an extractor which taps into a data source with a consistent source unit. This is not the case though for manual data entry, like what is offered in Infield. With the method introduced in this PR, Infield can allow users to select which unit they want to use when entering data.