### PR TITLE
feat(alpha): add data products API support

### DIFF
--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -1,0 +1,97 @@
+// Copyright 2026 Cognite AS
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
+import type { DataProduct } from '../../types';
+import { randomInt, setupLoggedInClient } from '../testUtils';
+
+describe('Data products integration test', () => {
+  let client: CogniteClientAlpha;
+  const dataProductExternalId = `int-dataproduct-${randomInt()}`;
+  let createdDataProduct: DataProduct | undefined;
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+    const items = await client.dataProducts.create([
+      {
+        externalId: dataProductExternalId,
+        name: 'integration test data product',
+        isGoverned: true,
+        tags: ['integration'],
+      },
+    ]);
+    createdDataProduct = items[0];
+  });
+
+  afterAll(async () => {
+    if (!createdDataProduct) {
+      return;
+    }
+    await client.dataProducts
+      .delete([{ externalId: dataProductExternalId }])
+      .catch();
+  });
+
+  test('create', async () => {
+    const externalId = `int-dataproduct-create-${randomInt()}`;
+    const items = await client.dataProducts.create([
+      {
+        externalId,
+        name: 'data product create test',
+        isGoverned: true,
+        tags: ['create'],
+      },
+    ]);
+    const created = items[0];
+
+    expect(created.externalId).toBe(externalId);
+    expect(created.name).toBe('data product create test');
+    expect(created.isGoverned).toBe(true);
+
+    await client.dataProducts.delete([{ externalId }]).catch();
+  });
+
+  test('list', async () => {
+    const response = await client.dataProducts.list({ limit: 10 });
+    expect(Array.isArray(response.items)).toBe(true);
+  });
+
+  test('retrieve by external id', async () => {
+    const dataProduct = await client.dataProducts.retrieve(dataProductExternalId);
+    expect(dataProduct.externalId).toBe(dataProductExternalId);
+  });
+
+  test('update existing data product', async () => {
+    const items = await client.dataProducts.update([
+      {
+        externalId: dataProductExternalId,
+        update: {
+          description: { set: 'integration updated description' },
+          isGoverned: { set: false },
+          tags: { set: ['integration', 'updated'] },
+        },
+      },
+    ]);
+    const updatedDataProduct = items[0];
+
+    expect(updatedDataProduct.description).toBe('integration updated description');
+    expect(updatedDataProduct.isGoverned).toBe(false);
+  });
+
+  test('delete', async () => {
+    const externalId = `int-dataproduct-delete-${randomInt()}`;
+    const items = await client.dataProducts.create([
+      {
+        externalId,
+        name: 'data product to delete',
+      },
+    ]);
+    const dataProductToDelete = items[0];
+
+    expect(dataProductToDelete.externalId).toBe(externalId);
+
+    await expect(
+      client.dataProducts.delete([{ externalId: dataProductToDelete.externalId }])
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -7,7 +7,8 @@ import { randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Data products integration test', () => {
   let client: CogniteClientAlpha;
-  const dataProductExternalId = `int-dataproduct-${randomInt()}`;
+  const dataProductRandom = randomInt();
+  const dataProductExternalId = `int-dataproduct-${dataProductRandom}`;
   let createdDataProduct: DataProduct | undefined;
 
   beforeAll(async () => {
@@ -15,7 +16,7 @@ describe('Data products integration test', () => {
     const items = await client.dataProducts.create([
       {
         externalId: dataProductExternalId,
-        name: 'integration test data product',
+        name: `integration test data product ${dataProductRandom}`,
         isGoverned: true,
         tags: ['integration'],
       },
@@ -53,7 +54,12 @@ describe('Data products integration test', () => {
 
   test('list', async () => {
     const response = await client.dataProducts.list({ limit: 10 });
-    expect(Array.isArray(response.items)).toBe(true);
+    expect(response.items.length).toBeGreaterThan(0);
+    expect(
+      response.items.some(
+        (item) => item.externalId === dataProductExternalId
+      )
+    ).toBe(true);
   });
 
   test('retrieve by external id', async () => {

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -56,9 +56,7 @@ describe('Data products integration test', () => {
     const response = await client.dataProducts.list({ limit: 10 });
     expect(response.items.length).toBeGreaterThan(0);
     expect(
-      response.items.some(
-        (item) => item.externalId === dataProductExternalId
-      )
+      response.items.some((item) => item.externalId === dataProductExternalId)
     ).toBe(true);
   });
 

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -5,6 +5,8 @@ import type CogniteClientAlpha from '../../cogniteClient';
 import type { DataProduct } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
+const RESERVED_SCHEMA_SPACE = 'sdk_js_alpha_dataproducts_int_space';
+
 describe('Data products integration test', () => {
   let client: CogniteClientAlpha;
   const dataProductRandom = randomInt();
@@ -13,10 +15,20 @@ describe('Data products integration test', () => {
 
   beforeAll(async () => {
     client = setupLoggedInClient();
+
+    await client.spaces.upsert([
+      {
+        space: RESERVED_SCHEMA_SPACE,
+        name: RESERVED_SCHEMA_SPACE,
+        description: 'Space for Data Products integration tests',
+      },
+    ]);
+
     const items = await client.dataProducts.create([
       {
         externalId: dataProductExternalId,
         name: `integration test data product ${dataProductRandom}`,
+        schemaSpace: RESERVED_SCHEMA_SPACE,
         isGoverned: true,
         tags: ['integration'],
       },
@@ -39,6 +51,7 @@ describe('Data products integration test', () => {
       {
         externalId,
         name: 'data product create test',
+        schemaSpace: RESERVED_SCHEMA_SPACE,
         isGoverned: true,
         tags: ['create'],
       },
@@ -92,6 +105,7 @@ describe('Data products integration test', () => {
       {
         externalId,
         name: 'data product to delete',
+        schemaSpace: RESERVED_SCHEMA_SPACE,
       },
     ]);
     const dataProductToDelete = items[0];

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -5,12 +5,16 @@ import type CogniteClientAlpha from '../../cogniteClient';
 import type { DataProduct } from '../../types';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
-const RESERVED_SCHEMA_SPACE = 'sdk_js_alpha_dataproducts_int_space';
+function uniqueSchemaSpace(prefix: string): string {
+  return `${prefix}_${randomInt()}`;
+}
 
 describe('Data products integration test', () => {
   let client: CogniteClientAlpha;
   const dataProductRandom = randomInt();
   const dataProductExternalId = `int-dataproduct-${dataProductRandom}`;
+  const setupSchemaSpace = uniqueSchemaSpace('sdk_js_alpha_dp_int_setup');
+  const schemaSpacesToDelete: string[] = [setupSchemaSpace];
   let createdDataProduct: DataProduct | undefined;
 
   beforeAll(async () => {
@@ -18,8 +22,8 @@ describe('Data products integration test', () => {
 
     await client.spaces.upsert([
       {
-        space: RESERVED_SCHEMA_SPACE,
-        name: RESERVED_SCHEMA_SPACE,
+        space: setupSchemaSpace,
+        name: setupSchemaSpace,
         description: 'Space for Data Products integration tests',
       },
     ]);
@@ -28,7 +32,7 @@ describe('Data products integration test', () => {
       {
         externalId: dataProductExternalId,
         name: `integration test data product ${dataProductRandom}`,
-        schemaSpace: RESERVED_SCHEMA_SPACE,
+        schemaSpace: setupSchemaSpace,
         isGoverned: true,
         tags: ['integration'],
       },
@@ -37,21 +41,32 @@ describe('Data products integration test', () => {
   });
 
   afterAll(async () => {
-    if (!createdDataProduct) {
-      return;
+    if (createdDataProduct) {
+      await client.dataProducts
+        .delete([{ externalId: dataProductExternalId }])
+        .catch();
     }
-    await client.dataProducts
-      .delete([{ externalId: dataProductExternalId }])
-      .catch();
+
+    await client.spaces.delete(schemaSpacesToDelete).catch();
   });
 
   test('create', async () => {
     const externalId = `int-dataproduct-create-${randomInt()}`;
+    const schemaSpace = uniqueSchemaSpace('sdk_js_alpha_dp_int_create');
+    schemaSpacesToDelete.push(schemaSpace);
+    await client.spaces.upsert([
+      {
+        space: schemaSpace,
+        name: schemaSpace,
+        description: 'Space for Data Products create integration test',
+      },
+    ]);
+
     const items = await client.dataProducts.create([
       {
         externalId,
         name: 'data product create test',
-        schemaSpace: RESERVED_SCHEMA_SPACE,
+        schemaSpace,
         isGoverned: true,
         tags: ['create'],
       },
@@ -101,11 +116,21 @@ describe('Data products integration test', () => {
 
   test('delete', async () => {
     const externalId = `int-dataproduct-delete-${randomInt()}`;
+    const schemaSpace = uniqueSchemaSpace('sdk_js_alpha_dp_int_delete');
+    schemaSpacesToDelete.push(schemaSpace);
+    await client.spaces.upsert([
+      {
+        space: schemaSpace,
+        name: schemaSpace,
+        description: 'Space for Data Products delete integration test',
+      },
+    ]);
+
     const items = await client.dataProducts.create([
       {
         externalId,
         name: 'data product to delete',
-        schemaSpace: RESERVED_SCHEMA_SPACE,
+        schemaSpace,
       },
     ]);
     const dataProductToDelete = items[0];

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -57,7 +57,9 @@ describe('Data products integration test', () => {
   });
 
   test('retrieve by external id', async () => {
-    const dataProduct = await client.dataProducts.retrieve(dataProductExternalId);
+    const dataProduct = await client.dataProducts.retrieve(
+      dataProductExternalId
+    );
     expect(dataProduct.externalId).toBe(dataProductExternalId);
   });
 
@@ -74,7 +76,9 @@ describe('Data products integration test', () => {
     ]);
     const updatedDataProduct = items[0];
 
-    expect(updatedDataProduct.description).toBe('integration updated description');
+    expect(updatedDataProduct.description).toBe(
+      'integration updated description'
+    );
     expect(updatedDataProduct.isGoverned).toBe(false);
   });
 
@@ -91,7 +95,9 @@ describe('Data products integration test', () => {
     expect(dataProductToDelete.externalId).toBe(externalId);
 
     await expect(
-      client.dataProducts.delete([{ externalId: dataProductToDelete.externalId }])
+      client.dataProducts.delete([
+        { externalId: dataProductToDelete.externalId },
+      ])
     ).resolves.toBeDefined();
   });
 });

--- a/packages/alpha/src/__tests__/api/dataProducts.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.unit.spec.ts
@@ -62,7 +62,10 @@ describe('Data products unit test', () => {
         nextCursor: 'next',
       });
 
-    const response = await client.dataProducts.list({ limit: 10, cursor: 'abc' });
+    const response = await client.dataProducts.list({
+      limit: 10,
+      cursor: 'abc',
+    });
     expect(response.items).toHaveLength(1);
     expect(response.items[0].externalId).toBe(mockDataProduct.externalId);
     expect(response.nextCursor).toBe('next');

--- a/packages/alpha/src/__tests__/api/dataProducts.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.unit.spec.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Cognite AS
+
+import matches from 'lodash/matches';
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+describe('Data products unit test', () => {
+  let client: CogniteClientAlpha;
+
+  const dataProductFixture = {
+    externalId: 'dp-1',
+    name: 'Demo Data Product',
+    schemaSpace: 'dp_1_space',
+    description: 'Test data product',
+    isGoverned: true,
+    tags: ['demo'],
+    domains: [],
+  };
+
+  const mockDataProduct = {
+    ...dataProductFixture,
+    createdTime: Date.now(),
+    lastUpdatedTime: Date.now() + 1000,
+  };
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test('create', async () => {
+    const createBody = {
+      externalId: 'dp-1',
+      name: 'Demo Data Product',
+      description: 'create test',
+      isGoverned: false,
+      tags: ['a', 'b'],
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/dataproducts$/, matches({ items: [createBody] }))
+      .once()
+      .reply(201, {
+        items: [{ ...mockDataProduct, ...createBody }],
+      });
+
+    const items = await client.dataProducts.create([createBody]);
+    expect(items).toHaveLength(1);
+    expect(items[0].externalId).toEqual(mockDataProduct.externalId);
+  });
+
+  test('list', async () => {
+    nock(mockBaseUrl)
+      .get(/\/dataproducts\/?$/)
+      .query({ limit: '10', cursor: 'abc' })
+      .once()
+      .reply(200, {
+        items: [mockDataProduct],
+        nextCursor: 'next',
+      });
+
+    const response = await client.dataProducts.list({ limit: 10, cursor: 'abc' });
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].externalId).toBe(mockDataProduct.externalId);
+    expect(response.nextCursor).toBe('next');
+  });
+
+  test('retrieve by external id', async () => {
+    nock(mockBaseUrl)
+      .get(/\/dataproducts\/dp-2$/)
+      .once()
+      .reply(200, {
+        ...mockDataProduct,
+        externalId: 'dp-2',
+      });
+
+    const response = await client.dataProducts.retrieve('dp-2');
+    expect(response.externalId).toEqual('dp-2');
+  });
+
+  test('update', async () => {
+    const updateBody = {
+      externalId: 'dp-1',
+      update: {
+        name: { set: 'Renamed data product' },
+        description: { set: 'updated description' },
+      },
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/dataproducts\/update$/, matches({ items: [updateBody] }))
+      .once()
+      .reply(200, {
+        items: [{ ...mockDataProduct, name: 'Renamed data product' }],
+      });
+
+    const items = await client.dataProducts.update([updateBody]);
+    expect(items).toHaveLength(1);
+    expect(items[0].name).toEqual('Renamed data product');
+  });
+
+  test('delete', async () => {
+    nock(mockBaseUrl)
+      .post(/\/dataproducts\/delete$/, { items: [{ externalId: 'dp-1' }] })
+      .once()
+      .reply(200, {});
+
+    await client.dataProducts.delete([{ externalId: 'dp-1' }]);
+  });
+});

--- a/packages/alpha/src/api/dataProducts/dataProductsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductsApi.ts
@@ -34,7 +34,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ```
    */
   public create = (items: DataProductCreate[]): Promise<DataProduct[]> => {
-    return this.createEndpoint(items, this.url());
+    return this.createEndpoint(items);
   };
 
   /**
@@ -91,7 +91,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * await client.dataProducts.delete([{ externalId: 'my-data-product' }]);
    * ```
    */
-  public delete = (ids: DataProductDelete[]) => {
+  public delete = (ids: DataProductDelete[]): Promise<{}> => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/dataProducts/dataProductsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductsApi.ts
@@ -34,7 +34,9 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ]);
    * ```
    */
-  public create = (items: SingleItem<DataProductCreate>): Promise<DataProduct[]> => {
+  public create = (
+    items: SingleItem<DataProductCreate>
+  ): Promise<DataProduct[]> => {
     return this.createEndpoint(items);
   };
 
@@ -81,7 +83,9 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ]);
    * ```
    */
-  public update = (items: SingleItem<DataProductChange>): Promise<DataProduct[]> => {
+  public update = (
+    items: SingleItem<DataProductChange>
+  ): Promise<DataProduct[]> => {
     return this.updateEndpoint(items, this.url('update'));
   };
 

--- a/packages/alpha/src/api/dataProducts/dataProductsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductsApi.ts
@@ -1,0 +1,97 @@
+// Copyright 2026 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import type {
+  CogniteExternalId,
+  CursorAndAsyncIterator,
+} from '@cognite/sdk-core';
+import type {
+  DataProduct,
+  DataProductChange,
+  DataProductCreate,
+  DataProductDelete,
+  DataProductListQuery,
+} from './types';
+
+export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
+  /**
+   * @hidden
+   */
+  protected getDateProps() {
+    return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
+  }
+
+  /**
+   * [Create data products](https://api-docs.cognite.com/20230101/tag/Data-products/operation/createDataProduct)
+   *
+   * ```js
+   * const dataProducts = await client.dataProducts.create([
+   *   {
+   *     externalId: 'my-data-product',
+   *     name: 'My Data Product',
+   *   },
+   * ]);
+   * ```
+   */
+  public create = (items: DataProductCreate[]): Promise<DataProduct[]> => {
+    return this.createEndpoint(items, this.url());
+  };
+
+  /**
+   * [List data products](https://api-docs.cognite.com/20230101/tag/Data-products/operation/listDataProducts)
+   *
+   * ```js
+   * const dataProducts = await client.dataProducts.list({ limit: 10 });
+   * ```
+   */
+  public list = (
+    query?: DataProductListQuery
+  ): CursorAndAsyncIterator<DataProduct> => {
+    return this.listEndpoint(this.callListEndpointWithGet, query);
+  };
+
+  /**
+   * [Retrieve a data product by external id](https://api-docs.cognite.com/20230101/tag/Data-products/operation/getDataProduct)
+   *
+   * ```js
+   * const dataProduct = await client.dataProducts.retrieve('my-data-product');
+   * ```
+   */
+  public retrieve = async (
+    externalId: CogniteExternalId
+  ): Promise<DataProduct> => {
+    const response = await this.get<DataProduct>(
+      this.url(encodeURIComponent(externalId))
+    );
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [Update data products](https://api-docs.cognite.com/20230101/tag/Data-products/operation/updateDataProduct)
+   *
+   * ```js
+   * const updated = await client.dataProducts.update([
+   *   {
+   *     externalId: 'my-data-product',
+   *     update: {
+   *       description: { set: 'Updated description' },
+   *     },
+   *   },
+   * ]);
+   * ```
+   */
+  public update = (items: DataProductChange[]): Promise<DataProduct[]> => {
+    return this.updateEndpoint(items, this.url('update'));
+  };
+
+  /**
+   * [Delete data products](https://api-docs.cognite.com/20230101/tag/Data-products/operation/deleteDataProduct)
+   *
+   * ```js
+   * await client.dataProducts.delete([{ externalId: 'my-data-product' }]);
+   * ```
+   */
+  public delete = (ids: DataProductDelete[]) => {
+    return this.deleteEndpoint(ids);
+  };
+}

--- a/packages/alpha/src/api/dataProducts/dataProductsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductsApi.ts
@@ -11,6 +11,7 @@ import type {
   DataProductCreate,
   DataProductDelete,
   DataProductListQuery,
+  SingleItem,
 } from './types';
 
 export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
@@ -33,7 +34,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ]);
    * ```
    */
-  public create = (items: DataProductCreate[]): Promise<DataProduct[]> => {
+  public create = (items: SingleItem<DataProductCreate>): Promise<DataProduct[]> => {
     return this.createEndpoint(items);
   };
 
@@ -80,7 +81,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ]);
    * ```
    */
-  public update = (items: DataProductChange[]): Promise<DataProduct[]> => {
+  public update = (items: SingleItem<DataProductChange>): Promise<DataProduct[]> => {
     return this.updateEndpoint(items, this.url('update'));
   };
 
@@ -91,7 +92,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * await client.dataProducts.delete([{ externalId: 'my-data-product' }]);
    * ```
    */
-  public delete = (ids: DataProductDelete[]): Promise<object> => {
+  public delete = (ids: SingleItem<DataProductDelete>): Promise<object> => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/dataProducts/dataProductsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductsApi.ts
@@ -33,9 +33,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ]);
    * ```
    */
-  public create = (
-    items: [DataProductCreate]
-  ): Promise<DataProduct[]> => {
+  public create = (items: [DataProductCreate]): Promise<DataProduct[]> => {
     return this.createEndpoint(items);
   };
 
@@ -82,9 +80,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ]);
    * ```
    */
-  public update = (
-    items: [DataProductChange]
-  ): Promise<DataProduct[]> => {
+  public update = (items: [DataProductChange]): Promise<DataProduct[]> => {
     return this.updateEndpoint(items, this.url('update'));
   };
 

--- a/packages/alpha/src/api/dataProducts/dataProductsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductsApi.ts
@@ -11,7 +11,6 @@ import type {
   DataProductCreate,
   DataProductDelete,
   DataProductListQuery,
-  SingleItem,
 } from './types';
 
 export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
@@ -35,7 +34,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ```
    */
   public create = (
-    items: SingleItem<DataProductCreate>
+    items: [DataProductCreate]
   ): Promise<DataProduct[]> => {
     return this.createEndpoint(items);
   };
@@ -84,7 +83,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * ```
    */
   public update = (
-    items: SingleItem<DataProductChange>
+    items: [DataProductChange]
   ): Promise<DataProduct[]> => {
     return this.updateEndpoint(items, this.url('update'));
   };
@@ -96,7 +95,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * await client.dataProducts.delete([{ externalId: 'my-data-product' }]);
    * ```
    */
-  public delete = (ids: SingleItem<DataProductDelete>): Promise<object> => {
+  public delete = (ids: [DataProductDelete]): Promise<object> => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/dataProducts/dataProductsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductsApi.ts
@@ -91,7 +91,7 @@ export class DataProductsAPI extends BaseResourceAPI<DataProduct> {
    * await client.dataProducts.delete([{ externalId: 'my-data-product' }]);
    * ```
    */
-  public delete = (ids: DataProductDelete[]): Promise<{}> => {
+  public delete = (ids: DataProductDelete[]): Promise<object> => {
     return this.deleteEndpoint(ids);
   };
 }

--- a/packages/alpha/src/api/dataProducts/types.ts
+++ b/packages/alpha/src/api/dataProducts/types.ts
@@ -7,7 +7,6 @@ import type {
 } from '@cognite/sdk-core';
 
 export type DataProductExternalId = CogniteExternalId;
-export type SingleItem<T> = [T];
 
 export interface DataProduct {
   externalId: DataProductExternalId;

--- a/packages/alpha/src/api/dataProducts/types.ts
+++ b/packages/alpha/src/api/dataProducts/types.ts
@@ -7,6 +7,7 @@ import type {
 } from '@cognite/sdk-core';
 
 export type DataProductExternalId = CogniteExternalId;
+export type SingleItem<T> = [T];
 
 export interface DataProduct {
   externalId: DataProductExternalId;

--- a/packages/alpha/src/api/dataProducts/types.ts
+++ b/packages/alpha/src/api/dataProducts/types.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Cognite AS
+
+import type {
+  CogniteExternalId,
+  FilterQuery,
+  ListResponse,
+} from '@cognite/sdk-core';
+
+export type DataProductExternalId = CogniteExternalId;
+
+export interface DataProduct {
+  externalId: DataProductExternalId;
+  name: string;
+  schemaSpace: string;
+  description?: string;
+  isGoverned: boolean;
+  tags: string[];
+  domains: string[];
+  createdTime: Date;
+  lastUpdatedTime: Date;
+}
+
+export interface DataProductCreate {
+  externalId: DataProductExternalId;
+  name: string;
+  schemaSpace?: string;
+  description?: string;
+  isGoverned?: boolean;
+  tags?: string[];
+}
+
+export interface DataProductDelete {
+  externalId: DataProductExternalId;
+}
+
+export interface DataProductPatch {
+  name?: { set: string };
+  description?: { set: string } | { setNull: boolean };
+  isGoverned?: { set: boolean };
+  tags?: { set: string[] } | { add?: string[]; remove?: string[] };
+}
+
+export interface DataProductChange extends DataProductDelete {
+  update: DataProductPatch;
+}
+
+export interface DataProductListQuery extends FilterQuery {}
+
+export type DataProductListResponse = ListResponse<DataProduct[]>;

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -42,7 +42,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
   public get workflowExecutions() {
     return accessApi(this.workflowExecutionsApi);
   }
-  
+
   public get dataProducts() {
     return accessApi(this.dataProductsApi);
   }

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -7,6 +7,7 @@ import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
 import { WorkflowVersionsAPI } from './api/workflows/workflowVersionsApi';
 import { WorkflowsAPI } from './api/workflows/workflowsApi';
+import { DataProductsAPI } from './api/dataProducts/dataProductsApi';
 
 export default class CogniteClientAlpha extends CogniteClientStable {
   private simulatorsApi?: SimulatorsAPI;
@@ -14,6 +15,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
   private meteringApi?: MeteringAPI;
   private workflowsApi?: WorkflowsAPI;
   private workflowVersionsApi?: WorkflowVersionsAPI;
+  private dataProductsApi?: DataProductsAPI;
 
   public get limits() {
     return accessApi(this.limitsApi);
@@ -35,6 +37,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     return accessApi(this.workflowVersionsApi);
   }
 
+  public get dataProducts() {
+    return accessApi(this.dataProductsApi);
+  }
+
   protected initAPIs() {
     super.initAPIs();
 
@@ -48,6 +54,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
       WorkflowVersionsAPI,
       'workflows/versions'
     );
+    this.dataProductsApi = this.apiFactory(DataProductsAPI, 'dataproducts');
   }
 
   protected get version() {

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -2,12 +2,12 @@
 import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
 import { accessApi } from '@cognite/sdk-core';
 import { version } from '../package.json';
+import { DataProductsAPI } from './api/dataProducts/dataProductsApi';
 import { LimitsAPI } from './api/limits/limitsApi';
 import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
 import { WorkflowVersionsAPI } from './api/workflows/workflowVersionsApi';
 import { WorkflowsAPI } from './api/workflows/workflowsApi';
-import { DataProductsAPI } from './api/dataProducts/dataProductsApi';
 
 export default class CogniteClientAlpha extends CogniteClientStable {
   private simulatorsApi?: SimulatorsAPI;

--- a/packages/alpha/src/types.ts
+++ b/packages/alpha/src/types.ts
@@ -16,6 +16,7 @@ import type {
 
 export * from '@cognite/sdk';
 export * from './api/workflows/types';
+export * from './api/dataProducts/types';
 
 // This file is here mostly to allow apis to import { ... } from '../../types';
 // Overriding types should probably be done in their respective API endpoint files, where possible


### PR DESCRIPTION
### Summary
Add Data Products API support to `@cognite/sdk-alpha`

### What’s included

- New dataProducts API in alpha client: `create, list, retrieve, update, delete`
- Data Products types added in alpha
- Unit tests for all CRUD operations
- Integration tests covering lifecycle flows