### PR TITLE
feat(alpha): add support for workflows execution

### DIFF
--- a/packages/alpha/src/__tests__/api/workflowExecutions.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowExecutions.int.spec.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 Cognite AS
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
+import type {
+  TaskDefinition,
+  Version,
+  Workflow,
+  WorkflowExecution,
+} from '../../types';
+import { randomInt, setupLoggedInClient } from '../testUtils';
+
+const workflowTasks: TaskDefinition = {
+  externalId: 'int-execution-task-1',
+  type: 'function',
+  parameters: {
+    function: { externalId: 'int-fn-external-id' },
+  },
+};
+
+describe('Workflow executions integration test', () => {
+  let client: CogniteClientAlpha;
+  const workflowExternalId = `int-workflow-execution-${randomInt()}`;
+  const versionExternalId = '1';
+  let createdWorkflow: Workflow | undefined;
+  let createdVersion: Version | undefined;
+  let createdExecution: WorkflowExecution | undefined;
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+
+    const workflowItems = await client.workflows.upsert([
+      {
+        externalId: workflowExternalId,
+        description: 'integration test workflow for executions',
+        maxConcurrentExecutions: 1,
+      },
+    ]);
+    createdWorkflow = workflowItems[0];
+
+    const versionItems = await client.workflowVersions.upsert([
+      {
+        workflowExternalId,
+        version: versionExternalId,
+        workflowDefinition: {
+          description: 'integration test workflow version for executions',
+          tasks: [workflowTasks],
+        },
+      },
+    ]);
+    createdVersion = versionItems[0];
+  });
+
+  afterAll(async () => {
+    if (createdExecution) {
+      await client.workflowExecutions
+        .cancel(createdExecution.id, {
+          reason: 'cleanup after integration test',
+        })
+        .catch();
+    }
+
+    if (createdVersion) {
+      await client.workflowVersions
+        .delete([
+          {
+            workflowExternalId,
+            version: versionExternalId,
+          },
+        ])
+        .catch();
+    }
+
+    if (createdWorkflow) {
+      await client.workflows
+        .delete([{ externalId: workflowExternalId }])
+        .catch();
+    }
+  });
+
+  test('run', async () => {
+    const clientSecret = process.env.COGNITE_CLIENT_SECRET || '';
+    const clientId = process.env.COGNITE_CLIENT_ID || '';
+    const [session] = await client.sessions.create([
+      {
+        clientId,
+        clientSecret,
+      },
+    ]);
+
+    createdExecution = await client.workflowExecutions.run(
+      workflowExternalId,
+      versionExternalId,
+      {
+        authentication: { nonce: session.nonce },
+        metadata: { source: 'sdk-int-test' },
+      }
+    );
+
+    expect(createdExecution.id).toBeTruthy();
+    expect(createdExecution.workflowExternalId).toBe(workflowExternalId);
+    expect(createdExecution.version).toBe(versionExternalId);
+    expect(createdExecution.status).toBe('RUNNING');
+    expect(createdExecution.engineExecutionId).toBeTruthy();
+    expect(createdExecution.createdTime).toBeTruthy();
+    expect(createdExecution.metadata).toEqual({ source: 'sdk-int-test' });
+  });
+
+  test('list', async () => {
+    const response = await client.workflowExecutions.list({
+      filter: {
+        workflowFilters: [
+          {
+            externalId: workflowExternalId,
+            version: versionExternalId,
+          },
+        ],
+      },
+      limit: 10,
+    });
+
+    expect(Array.isArray(response.items)).toBe(true);
+    expect(response.items.length).toBeGreaterThan(0);
+    expect(
+      response.items.some(
+        (item) =>
+          item.workflowExternalId === workflowExternalId &&
+          item.version === versionExternalId
+      )
+    ).toBe(true);
+  });
+
+  test('retrieve by execution id', async () => {
+    expect(createdExecution).toBeDefined();
+    if (!createdExecution) {
+      return;
+    }
+
+    const execution = await client.workflowExecutions.retrieve(
+      createdExecution.id
+    );
+
+    expect(execution.id).toBe(createdExecution.id);
+    expect(execution.workflowExternalId).toBe(workflowExternalId);
+    expect(execution.version).toBe(versionExternalId);
+  });
+
+  test('cancel', async () => {
+    expect(createdExecution).toBeDefined();
+    if (!createdExecution) {
+      return;
+    }
+
+    const execution = await client.workflowExecutions.cancel(
+      createdExecution.id,
+      { reason: 'integration test cancel' }
+    );
+
+    expect(execution.id).toBe(createdExecution.id);
+    expect(execution.status).toBe('TERMINATED');
+    createdExecution = undefined;
+  });
+});

--- a/packages/alpha/src/__tests__/api/workflowExecutions.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowExecutions.unit.spec.ts
@@ -1,0 +1,181 @@
+// Copyright 2026 Cognite AS
+
+import matches from 'lodash/matches';
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+describe('Workflow executions unit test', () => {
+  let client: CogniteClientAlpha;
+
+  const executionId = '550e8400-e29b-41d4-a716-446655440000';
+  const engineExecutionId = '660e8400-e29b-41d4-a716-446655440001';
+
+  const mockExecution = {
+    id: executionId,
+    workflowExternalId: 'wf-1',
+    status: 'RUNNING' as const,
+    engineExecutionId,
+    createdTime: 1716900000000,
+    metadata: { source: 'test' },
+    version: '1',
+    startTime: 1716900000001,
+  };
+
+  const mockExecutionDetails = {
+    ...mockExecution,
+    workflowDefinition: {
+      hash: 'abc123',
+      description: 'Test workflow',
+      tasks: [
+        {
+          externalId: 'task-1',
+          type: 'function',
+          parameters: {
+            function: { externalId: 'fn-1' },
+          },
+        },
+      ],
+    },
+    executedTasks: [
+      {
+        id: 'task-exec-1',
+        externalId: 'task-1',
+        status: 'IN_PROGRESS',
+        taskType: 'function',
+        input: { function: { externalId: 'fn-1' } },
+        output: {},
+      },
+    ],
+    input: { key: 'value' },
+  };
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test('list', async () => {
+    const listQuery = {
+      filter: {
+        workflowFilters: [{ externalId: 'wf-1', version: '1' }],
+        status: ['RUNNING' as const],
+      },
+      limit: 10,
+      cursor: 'abc',
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/workflows\/executions\/list$/, listQuery)
+      .once()
+      .reply(200, {
+        items: [mockExecution],
+        nextCursor: 'next',
+      });
+
+    const response = await client.workflowExecutions.list(listQuery);
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].id).toBe(executionId);
+    expect(response.items[0].status).toBe('RUNNING');
+    expect(response.nextCursor).toBe('next');
+  });
+
+  test('retrieve by execution id', async () => {
+    nock(mockBaseUrl)
+      .get(/\/workflows\/executions\/550e8400-e29b-41d4-a716-446655440000$/)
+      .once()
+      .reply(200, mockExecutionDetails);
+
+    const response = await client.workflowExecutions.retrieve(executionId);
+    expect(response.id).toEqual(executionId);
+    expect(response.workflowDefinition.hash).toEqual('abc123');
+    expect(response.executedTasks).toHaveLength(1);
+    expect(response.executedTasks[0].externalId).toEqual('task-1');
+  });
+
+  test('run', async () => {
+    const runRequest = {
+      authentication: { nonce: 'session-nonce' },
+      input: { key: 'value' },
+      metadata: { source: 'sdk-test' },
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/workflows\/wf-1\/versions\/1\/run$/, matches(runRequest))
+      .once()
+      .reply(202, mockExecution);
+
+    const response = await client.workflowExecutions.run(
+      'wf-1',
+      '1',
+      runRequest
+    );
+
+    expect(response.id).toEqual(executionId);
+    expect(response.workflowExternalId).toEqual('wf-1');
+    expect(response.status).toEqual('RUNNING');
+  });
+
+  test('retry', async () => {
+    const retryRequest = {
+      authentication: { nonce: 'session-nonce' },
+    };
+
+    nock(mockBaseUrl)
+      .post(
+        /\/workflows\/executions\/550e8400-e29b-41d4-a716-446655440000\/retry$/,
+        matches(retryRequest)
+      )
+      .once()
+      .reply(200, { ...mockExecution, status: 'RUNNING' });
+
+    const response = await client.workflowExecutions.retry(
+      executionId,
+      retryRequest
+    );
+
+    expect(response.id).toEqual(executionId);
+    expect(response.status).toEqual('RUNNING');
+  });
+
+  test('cancel', async () => {
+    nock(mockBaseUrl)
+      .post(
+        /\/workflows\/executions\/550e8400-e29b-41d4-a716-446655440000\/cancel$/,
+        {}
+      )
+      .once()
+      .reply(200, { ...mockExecution, status: 'TERMINATED' });
+
+    const response = await client.workflowExecutions.cancel(executionId);
+
+    expect(response.id).toEqual(executionId);
+    expect(response.status).toEqual('TERMINATED');
+  });
+
+  test('cancel with reason', async () => {
+    const cancelRequest = { reason: 'no longer needed' };
+
+    nock(mockBaseUrl)
+      .post(
+        /\/workflows\/executions\/550e8400-e29b-41d4-a716-446655440000\/cancel$/,
+        matches(cancelRequest)
+      )
+      .once()
+      .reply(200, {
+        ...mockExecution,
+        status: 'TERMINATED',
+        reasonForIncompletion: 'no longer needed',
+      });
+
+    const response = await client.workflowExecutions.cancel(
+      executionId,
+      cancelRequest
+    );
+
+    expect(response.status).toEqual('TERMINATED');
+    expect(response.reasonForIncompletion).toEqual('no longer needed');
+  });
+});

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -139,6 +139,18 @@ export type TaskDependency = {
   externalId: string;
 };
 
+export type TaskDefinition = {
+  externalId: string;
+  type: TaskTypes;
+  name?: string;
+  description?: string;
+  parameters?: TaskParameters;
+  retries?: number;
+  timeout?: number;
+  dependsOn?: TaskDependency[];
+  onFailure?: OnFailureType;
+};
+
 export type WorkflowDefinition = {
   hash: string;
   description?: string;
@@ -183,50 +195,6 @@ export interface WorkflowVersionFilterQuery extends FilterQuery {
   filter?: WorkflowVersionFilter;
 }
 
-type SdkTaskDefinition = {
-  externalId: string;
-  type: TaskTypes;
-  name?: string;
-  description?: string;
-  parameters?: TaskParameters;
-  retries?: number;
-  timeout?: number;
-  dependsOn?: TaskDependency[];
-  onFailure?: OnFailureType;
-};
-
-export type LineageAnnotationOption = {
-  label: string;
-  value: string;
-};
-
-export type LineageAnnotationItem = Partial<
-  Record<LineageAnnotationOption['value'], string>
->;
-
-export type LineageAnnotation = {
-  sources?: LineageAnnotationItem[];
-  targets?: LineageAnnotationItem[];
-};
-
-export type TaskDefinition = Omit<SdkTaskDefinition, 'type' | 'parameters'> & {
-  type: TaskTypes;
-  parameters?: TaskParameters;
-  lineageAnnotation?: LineageAnnotation;
-};
-
-export type InputType = DynamicTaskInput | object;
-
-type DynamicTaskInputTasks =
-  | TaskDefinition[] // Array of task definitions that are dynamically generated
-  | string // Bad or non-resolved reference during runtime
-  | null; // Error whilst resolving the tasks
-
-type DynamicTaskInput = {
-  dynamic: {
-    tasks: DynamicTaskInputTasks;
-  };
-};
 
 export type FunctionOutput = {
   callId: number;
@@ -299,7 +267,7 @@ export interface WorkflowTaskExecution {
   externalId?: string;
   status: WorkflowTaskExecutionStatus;
   taskType: TaskTypes;
-  input: InputType;
+  input: TaskParameters;
   output: OutputType;
   parentTaskExternalId?: string | null;
   startTime?: number;

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -32,6 +32,7 @@ export type JsonValue =
   | number
   | boolean
   | null
+  | undefined
   | JsonValue[]
   | { readonly [key: string]: JsonValue };
 
@@ -137,17 +138,6 @@ export type OnFailureType = `${OnFailureTypeEnum}`;
 export type TaskDependency = {
   externalId: string;
 };
-export type TaskDefinition = {
-  externalId: string;
-  type: TaskTypes;
-  name?: string;
-  description?: string;
-  parameters?: TaskParameters;
-  retries?: number;
-  timeout?: number;
-  dependsOn?: TaskDependency[];
-  onFailure?: OnFailureType;
-};
 
 export type WorkflowDefinition = {
   hash: string;
@@ -193,6 +183,86 @@ export interface WorkflowVersionFilterQuery extends FilterQuery {
   filter?: WorkflowVersionFilter;
 }
 
+type SdkTaskDefinition = {
+  externalId: string;
+  type: TaskTypes;
+  name?: string;
+  description?: string;
+  parameters?: TaskParameters;
+  retries?: number;
+  timeout?: number;
+  dependsOn?: TaskDependency[];
+  onFailure?: OnFailureType;
+};
+
+export type LineageAnnotationOption = {
+  label: string;
+  value: string;
+};
+
+export type LineageAnnotationItem = Partial<
+  Record<LineageAnnotationOption['value'], string>
+>;
+
+export type LineageAnnotation = {
+  sources?: LineageAnnotationItem[];
+  targets?: LineageAnnotationItem[];
+};
+
+export type TaskDefinition = Omit<SdkTaskDefinition, 'type' | 'parameters'> & {
+  type: TaskTypes;
+  parameters?: TaskParameters;
+  lineageAnnotation?: LineageAnnotation;
+};
+
+export type InputType = DynamicTaskInput | object;
+
+type DynamicTaskInputTasks =
+  | TaskDefinition[] // Array of task definitions that are dynamically generated
+  | string // Bad or non-resolved reference during runtime
+  | null; // Error whilst resolving the tasks
+
+type DynamicTaskInput = {
+  dynamic: {
+    tasks: DynamicTaskInputTasks;
+  };
+};
+
+export type FunctionOutput = {
+  callId: number;
+  functionId: number;
+  response: object;
+};
+
+export type TransformationOutput = {
+  jobId: number;
+};
+
+export type SimulationOutput = {
+  runId: number;
+  logId: number;
+};
+
+type CdfResponseOutput = {
+  response: string | object;
+  statusCode: number;
+};
+
+type DynamicTaskOutput = {
+  dynamicTasks: TaskDefinition[];
+};
+
+type EmptyTaskOutput = Record<string, never>; // Represents an empty output type for tasks that do not produce any output
+
+export type OutputType =
+  | FunctionOutput
+  | TransformationOutput
+  | CdfResponseOutput
+  | DynamicTaskOutput
+  | SimulationOutput
+  | EmptyTaskOutput;
+
+
 export type WorkflowExecutionStatus =
   | 'RUNNING'
   | 'COMPLETED'
@@ -216,9 +286,9 @@ export interface WorkflowExecution {
   workflowExternalId: CogniteExternalId;
   status: WorkflowExecutionStatus;
   engineExecutionId: string;
-  createdTime: number;
-  metadata: Record<string, string>;
-  version?: string;
+  createdTime?: number;
+  metadata: object;
+  version: string;
   startTime?: number;
   endTime?: number;
   reasonForIncompletion?: string;
@@ -226,14 +296,15 @@ export interface WorkflowExecution {
 
 export interface WorkflowTaskExecution {
   id: string;
-  externalId: string;
+  externalId?: string;
   status: WorkflowTaskExecutionStatus;
   taskType: TaskTypes;
-  input: TaskParameters;
-  output: Record<string, unknown>;
+  input: InputType;
+  output: OutputType;
   parentTaskExternalId?: string | null;
   startTime?: number;
   endTime?: number;
+  eventTime?: number;
   reasonForIncompletion?: string;
 }
 

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -192,3 +192,87 @@ export interface WorkflowVersionFilter {
 export interface WorkflowVersionFilterQuery extends FilterQuery {
   filter?: WorkflowVersionFilter;
 }
+
+export type WorkflowExecutionStatus =
+  | 'RUNNING'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'TIMED_OUT'
+  | 'TERMINATED';
+
+export type WorkflowTaskExecutionStatus =
+  | 'IN_PROGRESS'
+  | 'CANCELED'
+  | 'FAILED'
+  | 'FAILED_WITH_TERMINAL_ERROR'
+  | 'COMPLETED'
+  | 'COMPLETED_WITH_ERRORS'
+  | 'SCHEDULED'
+  | 'TIMED_OUT'
+  | 'SKIPPED';
+
+export interface WorkflowExecution {
+  id: string;
+  workflowExternalId: CogniteExternalId;
+  status: WorkflowExecutionStatus;
+  engineExecutionId: string;
+  createdTime: number;
+  metadata: Record<string, string>;
+  version?: string;
+  startTime?: number;
+  endTime?: number;
+  reasonForIncompletion?: string;
+}
+
+export interface WorkflowTaskExecution {
+  id: string;
+  externalId: string;
+  status: WorkflowTaskExecutionStatus;
+  taskType: TaskTypes;
+  input: TaskParameters;
+  output: Record<string, unknown>;
+  parentTaskExternalId?: string | null;
+  startTime?: number;
+  endTime?: number;
+  reasonForIncompletion?: string;
+}
+
+export interface WorkflowExecutionDetails extends WorkflowExecution {
+  workflowDefinition: WorkflowDefinition;
+  executedTasks: WorkflowTaskExecution[];
+  input?: Record<string, JsonValue>;
+}
+
+export interface WorkflowExecutionWorkflowFilter {
+  externalId: CogniteExternalId;
+  version?: string;
+}
+
+export interface WorkflowExecutionFilter {
+  workflowFilters?: WorkflowExecutionWorkflowFilter[];
+  createdTimeStart?: number;
+  createdTimeEnd?: number;
+  status?: WorkflowExecutionStatus[];
+}
+
+export interface WorkflowExecutionFilterQuery extends FilterQuery {
+  filter?: WorkflowExecutionFilter;
+}
+
+export interface WorkflowExecutionAuthentication {
+  nonce: string;
+}
+
+export interface WorkflowExecutionRunRequest {
+  authentication: WorkflowExecutionAuthentication;
+  input?: Record<string, JsonValue>;
+  metadata?: Record<string, string>;
+}
+
+export interface WorkflowExecutionRetryRequest {
+  authentication: WorkflowExecutionAuthentication;
+}
+
+export interface WorkflowExecutionCancelRequest {
+  reason?: string;
+}

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -138,7 +138,6 @@ export type OnFailureType = `${OnFailureTypeEnum}`;
 export type TaskDependency = {
   externalId: string;
 };
-
 export type TaskDefinition = {
   externalId: string;
   type: TaskTypes;
@@ -195,7 +194,6 @@ export interface WorkflowVersionFilterQuery extends FilterQuery {
   filter?: WorkflowVersionFilter;
 }
 
-
 export type FunctionOutput = {
   callId: number;
   functionId: number;
@@ -229,7 +227,6 @@ export type OutputType =
   | DynamicTaskOutput
   | SimulationOutput
   | EmptyTaskOutput;
-
 
 export type WorkflowExecutionStatus =
   | 'RUNNING'

--- a/packages/alpha/src/api/workflows/workflowExecutionsApi.ts
+++ b/packages/alpha/src/api/workflows/workflowExecutionsApi.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import type {
+  CogniteExternalId,
+  CursorAndAsyncIterator,
+} from '@cognite/sdk-core';
+import type {
+  WorkflowExecution,
+  WorkflowExecutionCancelRequest,
+  WorkflowExecutionDetails,
+  WorkflowExecutionFilterQuery,
+  WorkflowExecutionRetryRequest,
+  WorkflowExecutionRunRequest,
+} from './types';
+
+export class WorkflowExecutionsAPI extends BaseResourceAPI<WorkflowExecution> {
+  /**
+   * [List workflow executions](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-executions/operation/FilterWorkflowExecutions)
+   *
+   * ```js
+   * const executions = await client.workflowExecutions.list({ limit: 10 });
+   * ```
+   */
+  public list = (
+    query?: WorkflowExecutionFilterQuery
+  ): CursorAndAsyncIterator<WorkflowExecution> => {
+    return this.listEndpoint(this.callListEndpointWithPost, query);
+  };
+
+  /**
+   * [Retrieve workflow execution details](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-executions/operation/RetrieveWorkflowExecutionDetails)
+   *
+   * ```js
+   * const execution = await client.workflowExecutions.retrieve('execution-id');
+   * ```
+   */
+  public retrieve = async (
+    executionId: string
+  ): Promise<WorkflowExecutionDetails> => {
+    const response = await this.get<WorkflowExecutionDetails>(
+      this.url(encodeURIComponent(executionId))
+    );
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [Run a workflow](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-executions/operation/RunWorkflow)
+   *
+   * ```js
+   * const execution = await client.workflowExecutions.run('my-workflow', '1', {
+   *   authentication: { nonce: 'session-nonce' },
+   * });
+   * ```
+   */
+  public run = (
+    workflowExternalId: CogniteExternalId,
+    version: string,
+    request: WorkflowExecutionRunRequest
+  ): Promise<WorkflowExecution> => {
+    const path = `${this.workflowsBasePath()}/${encodeURIComponent(workflowExternalId)}/versions/${encodeURIComponent(version)}/run`;
+    return this.createExecutionEndpoint(request, path);
+  };
+
+  /**
+   * [Retry workflow execution](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-executions/operation/RetryWorkflowExecution)
+   *
+   * ```js
+   * const execution = await client.workflowExecutions.retry('execution-id', {
+   *   authentication: { nonce: 'session-nonce' },
+   * });
+   * ```
+   */
+  public retry = (
+    executionId: string,
+    request: WorkflowExecutionRetryRequest
+  ): Promise<WorkflowExecution> => {
+    return this.createExecutionEndpoint(
+      request,
+      this.url(`${encodeURIComponent(executionId)}/retry`)
+    );
+  };
+
+  /**
+   * [Cancel workflow execution](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-executions/operation/CancelWorkflowExecution)
+   *
+   * ```js
+   * const execution = await client.workflowExecutions.cancel('execution-id');
+   * ```
+   */
+  public cancel = (
+    executionId: string,
+    request?: WorkflowExecutionCancelRequest
+  ): Promise<WorkflowExecution> => {
+    return this.createExecutionEndpoint(
+      request ?? {},
+      this.url(`${encodeURIComponent(executionId)}/cancel`)
+    );
+  };
+
+  private workflowsBasePath(): string {
+    return this.url('').replace(/\/executions\/?$/, '');
+  }
+
+  private createExecutionEndpoint<RequestType>(
+    request: RequestType,
+    path: string
+  ): Promise<WorkflowExecution> {
+    return this.post<WorkflowExecution>(path, { data: request }).then(
+      (response) => this.addToMapAndReturn(response.data, response)
+    );
+  }
+}

--- a/packages/alpha/src/api/workflows/workflowExecutionsApi.ts
+++ b/packages/alpha/src/api/workflows/workflowExecutionsApi.ts
@@ -2,8 +2,10 @@
 
 import { BaseResourceAPI } from '@cognite/sdk-core';
 import type {
+  CDFHttpClient,
   CogniteExternalId,
   CursorAndAsyncIterator,
+  MetadataMap,
 } from '@cognite/sdk-core';
 import type {
   WorkflowExecution,
@@ -15,6 +17,18 @@ import type {
 } from './types';
 
 export class WorkflowExecutionsAPI extends BaseResourceAPI<WorkflowExecution> {
+  private readonly workflowsPath: string;
+
+  constructor(
+    executionsPath: string,
+    workflowsPath: string,
+    httpClient: CDFHttpClient,
+    map: MetadataMap
+  ) {
+    super(executionsPath, httpClient, map);
+    this.workflowsPath = workflowsPath;
+  }
+
   /**
    * [List workflow executions](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-executions/operation/FilterWorkflowExecutions)
    *
@@ -58,7 +72,7 @@ export class WorkflowExecutionsAPI extends BaseResourceAPI<WorkflowExecution> {
     version: string,
     request: WorkflowExecutionRunRequest
   ): Promise<WorkflowExecution> => {
-    const path = `${this.workflowsBasePath()}/${encodeURIComponent(workflowExternalId)}/versions/${encodeURIComponent(version)}/run`;
+    const path = `${this.workflowsPath}/${encodeURIComponent(workflowExternalId)}/versions/${encodeURIComponent(version)}/run`;
     return this.createExecutionEndpoint(request, path);
   };
 
@@ -97,10 +111,6 @@ export class WorkflowExecutionsAPI extends BaseResourceAPI<WorkflowExecution> {
       this.url(`${encodeURIComponent(executionId)}/cancel`)
     );
   };
-
-  private workflowsBasePath(): string {
-    return this.url('').replace(/\/executions\/?$/, '');
-  }
 
   private createExecutionEndpoint<RequestType>(
     request: RequestType,

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -54,9 +54,11 @@ export default class CogniteClientAlpha extends CogniteClientStable {
       WorkflowVersionsAPI,
       'workflows/versions'
     );
-    this.workflowExecutionsApi = this.apiFactory(
-      WorkflowExecutionsAPI,
-      'workflows/executions'
+    this.workflowExecutionsApi = new WorkflowExecutionsAPI(
+      `${this.projectUrl}/workflows/executions`,
+      `${this.projectUrl}/workflows`,
+      this.httpClient,
+      this.metadataMap
     );
   }
 

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -5,6 +5,7 @@ import { version } from '../package.json';
 import { LimitsAPI } from './api/limits/limitsApi';
 import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
+import { WorkflowExecutionsAPI } from './api/workflows/workflowExecutionsApi';
 import { WorkflowVersionsAPI } from './api/workflows/workflowVersionsApi';
 import { WorkflowsAPI } from './api/workflows/workflowsApi';
 
@@ -14,6 +15,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
   private meteringApi?: MeteringAPI;
   private workflowsApi?: WorkflowsAPI;
   private workflowVersionsApi?: WorkflowVersionsAPI;
+  private workflowExecutionsApi?: WorkflowExecutionsAPI;
 
   public get limits() {
     return accessApi(this.limitsApi);
@@ -35,6 +37,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     return accessApi(this.workflowVersionsApi);
   }
 
+  public get workflowExecutions() {
+    return accessApi(this.workflowExecutionsApi);
+  }
+
   protected initAPIs() {
     super.initAPIs();
 
@@ -47,6 +53,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     this.workflowVersionsApi = this.apiFactory(
       WorkflowVersionsAPI,
       'workflows/versions'
+    );
+    this.workflowExecutionsApi = this.apiFactory(
+      WorkflowExecutionsAPI,
+      'workflows/executions'
     );
   }
 


### PR DESCRIPTION
This PR adds Workflow executions support to the JavaScript SDK.

**Included**

Added WorkflowExecutionsAPI with support for:

list
retrieve
run
retry
cancel

**Exposed workflow executions through:**

client.workflowExecutions

Added and exported public workflow execution types, including:

WorkflowExecution
WorkflowExecutionDetails
WorkflowTaskExecution
WorkflowExecutionFilterQuery
WorkflowExecutionRunRequest
WorkflowExecutionRetryRequest
WorkflowExecutionCancelRequest
Testing
Added unit tests for all supported operations (list, retrieve, run, retry, cancel with and without reason).
Related: CDF-27832

