### PR TITLE
feat: add type inference to instances.query endpoint

### DIFF
--- a/packages/stable/src/__tests__/api/files.int.spec.ts
+++ b/packages/stable/src/__tests__/api/files.int.spec.ts
@@ -134,39 +134,51 @@ describe('Files integration test', () => {
     expect(retrievedFile.directory).toEqual('/test/testing');
   });
 
-  test('retrieve by instance id', async () => {
-    // Syncing from instance to files API is eventually consistant
-    await runTestWithRetryWhenFailing(async () => {
-      const [retrievedFile] = await client.files.retrieve([
-        { instanceId: fileCdmInstanceId },
-      ]);
-      expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
-    });
-  });
+  test(
+    'retrieve by instance id',
+    async () => {
+      // Syncing from instance to files API is eventually consistant
+      await runTestWithRetryWhenFailing(async () => {
+        const [retrievedFile] = await client.files.retrieve([
+          { instanceId: fileCdmInstanceId },
+        ]);
+        expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
+      });
+    },
+    3 * 60 * 1000
+  );
 
-  test('update by instance id', async () => {
-    // Syncing from instance to files API is eventually consistant
-    await runTestWithRetryWhenFailing(async () => {
-      const testMetadata = { testKey: 'testVal' };
-      const [retrievedFile] = await client.files.update([
-        {
-          instanceId: fileCdmInstanceId,
-          update: { metadata: { set: testMetadata } },
-        },
-      ]);
-      expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
-      expect(retrievedFile.metadata).toEqual(testMetadata);
-    });
-  });
+  test(
+    'update by instance id',
+    async () => {
+      // Syncing from instance to files API is eventually consistant
+      await runTestWithRetryWhenFailing(async () => {
+        const testMetadata = { testKey: 'testVal' };
+        const [retrievedFile] = await client.files.update([
+          {
+            instanceId: fileCdmInstanceId,
+            update: { metadata: { set: testMetadata } },
+          },
+        ]);
+        expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
+        expect(retrievedFile.metadata).toEqual(testMetadata);
+      });
+    },
+    3 * 60 * 1000
+  );
 
-  test('download by instance id', async () => {
-    // Syncing from instance to files API is eventually consistant
-    await runTestWithRetryWhenFailing(async () => {
-      expect(
-        client.files.getDownloadUrls([{ instanceId: fileCdmInstanceId }])
-      ).rejects.toThrow(/Files not uploaded/);
-    });
-  });
+  test(
+    'download by instance id',
+    async () => {
+      // Syncing from instance to files API is eventually consistant
+      await runTestWithRetryWhenFailing(async () => {
+        expect(
+          client.files.getDownloadUrls([{ instanceId: fileCdmInstanceId }])
+        ).rejects.toThrow(/Files not uploaded/);
+      });
+    },
+    3 * 60 * 1000
+  );
 
   test.skip('retrieve with non-existent id', async () => {
     const res = await client.files.retrieve([{ id: 1 }], {

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -1,0 +1,192 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { QueryRequest } from 'stable/src/types';
+import CogniteClient from '../../../cogniteClient';
+
+type Expect<T extends true> = T;
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+
+describe('queryNodesEdges type tests', () => {
+  test('query result keys should match const query select keys', () => {
+    type QueryResultSelectKeys = keyof Awaited<ReturnType<typeof CogniteClient.prototype.instances.query<typeof testQuery>>>['items'];
+    type Assert = Expect<Equal<QueryResultSelectKeys, keyof typeof testQuery.select>>;
+
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('Each source with unique space should map to a key in properties of result', () => {
+    type ResultSourceSpaces = keyof Awaited<ReturnType<
+      typeof CogniteClient.prototype.instances.query<typeof testQuery>
+    >>['items']['resultExpressionA'][number]['properties'];
+
+    type QueryResultSpaces =
+      (typeof testQuery.select.resultExpressionA.sources)[number]['source']['space'];
+    type Assert = Expect<Equal<ResultSourceSpaces, QueryResultSpaces>>;
+
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('property keys of result should match property keys of sources', () => {
+    type ResultPropertiesA = keyof Awaited<ReturnType<
+      typeof CogniteClient.prototype.instances.query<typeof testQuery>
+    >>['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+    type QueryPropertiesA =
+      (typeof testQuery.select.resultExpressionA.sources)[0]['properties'][number];
+
+    type Assert0 = Expect<Equal<ResultPropertiesA, QueryPropertiesA>>;
+    // @ts-ignore
+    type _0 = Assert0;
+
+    type ResultPropertiesB = keyof Awaited<ReturnType<
+      typeof CogniteClient.prototype.instances.query<typeof testQuery>
+    >>['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdB/v1'];
+    type QueryPropertiesB =
+      (typeof testQuery.select.resultExpressionA.sources)[1]['properties'][number];
+
+    type Assert1 = Expect<Equal<ResultPropertiesB, QueryPropertiesB>>;
+    // @ts-ignore
+    type _1 = Assert1;
+
+    type ResultPropertiesC = keyof Awaited<ReturnType<
+      typeof CogniteClient.prototype.instances.query<typeof testQuery>
+    >>['items']['resultExpressionA'][number]['properties']['spaceB']['externalIdC/v1'];
+    type QueryPropertiesC =
+      (typeof testQuery.select.resultExpressionA.sources)[2]['properties'][number];
+
+    type Assert2 = Expect<Equal<ResultPropertiesC, QueryPropertiesC>>;
+    // @ts-ignore
+    type _2 = Assert2;
+  });
+
+  test('passing a typed Source generic should return a typed results for parameters', () => {
+    type SourceExternalIdAPropertyTypes = [
+      {
+        source: {
+          type: 'view';
+          space: 'spaceA';
+          externalId: 'externalIdA';
+          version: 'v1';
+        };
+        properties: {
+          aPropOne: string;
+          aPropTwo: number;
+          aPropThree: { externalId: string; space: string };
+        };
+      }
+    ];
+
+    type TypedResultProperties = Awaited<ReturnType<
+      typeof CogniteClient.prototype.instances.query<typeof testQuery, SourceExternalIdAPropertyTypes>
+    >>['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+
+    type Assert = Expect<Equal<TypedResultProperties, SourceExternalIdAPropertyTypes[0]['properties']>>;
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('Passing a non-constant query should be valid', () => {
+    type QueryResult = Awaited<ReturnType<typeof CogniteClient.prototype.instances.query<QueryRequest>>>;
+
+    type TestType = QueryResult extends {
+      items: Record<string, any>;
+      nextCursors?: Record<string, any>;
+    }
+      ? true
+      : false;
+
+    type Assert = Expect<Equal<TestType, true>>;
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('passing * as property should type properties as Record', () => {
+    type ResultSourceSpaces = Awaited<ReturnType<
+      typeof CogniteClient.prototype.instances.query<typeof testQuery>
+    >>['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
+
+    // @ts-expect-error - property key should not be the string '*'
+    type _ = Expect<Equal<ResultSourceSpaces, '*'>>;
+
+    type Assert = Expect<Equal<ResultSourceSpaces, Record<string, unknown>>>;
+    // @ts-ignore
+    type _1 = Assert;
+  });
+});
+
+const testQuery = {
+  with: {
+    resultExpressionA: {
+      nodes: {}
+    },
+    resultExpressionB: {
+      nodes: {}
+    },
+    resultExpressionC: {
+      edges: {}
+    }
+  },
+  select: {
+    resultExpressionA: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdA',
+            version: 'v1'
+          },
+          properties: ['aPropOne', 'aPropTwo', 'aPropThree']
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdB',
+            version: 'v1'
+          },
+          properties: ['bPropOne', 'bPropTwo']
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceB',
+            externalId: 'externalIdC',
+            version: 'v1'
+          },
+          properties: ['cPropOne']
+        }
+      ]
+    },
+    resultExpressionB: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceD',
+            externalId: 'externalIdD',
+            version: 'v1'
+          },
+          properties: ['*']
+        }
+      ]
+    },
+    resultExpressionC: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceE',
+            externalId: 'externalIdE',
+            version: 'v1'
+          },
+          properties: ['ePropOne', 'ePropTwo']
+        }
+      ]
+    }
+  }
+} as const satisfies QueryRequest;

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -2,27 +2,38 @@
  * Copyright 2024 Cognite AS
  */
 
+import type { QueryRequest } from 'stable/src/types';
 import { describe, test } from 'vitest';
-import { QueryRequest } from 'stable/src/types';
-import CogniteClient from '../../../cogniteClient';
+import type CogniteClient from '../../../cogniteClient';
 
 type Expect<T extends true> = T;
-type Equal<X, Y> =
-  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+  ? 1
+  : 2
+  ? true
+  : false;
 
 describe('queryNodesEdges type tests', () => {
   test('query result keys should match const query select keys', () => {
-    type QueryResultSelectKeys = keyof Awaited<ReturnType<typeof CogniteClient.prototype.instances.query<typeof testQuery>>>['items'];
-    type Assert = Expect<Equal<QueryResultSelectKeys, keyof typeof testQuery.select>>;
+    type QueryResultSelectKeys = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items'];
+    type Assert = Expect<
+      Equal<QueryResultSelectKeys, keyof typeof testQuery.select>
+    >;
 
     // @ts-ignore
     type _ = Assert;
   });
 
   test('Each source with unique space should map to a key in properties of result', () => {
-    type ResultSourceSpaces = keyof Awaited<ReturnType<
-      typeof CogniteClient.prototype.instances.query<typeof testQuery>
-    >>['items']['resultExpressionA'][number]['properties'];
+    type ResultSourceSpaces = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties'];
 
     type QueryResultSpaces =
       (typeof testQuery.select.resultExpressionA.sources)[number]['source']['space'];
@@ -33,9 +44,11 @@ describe('queryNodesEdges type tests', () => {
   });
 
   test('property keys of result should match property keys of sources', () => {
-    type ResultPropertiesA = keyof Awaited<ReturnType<
-      typeof CogniteClient.prototype.instances.query<typeof testQuery>
-    >>['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+    type ResultPropertiesA = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
     type QueryPropertiesA =
       (typeof testQuery.select.resultExpressionA.sources)[0]['properties'][number];
 
@@ -43,9 +56,11 @@ describe('queryNodesEdges type tests', () => {
     // @ts-ignore
     type _0 = Assert0;
 
-    type ResultPropertiesB = keyof Awaited<ReturnType<
-      typeof CogniteClient.prototype.instances.query<typeof testQuery>
-    >>['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdB/v1'];
+    type ResultPropertiesB = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdB/v1'];
     type QueryPropertiesB =
       (typeof testQuery.select.resultExpressionA.sources)[1]['properties'][number];
 
@@ -53,9 +68,11 @@ describe('queryNodesEdges type tests', () => {
     // @ts-ignore
     type _1 = Assert1;
 
-    type ResultPropertiesC = keyof Awaited<ReturnType<
-      typeof CogniteClient.prototype.instances.query<typeof testQuery>
-    >>['items']['resultExpressionA'][number]['properties']['spaceB']['externalIdC/v1'];
+    type ResultPropertiesC = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceB']['externalIdC/v1'];
     type QueryPropertiesC =
       (typeof testQuery.select.resultExpressionA.sources)[2]['properties'][number];
 
@@ -78,20 +95,32 @@ describe('queryNodesEdges type tests', () => {
           aPropTwo: number;
           aPropThree: { externalId: string; space: string };
         };
-      }
+      },
     ];
 
-    type TypedResultProperties = Awaited<ReturnType<
-      typeof CogniteClient.prototype.instances.query<typeof testQuery, SourceExternalIdAPropertyTypes>
-    >>['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+    type TypedResultProperties = Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<
+          typeof testQuery,
+          SourceExternalIdAPropertyTypes
+        >
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
 
-    type Assert = Expect<Equal<TypedResultProperties, SourceExternalIdAPropertyTypes[0]['properties']>>;
+    type Assert = Expect<
+      Equal<
+        TypedResultProperties,
+        SourceExternalIdAPropertyTypes[0]['properties']
+      >
+    >;
     // @ts-ignore
     type _ = Assert;
   });
 
   test('Passing a non-constant query should be valid', () => {
-    type QueryResult = Awaited<ReturnType<typeof CogniteClient.prototype.instances.query<QueryRequest>>>;
+    type QueryResult = Awaited<
+      ReturnType<typeof CogniteClient.prototype.instances.query<QueryRequest>>
+    >;
 
     type TestType = QueryResult extends {
       items: Record<string, unknown>;
@@ -106,9 +135,11 @@ describe('queryNodesEdges type tests', () => {
   });
 
   test('passing * as property should type properties as Record', () => {
-    type ResultSourceSpaces = Awaited<ReturnType<
-      typeof CogniteClient.prototype.instances.query<typeof testQuery>
-    >>['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
+    type ResultSourceSpaces = Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
 
     // @ts-expect-error - property key should not be the string '*'
     type _ = Expect<Equal<ResultSourceSpaces, '*'>>;
@@ -122,14 +153,14 @@ describe('queryNodesEdges type tests', () => {
 const testQuery = {
   with: {
     resultExpressionA: {
-      nodes: {}
+      nodes: {},
     },
     resultExpressionB: {
-      nodes: {}
+      nodes: {},
     },
     resultExpressionC: {
-      edges: {}
-    }
+      edges: {},
+    },
   },
   select: {
     resultExpressionA: {
@@ -139,29 +170,29 @@ const testQuery = {
             type: 'view',
             space: 'spaceA',
             externalId: 'externalIdA',
-            version: 'v1'
+            version: 'v1',
           },
-          properties: ['aPropOne', 'aPropTwo', 'aPropThree']
+          properties: ['aPropOne', 'aPropTwo', 'aPropThree'],
         },
         {
           source: {
             type: 'view',
             space: 'spaceA',
             externalId: 'externalIdB',
-            version: 'v1'
+            version: 'v1',
           },
-          properties: ['bPropOne', 'bPropTwo']
+          properties: ['bPropOne', 'bPropTwo'],
         },
         {
           source: {
             type: 'view',
             space: 'spaceB',
             externalId: 'externalIdC',
-            version: 'v1'
+            version: 'v1',
           },
-          properties: ['cPropOne']
-        }
-      ]
+          properties: ['cPropOne'],
+        },
+      ],
     },
     resultExpressionB: {
       sources: [
@@ -170,11 +201,11 @@ const testQuery = {
             type: 'view',
             space: 'spaceD',
             externalId: 'externalIdD',
-            version: 'v1'
+            version: 'v1',
           },
-          properties: ['*']
-        }
-      ]
+          properties: ['*'],
+        },
+      ],
     },
     resultExpressionC: {
       sources: [
@@ -183,11 +214,11 @@ const testQuery = {
             type: 'view',
             space: 'spaceE',
             externalId: 'externalIdE',
-            version: 'v1'
+            version: 'v1',
           },
-          properties: ['ePropOne', 'ePropTwo']
-        }
-      ]
-    }
-  }
+          properties: ['ePropOne', 'ePropTwo'],
+        },
+      ],
+    },
+  },
 } as const satisfies QueryRequest;

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -2,6 +2,7 @@
  * Copyright 2024 Cognite AS
  */
 
+import { describe, test } from 'vitest';
 import { QueryRequest } from 'stable/src/types';
 import CogniteClient from '../../../cogniteClient';
 
@@ -93,8 +94,8 @@ describe('queryNodesEdges type tests', () => {
     type QueryResult = Awaited<ReturnType<typeof CogniteClient.prototype.instances.query<QueryRequest>>>;
 
     type TestType = QueryResult extends {
-      items: Record<string, any>;
-      nextCursors?: Record<string, any>;
+      items: Record<string, unknown>;
+      nextCursors?: Record<string, unknown>;
     }
       ? true
       : false;

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -19,6 +19,7 @@ import type {
   SlimNodeAndEdgeCollectionResponse,
   SyncRequest,
 } from './types.gen';
+import { QueryResult, SelectSourceWithParams } from './query.types';
 
 export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
   /**
@@ -237,8 +238,15 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    *   });
    * ```
    */
-  public query = async (params: QueryRequest): Promise<QueryResponse> => {
-    const response = await this.post<QueryResponse>(this.url('query'), {
+  public query = async <
+    TQueryRequest extends QueryRequest,
+    TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams
+  >(
+    params: TQueryRequest
+  ): Promise<QueryResult<TQueryRequest, TypedSelectSources>> => {
+    const response = await this.post<
+      QueryResult<TQueryRequest, TypedSelectSources>
+    >(this.url('query'), {
       data: params,
     });
     return response.data;

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Cognite AS
 
 import { BaseResourceAPI } from '@cognite/sdk-core';
+import type { QueryResult, SelectSourceWithParams } from './query.types';
 import type {
   AggregationRequest,
   AggregationResponse,
@@ -19,7 +20,6 @@ import type {
   SlimNodeAndEdgeCollectionResponse,
   SyncRequest,
 } from './types.gen';
-import { QueryResult, SelectSourceWithParams } from './query.types';
 
 export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
   /**
@@ -240,7 +240,7 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    */
   public query = async <
     TQueryRequest extends QueryRequest,
-    TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams
+    TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams,
   >(
     params: TQueryRequest
   ): Promise<QueryResult<TQueryRequest, TypedSelectSources>> => {

--- a/packages/stable/src/api/instances/query.types.ts
+++ b/packages/stable/src/api/instances/query.types.ts
@@ -1,0 +1,82 @@
+import {
+  EdgeDefinition,
+  NodeDefinition,
+  NodeOrEdge,
+  QueryRequest,
+} from './types.gen';
+
+type SELECT = 'select';
+type WITH = 'with';
+type LIMIT = 'limit';
+type NODES = 'nodes';
+type EDGES = 'edges';
+type PROPERTIES = 'properties';
+type SOURCES = 'sources';
+type SOURCE = 'source';
+type SPACE = 'space';
+type EXTERNALID = 'externalId';
+type VERSION = 'version';
+type ALLPROPERTIES = '*';
+
+type InstanceType<
+  TQueryRequest extends QueryRequest,
+  SelectKey extends keyof TQueryRequest[SELECT]
+> = Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends NODES
+  ? Omit<NodeDefinition, PROPERTIES>
+  : Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends EDGES
+  ? Omit<EdgeDefinition, PROPERTIES>
+  : Omit<NodeOrEdge, PROPERTIES>;
+
+type TypedSourceProperty<
+  SelectSource extends NonNullable<
+    QueryRequest[SELECT][keyof QueryRequest[SELECT]][SOURCES]
+  >[number],
+  TypedSelectSourcePropertyMap extends SelectSourceWithParams = SelectSourceWithParams
+> = Extract<
+  TypedSelectSourcePropertyMap[number],
+  Pick<SelectSource, SOURCE>
+>[PROPERTIES];
+
+export type SelectSourceWithParams = Array<{
+  source: {
+    type: string;
+    space: string;
+    externalId: string;
+    version: string;
+  };
+  properties: Record<string, unknown>;
+}>;
+
+export type QueryResult<
+  TQueryRequest extends QueryRequest,
+  TSelectSourceWithParams extends SelectSourceWithParams = SelectSourceWithParams
+> = {
+  items: {
+    [SELECT_KEY in keyof TQueryRequest[SELECT]]: Array<
+      InstanceType<TQueryRequest, SELECT_KEY> & {
+        properties: {
+          [SELECT_SOURCE in NonNullable<
+            TQueryRequest[SELECT][SELECT_KEY][SOURCES]
+          >[number] as SELECT_SOURCE[SOURCE][SPACE]]: {
+            [SELECT_SOURCE_VAR in SELECT_SOURCE as `${SELECT_SOURCE_VAR[SOURCE][EXTERNALID]}/${SELECT_SOURCE_VAR[SOURCE][VERSION]}`]: SELECT_SOURCE_VAR[PROPERTIES][0] extends ALLPROPERTIES
+              ? Record<string, unknown>
+              : {
+                  [SELECT_SOURCE_PROPERTY in SELECT_SOURCE_VAR[PROPERTIES][number]]: TypedSourceProperty<
+                    SELECT_SOURCE_VAR,
+                    TSelectSourceWithParams
+                  >[SELECT_SOURCE_PROPERTY] extends never
+                    ? unknown
+                    : TypedSourceProperty<
+                        SELECT_SOURCE_VAR,
+                        TSelectSourceWithParams
+                      >[SELECT_SOURCE_PROPERTY];
+                };
+          };
+        };
+      }
+    >;
+  };
+  nextCursor?: Partial<{
+    [SELECT_SOURCE_KEY in keyof TQueryRequest[SELECT]]: string;
+  }>;
+};

--- a/packages/stable/src/api/instances/query.types.ts
+++ b/packages/stable/src/api/instances/query.types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   EdgeDefinition,
   NodeDefinition,
   NodeOrEdge,
@@ -20,18 +20,19 @@ type ALLPROPERTIES = '*';
 
 type InstanceType<
   TQueryRequest extends QueryRequest,
-  SelectKey extends keyof TQueryRequest[SELECT]
+  SelectKey extends keyof TQueryRequest[SELECT],
 > = Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends NODES
   ? Omit<NodeDefinition, PROPERTIES>
   : Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends EDGES
-  ? Omit<EdgeDefinition, PROPERTIES>
-  : Omit<NodeOrEdge, PROPERTIES>;
+    ? Omit<EdgeDefinition, PROPERTIES>
+    : Omit<NodeOrEdge, PROPERTIES>;
 
 type TypedSourceProperty<
   SelectSource extends NonNullable<
     QueryRequest[SELECT][keyof QueryRequest[SELECT]][SOURCES]
   >[number],
-  TypedSelectSourcePropertyMap extends SelectSourceWithParams = SelectSourceWithParams
+  TypedSelectSourcePropertyMap extends
+    SelectSourceWithParams = SelectSourceWithParams,
 > = Extract<
   TypedSelectSourcePropertyMap[number],
   Pick<SelectSource, SOURCE>
@@ -49,7 +50,8 @@ export type SelectSourceWithParams = Array<{
 
 export type QueryResult<
   TQueryRequest extends QueryRequest,
-  TSelectSourceWithParams extends SelectSourceWithParams = SelectSourceWithParams
+  TSelectSourceWithParams extends
+    SelectSourceWithParams = SelectSourceWithParams,
 > = {
   items: {
     [SELECT_KEY in keyof TQueryRequest[SELECT]]: Array<

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -2929,6 +2929,11 @@ export type {
 } from './api/instances/types.gen';
 
 export type {
+  QueryResult,
+  SelectSourceWithParams,
+} from './api/instances/query.types';
+
+export type {
   AllVersionsQueryParameter,
   ByExternalIdsDataModelsRequest,
   ConnectionDefinition,


### PR DESCRIPTION
## Summary

Revival of #1111 — applies the same changes on top of the current `master` branch.

- Adds `query.types.ts` with `QueryResult` and `SelectSourceWithParams` generic types
- Updates `instances.query()` to accept a const `QueryRequest` and infer typed results per select key, space, and property
- Exports `QueryResult` and `SelectSourceWithParams` from the stable package's public `types.ts`
- Adds type-level tests in `packages/stable/src/__tests__/types/instances/query.spec.ts`

## Original PR

https://github.com/cognitedata/cognite-sdk-js/pull/1111

Made with [Cursor](https://cursor.com)