### PR TITLE
feat(alpha): add support for workflow service

### DIFF
--- a/packages/alpha/src/__tests__/api/workflows.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflows.int.spec.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Cognite AS
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
+import type { Workflow } from '../../types';
+import { randomInt, setupLoggedInClient } from '../testUtils';
+
+describe('Workflows integration test', () => {
+  let client: CogniteClientAlpha;
+  const workflowExternalId = `int-workflow-${randomInt()}`;
+  let createdWorkflow: Workflow | undefined;
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+    const items = await client.workflows.upsert([
+      {
+        externalId: workflowExternalId,
+        description: 'integration test workflow',
+        maxConcurrentExecutions: 2,
+      },
+    ]);
+    createdWorkflow = items[0];
+  });
+
+  afterAll(async () => {
+    if (!createdWorkflow) {
+      return;
+    }
+    await client.workflows
+      .delete([{ externalId: workflowExternalId }])
+      .catch(() => {
+        return undefined;
+      });
+  });
+
+  test('list', async () => {
+    const response = await client.workflows.list({ limit: 10 });
+    expect(Array.isArray(response.items)).toBe(true);
+  });
+
+  test('retrieve by external id', async () => {
+    const workflow = await client.workflows.retrieve(workflowExternalId);
+    expect(workflow.externalId).toBe(workflowExternalId);
+  });
+
+  test('upsert updates existing workflow', async () => {
+    const items = await client.workflows.upsert([
+      {
+        externalId: workflowExternalId,
+        description: 'integration test workflow - updated',
+        maxConcurrentExecutions: 4,
+      },
+    ]);
+    const updatedWorkflow = items[0];
+
+    expect(updatedWorkflow.description).toBe(
+      'integration test workflow - updated'
+    );
+    expect(updatedWorkflow.maxConcurrentExecutions).toBe(4);
+  });
+
+  test('delete', async () => {
+    const externalId = `int-workflows-delete-${randomInt()}`;
+    const items = await client.workflows.upsert([
+      {
+        externalId,
+        description: 'workflow to delete',
+        maxConcurrentExecutions: 1,
+      },
+    ]);
+    const workflowToDelete = items[0];
+
+    expect(workflowToDelete.externalId).toBe(externalId);
+
+    await expect(
+      client.workflows.delete([{ externalId: workflowToDelete.externalId }])
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/alpha/src/__tests__/api/workflows.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflows.int.spec.ts
@@ -26,11 +26,7 @@ describe('Workflows integration test', () => {
     if (!createdWorkflow) {
       return;
     }
-    await client.workflows
-      .delete([{ externalId: workflowExternalId }])
-      .catch(() => {
-        return undefined;
-      });
+    await client.workflows.delete([{ externalId: workflowExternalId }]).catch();
   });
 
   test('list', async () => {

--- a/packages/alpha/src/__tests__/api/workflows.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflows.unit.spec.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Cognite AS
+
+import matches from 'lodash/matches';
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+describe('Workflows unit test', () => {
+  let client: CogniteClientAlpha;
+
+  const workflowFixture = {
+    externalId: 'wf-1',
+    description: 'Test workflow',
+    dataSetId: 42,
+    maxConcurrentExecutions: 3,
+  };
+
+  const mockWorkflow = {
+    ...workflowFixture,
+    createdTime: Date.now(),
+    lastUpdatedTime: Date.now() + 1000,
+  };
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test('list', async () => {
+    nock(mockBaseUrl)
+      .get(/\/workflows\/?$/)
+      .query({ limit: '10', cursor: 'abc' })
+      .once()
+      .reply(200, {
+        items: [mockWorkflow],
+        nextCursor: 'next',
+      });
+
+    const response = await client.workflows.list({ limit: 10, cursor: 'abc' });
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].externalId).toBe(mockWorkflow.externalId);
+    expect(response.nextCursor).toBe('next');
+  });
+
+  test('retrieve by external id', async () => {
+    nock(mockBaseUrl)
+      .get(/\/workflows\/wf-2$/)
+      .once()
+      .reply(200, {
+        ...mockWorkflow,
+        externalId: 'wf-2',
+      });
+
+    const response = await client.workflows.retrieve('wf-2');
+    expect(response.externalId).toEqual('wf-2');
+  });
+
+  test('upsert forwards maxConcurrentExecutions and dataSetId', async () => {
+    const upsertBody = {
+      externalId: 'wf-1',
+      description: 'd',
+      dataSetId: 42,
+      maxConcurrentExecutions: 5,
+    };
+    nock(mockBaseUrl)
+      .post(/\/workflows$/, matches({ items: [upsertBody] }))
+      .once()
+      .reply(200, {
+        items: [
+          {
+            ...mockWorkflow,
+            externalId: upsertBody.externalId,
+            maxConcurrentExecutions: upsertBody.maxConcurrentExecutions,
+          },
+        ],
+      });
+
+    const items = await client.workflows.upsert([upsertBody]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].externalId).toEqual('wf-1');
+    expect(items[0].maxConcurrentExecutions).toEqual(5);
+  });
+
+  test('delete', async () => {
+    nock(mockBaseUrl)
+      .post(/\/workflows\/delete/, { items: [{ externalId: 'wf-1' }] })
+      .once()
+      .reply(200, {});
+
+    await client.workflows.delete([{ externalId: 'wf-1' }]);
+  });
+});

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 Cognite AS
+
+import type { CogniteExternalId, CogniteInternalId } from '@cognite/sdk-core';
+
+export interface Workflow {
+  externalId: CogniteExternalId;
+  description?: string;
+  dataSetId?: CogniteInternalId;
+  maxConcurrentExecutions?: number;
+  createdTime?: number;
+  lastUpdatedTime: number;
+}
+
+export interface WorkflowUpsert {
+  externalId: CogniteExternalId;
+  description?: string;
+  dataSetId?: CogniteInternalId;
+  maxConcurrentExecutions?: number;
+}
+
+export interface WorkflowExternalId {
+  externalId: CogniteExternalId;
+}

--- a/packages/alpha/src/api/workflows/workflowsApi.ts
+++ b/packages/alpha/src/api/workflows/workflowsApi.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import type {
+  CogniteExternalId,
+  CursorAndAsyncIterator,
+  FilterQuery,
+} from '@cognite/sdk-core';
+import type { Workflow, WorkflowExternalId, WorkflowUpsert } from './types';
+
+export class WorkflowsAPI extends BaseResourceAPI<Workflow> {
+  /**
+   * [List workflows](https://api-docs.cognite.com/20230101-alpha/tag/Workflows/operation/FetchAllWorkflows)
+   *
+   * ```js
+   * const workflows = await client.workflows.list({ limit: 10 });
+   * ```
+   */
+  public list = (query?: FilterQuery): CursorAndAsyncIterator<Workflow> => {
+    return this.listEndpoint(this.callListEndpointWithGet, query);
+  };
+
+  /**
+   * [Retrieve a workflow by external id](https://api-docs.cognite.com/20230101/tag/Workflows/operation/fetchWorkflowDetails)
+   *
+   * ```js
+   * const workflow = await client.workflows.retrieve('my-workflow');
+   * ```
+   */
+  public retrieve = async (
+    externalId: CogniteExternalId
+  ): Promise<Workflow> => {
+    const response = await this.get<Workflow>(
+      this.url(encodeURIComponent(externalId))
+    );
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [Create or update a workflow](https://api-docs.cognite.com/20230101-alpha/tag/Workflows/operation/CreateOrUpdateWorkflow)
+   *
+   * ```js
+   * const workflows = await client.workflows.upsert([
+   *   { externalId: 'my-workflow', description: 'Demo', maxConcurrentExecutions: 2 },
+   * ]);
+   * ```
+   */
+  public upsert = (items: WorkflowUpsert[]): Promise<Workflow[]> => {
+    return this.createEndpoint(items, this.url());
+  };
+
+  /**
+   * [Delete workflows](https://api-docs.cognite.com/20230101-alpha/tag/Workflows/operation/DeleteWorkflows)
+   *
+   * ```js
+   * await client.workflows.delete([{ externalId: 'my-workflow' }]);
+   * ```
+   */
+  public delete = (ids: WorkflowExternalId[]) => {
+    return this.deleteEndpoint(ids);
+  };
+}

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -5,11 +5,13 @@ import { version } from '../package.json';
 import { LimitsAPI } from './api/limits/limitsApi';
 import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
+import { WorkflowsAPI } from './api/workflows/workflowsApi';
 
 export default class CogniteClientAlpha extends CogniteClientStable {
   private simulatorsApi?: SimulatorsAPI;
   private limitsApi?: LimitsAPI;
   private meteringApi?: MeteringAPI;
+  private workflowsApi?: WorkflowsAPI;
 
   public get limits() {
     return accessApi(this.limitsApi);
@@ -23,6 +25,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     return accessApi(this.simulatorsApi);
   }
 
+  public get workflows() {
+    return accessApi(this.workflowsApi);
+  }
+
   protected initAPIs() {
     super.initAPIs();
 
@@ -31,6 +37,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     this.simulatorsApi = this.apiFactory(SimulatorsAPI, 'simulators');
     this.limitsApi = this.apiFactory(LimitsAPI, 'limits');
     this.meteringApi = this.apiFactory(MeteringAPI, 'metering');
+    this.workflowsApi = this.apiFactory(WorkflowsAPI, 'workflows');
   }
 
   protected get version() {

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -15,6 +15,7 @@ import type {
 } from '@cognite/sdk-core';
 
 export * from '@cognite/sdk';
+export * from './api/workflows/types';
 
 // This file is here mostly to allow apis to import { ... } from '../../types';
 // Overriding types should probably be done in their respective API endpoint files, where possible


### PR DESCRIPTION
This PR adds Workflows support to the stable JavaScript SDK.

### Included

* Added `WorkflowsAPI` with support for:

  * list
  * retrieve
  * upsert
  * delete

* Exposed workflows through:

  ```ts
  client.workflows
  ```

* Added and exported public workflow types.

### Testing

* Added unit tests for all supported operations.
* Added integration tests covering create/update, list, retrieve, and delete flows.
