### PR TITLE
feat(timeseries): add support for state time series data points

### DIFF
--- a/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
+++ b/packages/beta/src/__tests__/api/dataPoints.int.spec.ts
@@ -1,0 +1,219 @@
+// Copyright 2026 Cognite AS
+
+import type { StateDatapointAggregates, StateDatapoints } from '@cognite/sdk';
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import {
+  randomInt,
+  runTestWithRetryWhenFailing,
+} from '../../../../core/src/__tests__/testUtils';
+import type CogniteClient from '../../cogniteClient';
+import { setupLoggedInClient } from '../testUtils';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+// Instances are per-run to avoid collisions in concurrent CI
+// The shared space is upserted idempotently and never deleted
+const RUN_SUFFIX = randomInt();
+const SPACE = 'sdk-beta-state-ts-test';
+const STATE_SET_EXT_ID = `sdk-beta-pump-states-${RUN_SUFFIX}`;
+const PUMP_A_EXT_ID = `sdk-beta-pump-a-state-${RUN_SUFFIX}`;
+const PUMP_B_EXT_ID = `sdk-beta-pump-b-state-${RUN_SUFFIX}`;
+
+const BASE_TS = new Date('2025-01-15T00:00:00Z').getTime();
+const END_TS = new Date('2025-01-17T00:00:00Z').getTime();
+const ts = (hours: number) => BASE_TS + Math.round(hours * 60 * 60 * 1000);
+
+const pumpADatapoints = [
+  // `value` is the compatibility alias; the SDK must send it as numericValue
+  { timestamp: ts(0), value: 2, stringValue: 'STANDBY' },
+  { timestamp: ts(6), numericValue: 1, stringValue: 'RUNNING' },
+  { timestamp: ts(10), numericValue: 3, stringValue: 'ERROR' },
+  { timestamp: ts(10.5), numericValue: 1, stringValue: 'RUNNING' },
+  { timestamp: ts(14), numericValue: 4, stringValue: 'MAINTENANCE' },
+  { timestamp: ts(16), numericValue: 1, stringValue: 'RUNNING' },
+  { timestamp: ts(22), numericValue: 0, stringValue: 'OFF' },
+];
+
+const pumpBDatapoints = [
+  { timestamp: ts(0), numericValue: 0, stringValue: 'OFF' },
+  { timestamp: ts(6), numericValue: 2, stringValue: 'STANDBY' },
+  { timestamp: ts(10), numericValue: 1, stringValue: 'RUNNING' },
+  { timestamp: ts(10.5), numericValue: 2, stringValue: 'STANDBY' },
+  { timestamp: ts(14), numericValue: 1, stringValue: 'RUNNING' },
+  { timestamp: ts(16), numericValue: 2, stringValue: 'STANDBY' },
+  { timestamp: ts(22), numericValue: 0, stringValue: 'OFF' },
+];
+
+const cdmView = (externalId: string) => ({
+  type: 'view' as const,
+  space: 'cdf_cdm',
+  externalId,
+  version: 'v1',
+});
+
+const stateTimeSeriesNode = (externalId: string, name: string) => ({
+  space: SPACE,
+  externalId,
+  instanceType: 'node' as const,
+  sources: [
+    {
+      source: cdmView('CogniteTimeSeries'),
+      properties: {
+        name,
+        type: 'state',
+        isStep: true,
+        stateSet: { space: SPACE, externalId: STATE_SET_EXT_ID },
+      },
+    },
+  ],
+});
+
+describe('State time series datapoints integration test', () => {
+  let client: CogniteClient;
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+
+    await client.spaces.upsert([
+      { space: SPACE, name: 'SDK beta integration test space' },
+    ]);
+
+    await client.instances.upsert({
+      items: [
+        {
+          space: SPACE,
+          externalId: STATE_SET_EXT_ID,
+          instanceType: 'node',
+          sources: [
+            {
+              source: cdmView('CogniteStateSet'),
+              properties: {
+                name: 'Pump Operating States',
+                states: [
+                  { numericValue: 0, stringValue: 'OFF' },
+                  { numericValue: 1, stringValue: 'RUNNING' },
+                  { numericValue: 2, stringValue: 'STANDBY' },
+                  { numericValue: 3, stringValue: 'ERROR' },
+                  { numericValue: 4, stringValue: 'MAINTENANCE' },
+                ],
+              },
+            },
+          ],
+        },
+        stateTimeSeriesNode(PUMP_A_EXT_ID, 'Pump A Operating State'),
+        stateTimeSeriesNode(PUMP_B_EXT_ID, 'Pump B Operating State'),
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await client.instances.delete([
+      { instanceType: 'node', space: SPACE, externalId: PUMP_A_EXT_ID },
+      { instanceType: 'node', space: SPACE, externalId: PUMP_B_EXT_ID },
+      { instanceType: 'node', space: SPACE, externalId: STATE_SET_EXT_ID },
+    ]);
+  });
+
+  test('insert state datapoints for two pumps', async () => {
+    await client.datapoints.insert([
+      {
+        instanceId: { space: SPACE, externalId: PUMP_A_EXT_ID },
+        datapoints: pumpADatapoints,
+      },
+      {
+        instanceId: { space: SPACE, externalId: PUMP_B_EXT_ID },
+        datapoints: pumpBDatapoints,
+      },
+    ]);
+  });
+
+  test('retrieve raw state datapoints', async () => {
+    await runTestWithRetryWhenFailing(async () => {
+      const result = await client.datapoints.retrieve({
+        items: [
+          {
+            instanceId: { space: SPACE, externalId: PUMP_A_EXT_ID },
+            start: BASE_TS,
+            end: END_TS,
+          },
+          {
+            instanceId: { space: SPACE, externalId: PUMP_B_EXT_ID },
+            start: BASE_TS,
+            end: END_TS,
+          },
+        ],
+      });
+
+      expect(result).toHaveLength(2);
+
+      const pumpA = result[0] as StateDatapoints;
+      expect(pumpA.type).toBe('state');
+      expect(pumpA.datapoints).toHaveLength(pumpADatapoints.length);
+      // Inserted via the deprecated `value` alias, stored as numericValue
+      expect(pumpA.datapoints[0].numericValue).toBe(2);
+      expect(pumpA.datapoints[0].stringValue).toBe('STANDBY');
+      // numericValue is mirrored into the deprecated `value` field (even 0)
+      expect(pumpA.datapoints[0].value).toBe(2);
+
+      const pumpB = result[1] as StateDatapoints;
+      expect(pumpB.type).toBe('state');
+      expect(pumpB.datapoints[0].stringValue).toBe('OFF');
+      expect(pumpB.datapoints[0].value).toBe(0);
+    });
+  });
+
+  test('retrieve state aggregates (stateCount, stateDuration, stateTransitions)', async () => {
+    await runTestWithRetryWhenFailing(async () => {
+      const result = await client.datapoints.retrieve({
+        items: [
+          {
+            instanceId: { space: SPACE, externalId: PUMP_A_EXT_ID },
+            start: BASE_TS,
+            end: END_TS,
+          },
+        ],
+        aggregates: ['stateCount', 'stateDuration', 'stateTransitions'],
+        granularity: '1d',
+      });
+
+      expect(result).toHaveLength(1);
+
+      const pumpA = result[0] as StateDatapointAggregates;
+      expect(pumpA.type).toBe('state');
+      expect(pumpA.datapoints.length).toBeGreaterThan(0);
+
+      const [firstBucket] = pumpA.datapoints;
+      expect(firstBucket.stateAggregates).toBeDefined();
+      expect(firstBucket.stateAggregates?.length).toBeGreaterThan(0);
+
+      const runningAgg = firstBucket.stateAggregates?.find(
+        (s) => s.stringValue === 'RUNNING'
+      );
+      expect(runningAgg).toBeDefined();
+      expect(runningAgg?.stateCount).toBeGreaterThan(0);
+      expect(runningAgg?.stateDuration).toBeGreaterThan(0);
+      expect(runningAgg?.stateTransitions).toBeGreaterThan(0);
+    });
+  });
+
+  test('retrieveLatest returns the most recent state datapoint', async () => {
+    await runTestWithRetryWhenFailing(async () => {
+      const result = await client.datapoints.retrieveLatest([
+        {
+          instanceId: { space: SPACE, externalId: PUMP_A_EXT_ID },
+          before: new Date(END_TS),
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+      const pumpA = result[0] as StateDatapoints;
+      expect(pumpA.type).toBe('state');
+      expect(pumpA.datapoints).toHaveLength(1);
+      // Last datapoint is OFF at 22h; `value` is mirrored here too
+      expect(pumpA.datapoints[0].timestamp).toEqual(new Date(ts(22)));
+      expect(pumpA.datapoints[0].numericValue).toBe(0);
+      expect(pumpA.datapoints[0].stringValue).toBe('OFF');
+      expect(pumpA.datapoints[0].value).toBe(0);
+    });
+  });
+});

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -4,17 +4,20 @@ import { BaseResourceAPI } from '@cognite/sdk-core';
 import type { ItemsWrapper } from '@cognite/sdk-core';
 import type { DatapointInfo, IgnoreUnknownIds } from '../../types/common';
 import type {
-  DatapointAggregates,
   Datapoints,
   DatapointsDeleteRequest,
   DatapointsInsertItem,
   DatapointsMonthlyGranularityMultiQuery,
   DatapointsMultiQuery,
   LatestDataBeforeRequest,
+  NumericDatapointAggregates,
+  StateDatapointAggregates,
+  StateDatapointWrite,
+  StateDatapointsInsertItem,
 } from './types';
 
 export class DataPointsAPI extends BaseResourceAPI<
-  DatapointAggregates | Datapoints
+  NumericDatapointAggregates | StateDatapointAggregates | Datapoints
 > {
   /**
    * @hidden
@@ -32,9 +35,21 @@ export class DataPointsAPI extends BaseResourceAPI<
    * ```js
    * await client.datapoints.insert([{ id: 123, datapoints: [{timestamp: 1557320284000, value: -2}] }]);
    * ```
+   *
+   * @remarks
+   * State time series (private beta) require the beta client (`cdf-version: beta` header):
+   *
+   * ```js
+   * await client.datapoints.insert([{
+   *   externalId: 'pump-state',
+   *   datapoints: [{ timestamp: Date.now(), numericValue: 1, stringValue: 'RUNNING' }],
+   * }]);
+   * ```
    */
-  public insert = (items: DatapointsInsertItem[]): Promise<object> => {
-    return this.insertEndpoint(items);
+  public insert = (
+    items: (DatapointsInsertItem | StateDatapointsInsertItem)[]
+  ): Promise<object> => {
+    return this.insertEndpoint(items.map(normalizeStateInsertItem));
   };
 
   /**
@@ -43,10 +58,23 @@ export class DataPointsAPI extends BaseResourceAPI<
    * ```js
    * const data = await client.datapoints.retrieve({ items: [{ id: 123 }] });
    * ```
+   *
+   * @remarks
+   * State time series (private beta) require the beta client (`cdf-version: beta` header):
+   *
+   * ```js
+   * const stateData = await client.datapoints.retrieve({
+   *   items: [{ externalId: 'pump-state' }],
+   *   aggregates: ['stateCount'],
+   *   granularity: '1h',
+   * });
+   * ```
    */
   public retrieve = (
     query: DatapointsMultiQuery
-  ): Promise<DatapointAggregates[] | Datapoints[]> => {
+  ): Promise<
+    Datapoints[] | NumericDatapointAggregates[] | StateDatapointAggregates[]
+  > => {
     return this.retrieveDatapointsEndpoint(query);
   };
 
@@ -59,11 +87,13 @@ export class DataPointsAPI extends BaseResourceAPI<
    */
   public retrieveDatapointMonthlyAggregates = async (
     query: DatapointsMonthlyGranularityMultiQuery
-  ): Promise<DatapointAggregates[]> => {
+  ): Promise<NumericDatapointAggregates[] | StateDatapointAggregates[]> => {
     console.warn(
       'retrieveDatapointMonthlyAggregates is deprecated. Use retrieve() with granularity "1mo" instead. This method will be removed in the next major release.'
     );
-    return this.retrieveDatapointsEndpoint<DatapointAggregates[]>({
+    return this.retrieveDatapointsEndpoint<
+      NumericDatapointAggregates[] | StateDatapointAggregates[]
+    >({
       ...query,
       granularity: '1mo',
     });
@@ -103,21 +133,30 @@ export class DataPointsAPI extends BaseResourceAPI<
     return this.deleteDatapointsEndpoint(items);
   };
 
-  private async insertEndpoint(items: DatapointsInsertItem[]) {
+  private async insertEndpoint(
+    items: (DatapointsInsertItem | StateDatapointsInsertItem)[]
+  ) {
     const path = this.url();
     await this.postInParallelWithAutomaticChunking({ path, items });
     return {};
   }
 
   protected async retrieveDatapointsEndpoint<
-    T extends DatapointAggregates[] | Datapoints[] =
-      | DatapointAggregates[]
+    T extends
+      | NumericDatapointAggregates[]
+      | StateDatapointAggregates[]
+      | Datapoints[] =
+      | NumericDatapointAggregates[]
+      | StateDatapointAggregates[]
       | Datapoints[],
   >(query: DatapointsMultiQuery) {
     const path = this.listPostUrl;
     const response = await this.post<ItemsWrapper<T>>(path, {
       data: query,
     });
+    for (const item of response.data.items) {
+      mirrorStateValueAlias(item.datapoints);
+    }
     return this.addToMapAndReturn(response.data.items, response);
   }
 
@@ -126,13 +165,22 @@ export class DataPointsAPI extends BaseResourceAPI<
     params: IgnoreUnknownIds
   ): Promise<Datapoints[]> {
     const path = this.url('latest');
-    return this.callEndpointWithMergeAndTransform(items, (request) =>
-      this.postInParallelWithAutomaticChunking({
-        items: request,
-        params,
-        path,
-        chunkSize: 100,
-      })
+    return this.callEndpointWithMergeAndTransform(
+      items,
+      (request) =>
+        this.postInParallelWithAutomaticChunking({
+          items: request,
+          params,
+          path,
+          chunkSize: 100,
+        }),
+      undefined,
+      (responseItems) => {
+        for (const item of responseItems) {
+          mirrorStateValueAlias(item.datapoints);
+        }
+        return responseItems;
+      }
     ) as Promise<Datapoints[]>;
   }
 
@@ -143,5 +191,51 @@ export class DataPointsAPI extends BaseResourceAPI<
       path: this.deleteUrl,
     });
     return {};
+  }
+}
+
+/**
+ * Folds the deprecated `value` alias into `numericValue` for state items
+ * (those with any data point carrying `numericValue` or `stringValue`).
+ */
+function normalizeStateInsertItem(
+  item: DatapointsInsertItem | StateDatapointsInsertItem
+): DatapointsInsertItem | StateDatapointsInsertItem {
+  const isStateItem = item.datapoints.some(
+    (datapoint) => 'numericValue' in datapoint || 'stringValue' in datapoint
+  );
+  if (!isStateItem) {
+    return item;
+  }
+  return {
+    ...item,
+    datapoints: (item.datapoints as StateDatapointWrite[]).map(
+      ({ value, ...datapoint }) =>
+        value === undefined
+          ? datapoint
+          : { ...datapoint, numericValue: datapoint.numericValue ?? value }
+    ),
+  };
+}
+
+/**
+ * Mirrors `numericValue` into the deprecated `value` alias on state data points.
+ * @hidden
+ */
+export function mirrorStateValueAlias(
+  datapoints: (
+    | Datapoints
+    | NumericDatapointAggregates
+    | StateDatapointAggregates
+  )['datapoints'][number][]
+): void {
+  for (const datapoint of datapoints) {
+    if (
+      'numericValue' in datapoint &&
+      datapoint.numericValue !== undefined &&
+      datapoint.value === undefined
+    ) {
+      datapoint.value = datapoint.numericValue;
+    }
   }
 }

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -165,7 +165,9 @@ export class DataPointsAPI extends BaseResourceAPI<
     params: IgnoreUnknownIds
   ): Promise<Datapoints[]> {
     const path = this.url('latest');
-    return this.callEndpointWithMergeAndTransform(items, (request) =>
+    return this.callEndpointWithMergeAndTransform(
+      items,
+      (request) =>
         this.postInParallelWithAutomaticChunking({
           items: request,
           params,

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -165,9 +165,7 @@ export class DataPointsAPI extends BaseResourceAPI<
     params: IgnoreUnknownIds
   ): Promise<Datapoints[]> {
     const path = this.url('latest');
-    return this.callEndpointWithMergeAndTransform(
-      items,
-      (request) =>
+    return this.callEndpointWithMergeAndTransform(items, (request) =>
         this.postInParallelWithAutomaticChunking({
           items: request,
           params,
@@ -194,10 +192,7 @@ export class DataPointsAPI extends BaseResourceAPI<
   }
 }
 
-/**
- * Folds the deprecated `value` alias into `numericValue` for state items
- * (those with any data point carrying `numericValue` or `stringValue`).
- */
+/* Folds `value` alias into `numericValue` for state items */
 function normalizeStateInsertItem(
   item: DatapointsInsertItem | StateDatapointsInsertItem
 ): DatapointsInsertItem | StateDatapointsInsertItem {
@@ -219,7 +214,7 @@ function normalizeStateInsertItem(
 }
 
 /**
- * Mirrors `numericValue` into the deprecated `value` alias on state data points.
+ * Mirrors `numericValue` into `value` alias on state data points.
  * @hidden
  */
 export function mirrorStateValueAlias(

--- a/packages/stable/src/api/dataPoints/dataPointsApi.ts
+++ b/packages/stable/src/api/dataPoints/dataPointsApi.ts
@@ -37,7 +37,7 @@ export class DataPointsAPI extends BaseResourceAPI<
    * ```
    *
    * @remarks
-   * State time series (private beta) require the beta client (`cdf-version: beta` header):
+   * State time series (beta) require the beta client (`cdf-version: beta` header):
    *
    * ```js
    * await client.datapoints.insert([{
@@ -60,7 +60,7 @@ export class DataPointsAPI extends BaseResourceAPI<
    * ```
    *
    * @remarks
-   * State time series (private beta) require the beta client (`cdf-version: beta` header):
+   * State time series (beta) require the beta client (`cdf-version: beta` header):
    *
    * ```js
    * const stateData = await client.datapoints.retrieve({

--- a/packages/stable/src/api/dataPoints/types.ts
+++ b/packages/stable/src/api/dataPoints/types.ts
@@ -51,7 +51,7 @@ export type StateAggregateName =
   | 'stateTransitions';
 
 /** All aggregate functions accepted by data point queries */
-export type AggregateName = NumericAggregateName | StateAggregateName;
+export type Aggregate = NumericAggregateName | StateAggregateName;
 
 // =====================================================
 // Data point status types
@@ -273,7 +273,7 @@ export interface DatapointsMultiQueryBase extends Limit, IgnoreUnknownIds {
   /**
    * The aggregates to be returned. This value overrides top-level default aggregates list when set. Specify all aggregates to be retrieved here. Specify empty array if this sub-query needs to return datapoints without aggregation.
    */
-  aggregates?: AggregateName[];
+  aggregates?: Aggregate[];
   /**
    * The time granularity size and unit to aggregate over.
    */
@@ -318,7 +318,7 @@ export interface DatapointsQueryProperties extends Limit, Cursor {
   /**
    * The aggregates to be returned.  Use default if null. An empty string must be sent to get raw data if the default is a set of aggregates.
    */
-  aggregates?: AggregateName[];
+  aggregates?: Aggregate[];
   /**
    * The granularity size and granularity of the aggregates (2h)
    */
@@ -497,9 +497,6 @@ export type LatestDataParams = IgnoreUnknownIds;
 
 /** @deprecated Use NumericDatapointAggregate instead. Will be removed in next major release. */
 export type DatapointAggregate = NumericDatapointAggregate;
-
-/** @deprecated Use NumericAggregateName instead. Will be removed in next major release. */
-export type Aggregate = NumericAggregateName;
 
 /** @deprecated Use NumericDatapoint instead. Will be removed in next major release. */
 export type DoubleDatapoint = NumericDatapoint;

--- a/packages/stable/src/api/dataPoints/types.ts
+++ b/packages/stable/src/api/dataPoints/types.ts
@@ -16,10 +16,13 @@ import type {
 } from '../../types/common';
 
 // =====================================================
-// Aggregate function type
+// Aggregate name types
 // =====================================================
 
-export type Aggregate =
+/**
+ * Aggregate functions available for numeric time series
+ */
+export type NumericAggregateName =
   | 'average'
   | 'max'
   | 'min'
@@ -38,6 +41,17 @@ export type Aggregate =
   | 'durationGood'
   | 'durationUncertain'
   | 'durationBad';
+
+/**
+ * Aggregate functions available for state time series
+ */
+export type StateAggregateName =
+  | 'stateCount'
+  | 'stateDuration'
+  | 'stateTransitions';
+
+/** All aggregate functions accepted by data point queries */
+export type AggregateName = NumericAggregateName | StateAggregateName;
 
 // =====================================================
 // Data point status types
@@ -65,21 +79,16 @@ export interface DatapointStatus {
 export interface DatapointExtremum {
   timestamp: Date;
   value: number;
+  status?: DatapointStatus;
 }
 
-export interface DatapointAggregate extends DatapointInfo {
-  average?: number;
-  max?: number;
-  min?: number;
+/**
+ * Aggregate fields common to all aggregate responses
+ * (data point counts and status-code durations).
+ */
+export interface CommonDatapointAggregate {
+  /** Number of data points in the aggregate period. */
   count?: number;
-  sum?: number;
-  interpolation?: number;
-  stepInterpolation?: number;
-  continuousVariance?: number;
-  discreteVariance?: number;
-  totalVariation?: number;
-  maxDatapoint?: DatapointExtremum;
-  minDatapoint?: DatapointExtremum;
   countGood?: number;
   countUncertain?: number;
   countBad?: number;
@@ -91,7 +100,23 @@ export interface DatapointAggregate extends DatapointInfo {
   durationBad?: number;
 }
 
-export interface DoubleDatapoint extends DatapointInfo {
+export interface NumericDatapointAggregate
+  extends DatapointInfo,
+    CommonDatapointAggregate {
+  average?: number;
+  max?: number;
+  min?: number;
+  sum?: number;
+  interpolation?: number;
+  stepInterpolation?: number;
+  continuousVariance?: number;
+  discreteVariance?: number;
+  totalVariation?: number;
+  maxDatapoint?: DatapointExtremum;
+  minDatapoint?: DatapointExtremum;
+}
+
+export interface NumericDatapoint extends DatapointInfo {
   value: number;
   status?: DatapointStatus;
 }
@@ -106,9 +131,6 @@ export interface DatapointWrite {
   value: number | string;
   status?: DatapointStatus;
 }
-
-/** @deprecated Use DatapointWrite instead. Will be removed in next major release. */
-export type ExternalDatapoint = DatapointWrite;
 
 // =====================================================
 // Data points delete types
@@ -159,23 +181,29 @@ export interface DatapointsMetadata extends InternalId {
   unit?: string;
 }
 
-export interface DatapointAggregates extends DatapointsMetadata, NextCursor {
+export interface NumericDatapointAggregates
+  extends DatapointsMetadata,
+    NextCursor {
   isString: false;
+  // TODO(next-major): Make required per API spec (DatapointsGetAggregateDatapoint)
+  type?: 'numeric';
   /**
    * Whether the timeseries is a step series or not
    */
   isStep: boolean;
-  datapoints: DatapointAggregate[];
+  datapoints: NumericDatapointAggregate[];
   /**
    * The physical unit of the time series (reference to unit catalog). Replaced with target unit if data points were converted.
    */
   unitExternalId?: CogniteExternalId;
 }
 
-export type Datapoints = StringDatapoints | DoubleDatapoints;
+export type Datapoints = NumericDatapoints | StringDatapoints | StateDatapoints;
 
-export interface DoubleDatapoints extends DatapointsMetadata, NextCursor {
+export interface NumericDatapoints extends DatapointsMetadata, NextCursor {
   isString: false;
+  // TODO(next-major): Make required per API spec (DatapointsGetDoubleDatapoint)
+  type?: 'numeric';
   /**
    * Whether the timeseries is a step series or not
    */
@@ -183,7 +211,7 @@ export interface DoubleDatapoints extends DatapointsMetadata, NextCursor {
   /**
    * The list of datapoints
    */
-  datapoints: DoubleDatapoint[];
+  datapoints: NumericDatapoint[];
   /**
    * The physical unit of the time series (reference to unit catalog). Replaced with target unit if data points were converted.
    */
@@ -192,6 +220,8 @@ export interface DoubleDatapoints extends DatapointsMetadata, NextCursor {
 
 export interface StringDatapoints extends DatapointsMetadata, NextCursor {
   isString: true;
+  // TODO(next-major): Make required per API spec (DatapointsGetStringDatapoint)
+  type?: 'string';
   /**
    * The list of datapoints
    */
@@ -206,51 +236,28 @@ export interface DatapointsInsertProperties {
   datapoints: DatapointWrite[];
 }
 
-/** @deprecated Use DatapointsInsertProperties instead. Will be removed in next major release. */
-export type ExternalDatapoints = DatapointsInsertProperties;
-
 export interface DatapointsInsertByExternalId
   extends DatapointsInsertProperties,
     ExternalId {}
-
-/** @deprecated Use DatapointsInsertByExternalId instead. Will be removed in next major release. */
-export type ExternalDatapointExternalId = DatapointsInsertByExternalId;
 
 export interface DatapointsInsertByInstanceId
   extends DatapointsInsertProperties,
     InstanceId {}
 
-/** @deprecated Use DatapointsInsertByInstanceId instead. Will be removed in next major release. */
-export type ExternalDatapointInstanceId = DatapointsInsertByInstanceId;
-
 export interface DatapointsInsertById
   extends DatapointsInsertProperties,
     InternalId {}
-
-/** @deprecated Use DatapointsInsertById instead. Will be removed in next major release. */
-export type ExternalDatapointId = DatapointsInsertById;
 
 export type DatapointsInsertItem =
   | DatapointsInsertById
   | DatapointsInsertByExternalId
   | DatapointsInsertByInstanceId;
 
-/** @deprecated Use DatapointsInsertItem instead. Will be removed in next major release. */
-export type ExternalDatapointsQuery = DatapointsInsertItem;
-
 // =====================================================
 // Data points query types
 // =====================================================
 
 export interface DatapointsMultiQuery extends DatapointsMultiQueryBase {
-  items: DatapointsQuery[];
-}
-
-/**
- * @deprecated Use DatapointsMultiQuery with `granularity: '1mo'` instead. Will be removed in next major release.
- */
-export interface DatapointsMonthlyGranularityMultiQuery
-  extends Omit<DatapointsMultiQueryBase, 'granularity'> {
   items: DatapointsQuery[];
 }
 
@@ -266,7 +273,7 @@ export interface DatapointsMultiQueryBase extends Limit, IgnoreUnknownIds {
   /**
    * The aggregates to be returned. This value overrides top-level default aggregates list when set. Specify all aggregates to be retrieved here. Specify empty array if this sub-query needs to return datapoints without aggregation.
    */
-  aggregates?: Aggregate[];
+  aggregates?: AggregateName[];
   /**
    * The time granularity size and unit to aggregate over.
    */
@@ -311,7 +318,7 @@ export interface DatapointsQueryProperties extends Limit, Cursor {
   /**
    * The aggregates to be returned.  Use default if null. An empty string must be sent to get raw data if the default is a set of aggregates.
    */
-  aggregates?: Aggregate[];
+  aggregates?: AggregateName[];
   /**
    * The granularity size and granularity of the aggregates (2h)
    */
@@ -396,8 +403,135 @@ export interface LatestDataPropertyFilter {
 }
 
 // =====================================================
-// Deprecated re-exports from other modules
+// State data point types
+// =====================================================
+
+/**
+ * A state data point to insert. At least one of `value`, `numericValue` or
+ * `stringValue` must be provided unless the status is bad.
+ */
+export interface StateDatapointWrite {
+  timestamp: Timestamp;
+  /**
+   * Alias for `numericValue`: the SDK sends it to the API as `numericValue`
+   * (ignored if `numericValue` is also set).
+   * @deprecated Use numericValue instead. Will be removed in next major release.
+   */
+  value?: number;
+  numericValue?: number;
+  stringValue?: string;
+  status?: DatapointStatus;
+}
+
+export interface StateDatapointsInsertProperties {
+  datapoints: StateDatapointWrite[];
+}
+
+export type StateDatapointsInsertItem =
+  | (InternalId & StateDatapointsInsertProperties)
+  | (ExternalId & StateDatapointsInsertProperties)
+  | (InstanceId & StateDatapointsInsertProperties);
+
+export interface StateDatapoint extends DatapointInfo {
+  /**
+   * Numeric representation of the state, mirrored by the SDK from
+   * `numericValue`. May be missing if status is bad.
+   * @deprecated Use numericValue instead. Will be removed in next major release.
+   */
+  value?: number;
+  /** Numeric representation of the state. May be missing if status is bad. */
+  numericValue?: number;
+  /** String representation of the state. May be missing if the state no longer exists in the state set or if status is bad. */
+  stringValue?: string;
+  status?: DatapointStatus;
+}
+
+export interface StateDatapoints extends DatapointsMetadata, NextCursor {
+  isString: false;
+  type: 'state';
+  isStep?: boolean;
+  datapoints: StateDatapoint[];
+}
+
+export interface StateAggregateValue {
+  numericValue: number;
+  /** String representation of the state. May be omitted if the state no longer exists in the state set. */
+  stringValue?: string;
+  /** Number of data points in the aggregate period with this state value. */
+  stateCount?: number;
+  /**
+   * Number of times the state changed to this value in the aggregate period,
+   * counting the very first data point and transitions from bad data points.
+   */
+  stateTransitions?: number;
+  /**
+   * Duration in milliseconds the time series was in this state. Carries over
+   * from the previous aggregate period, so it may be non-zero even if the
+   * state does not occur in the current period.
+   */
+  stateDuration?: number;
+}
+
+export interface StateDatapointAggregate
+  extends DatapointInfo,
+    CommonDatapointAggregate {
+  stateAggregates?: StateAggregateValue[];
+}
+
+export interface StateDatapointAggregates
+  extends DatapointsMetadata,
+    NextCursor {
+  isString: false;
+  type: 'state';
+  isStep: boolean;
+  datapoints: StateDatapointAggregate[];
+  unitExternalId?: CogniteExternalId;
+}
+
+// =====================================================
+// Deprecated exports
 // =====================================================
 
 /** @deprecated Use IgnoreUnknownIds directly. Will be removed in next major release. */
 export type LatestDataParams = IgnoreUnknownIds;
+
+/** @deprecated Use NumericDatapointAggregate instead. Will be removed in next major release. */
+export type DatapointAggregate = NumericDatapointAggregate;
+
+/** @deprecated Use NumericAggregateName instead. Will be removed in next major release. */
+export type Aggregate = NumericAggregateName;
+
+/** @deprecated Use NumericDatapoint instead. Will be removed in next major release. */
+export type DoubleDatapoint = NumericDatapoint;
+
+/** @deprecated Use DatapointWrite instead. Will be removed in next major release. */
+export type ExternalDatapoint = DatapointWrite;
+
+/** @deprecated Use NumericDatapointAggregates instead. Will be removed in next major release. */
+export type DatapointAggregates = NumericDatapointAggregates;
+
+/** @deprecated Use NumericDatapoints instead. Will be removed in next major release. */
+export type DoubleDatapoints = NumericDatapoints;
+
+/** @deprecated Use DatapointsInsertProperties instead. Will be removed in next major release. */
+export type ExternalDatapoints = DatapointsInsertProperties;
+
+/** @deprecated Use DatapointsInsertByExternalId instead. Will be removed in next major release. */
+export type ExternalDatapointExternalId = DatapointsInsertByExternalId;
+
+/** @deprecated Use DatapointsInsertByInstanceId instead. Will be removed in next major release. */
+export type ExternalDatapointInstanceId = DatapointsInsertByInstanceId;
+
+/** @deprecated Use DatapointsInsertById instead. Will be removed in next major release. */
+export type ExternalDatapointId = DatapointsInsertById;
+
+/** @deprecated Use DatapointsInsertItem instead. Will be removed in next major release. */
+export type ExternalDatapointsQuery = DatapointsInsertItem;
+
+/**
+ * @deprecated Use DatapointsMultiQuery with `granularity: '1mo'` instead. Will be removed in next major release.
+ */
+export interface DatapointsMonthlyGranularityMultiQuery
+  extends Omit<DatapointsMultiQueryBase, 'granularity'> {
+  items: DatapointsQuery[];
+}

--- a/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/dataPointSubscriptionsApi.ts
@@ -6,6 +6,7 @@ import {
   type CursorResponse,
 } from '@cognite/sdk-core';
 import cloneDeepWith from 'lodash/cloneDeepWith';
+import { mirrorStateValueAlias } from '../../dataPoints/dataPointsApi';
 import type {
   DataPointSubscription,
   DataPointSubscriptionByIdsQuery,
@@ -155,6 +156,9 @@ export class DataPointSubscriptionsAPI extends BaseResourceAPI<DataPointSubscrip
       }
     );
     const parsed = parseSubscriptionListDataDates(response.data);
+    for (const update of parsed.updates) {
+      mirrorStateValueAlias(update.upserts ?? []);
+    }
     return this.addToMapAndReturn(parsed, response);
   };
 }

--- a/packages/stable/src/api/timeSeries/subscriptions/types.ts
+++ b/packages/stable/src/api/timeSeries/subscriptions/types.ts
@@ -13,7 +13,8 @@ import type {
 } from '../../../types/common';
 import type {
   DatapointsDeleteRange,
-  DoubleDatapoint,
+  NumericDatapoint,
+  StateDatapoint,
   StringDatapoint,
 } from '../../dataPoints/types';
 import type { TimeSeriesType } from '../types';
@@ -219,7 +220,10 @@ export interface GetTimeSeriesForSubscription {
   type: TimeSeriesType;
 }
 
-export type SubscriptionDataUpsert = DoubleDatapoint | StringDatapoint;
+export type SubscriptionDataUpsert =
+  | NumericDatapoint
+  | StringDatapoint
+  | StateDatapoint;
 
 export interface DataPointSubscriptionDataUpdate {
   timeSeries?: GetTimeSeriesForSubscription;


### PR DESCRIPTION
This PR adds SDK support for state time series across the datapoints API surface:
- `insert()` accepts state data points (`numericValue` / `stringValue` pairs)
- `retrieve()` returns raw state data points and the new state aggregates (`stateCount`, `stateDuration`, `stateTransitions`) with `stateAggregates` buckets
- `retrieveLatest()` and data point subscription upserts handle state data points
- Numeric-specific types are renamed to match the new type specific naming convention. All old names remain as `@deprecated` aliases, to be removed in the next major release.

### Design decisions

**State types live in the stable package.** State time series are in beta, but it would require significant amount of code duplication to implement the small changes needed to support state time series in the beta client since it inherits stable's `DataPointsAPI` surface. The docs note that the beta client (`cdf-version: beta` header) is required and the API itself validates aggregate/type compatibility at runtime. This is the same behaviour as today, where requesting numeric aggregates on a string time series returns a 400.

**A deprecated `value` alias keeps existing consumers compiling.** State data points carry `numericValue`/`stringValue` instead of `value`, so adding `StateDatapoints` to the `Datapoints` union would have broken typescript compilation for every consumer reading `.value` without checking first the time series `type`. To address this without introducing breaking changes, the SDK bridges the two representations:
- on **insert**, `value` is folded into `numericValue` (explicit `numericValue` wins)
- on **responses** (`retrieve`, `retrieveLatest`, subscription `listData`), `numericValue` is mirrored into `value`.

The alias is declared as `@deprecated` and will be dropped in the next major release (when clients are expected to use the `type` property to discriminate when `value` is available).