### PR TITLE
feat: add queryTyped method with inferred return types (non-breaking)

### DIFF
--- a/packages/stable/src/__tests__/api/datasets.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datasets.int.spec.ts
@@ -204,15 +204,19 @@ describe('data sets integration test', () => {
 
       expect(timeseries.dataSetId).toEqual(dataSetId);
     });
-    test('list', async () => {
-      await runTestWithRetryWhenFailing(async () => {
-        const filteredTimeseries = await client.timeseries
-          .list(dataSetFilter(dataSetId))
-          .autoPagingToArray();
+    test(
+      'list',
+      async () => {
+        await runTestWithRetryWhenFailing(async () => {
+          const filteredTimeseries = await client.timeseries
+            .list(dataSetFilter(dataSetId))
+            .autoPagingToArray();
 
-        expect(filteredTimeseries.length).toBeTruthy();
-      });
-    });
+          expect(filteredTimeseries.length).toBeTruthy();
+        });
+      },
+      3 * 60 * 1000
+    );
     test('update', async () => {
       const [updatedTimeseries] = await client.timeseries.update([
         { id: timeseries.id, ...updateDataSetObject },
@@ -239,16 +243,20 @@ describe('data sets integration test', () => {
 
       expect(sequence.dataSetId).toEqual(dataSetId);
     });
-    test('list', async () => {
-      await runTestWithRetryWhenFailing(async () => {
-        const sequences = await client.sequences
-          .list(dataSetFilter(dataSetId))
-          .autoPagingToArray();
+    test(
+      'list',
+      async () => {
+        await runTestWithRetryWhenFailing(async () => {
+          const sequences = await client.sequences
+            .list(dataSetFilter(dataSetId))
+            .autoPagingToArray();
 
-        expect(sequences.length).toBeTruthy();
-        expect(sequences[0].dataSetId).toEqual(dataSetId);
-      });
-    });
+          expect(sequences.length).toBeTruthy();
+          expect(sequences[0].dataSetId).toEqual(dataSetId);
+        });
+      },
+      3 * 60 * 1000
+    );
     test('update', async () => {
       const [updatedSequence] = await client.sequences.update([
         { id: sequence.id, ...updateDataSetObject },

--- a/packages/stable/src/__tests__/api/files.int.spec.ts
+++ b/packages/stable/src/__tests__/api/files.int.spec.ts
@@ -27,9 +27,9 @@ describe('Files integration test', () => {
   let label: LabelDefinition;
 
   const testSpace = {
-    space: 'test_data_space',
-    name: 'test_data_space',
-    description: 'Instance space used for integration tests.',
+    space: `test_file_space_${randomInt()}`,
+    name: 'test_file_space',
+    description: 'Instance space used for file integration tests.',
   };
 
   const fileCdmInstance: NodeWrite = {
@@ -84,6 +84,7 @@ describe('Files integration test', () => {
         space: fileCdmInstance.space,
       },
     ]);
+    await client.spaces.delete([testSpace.space]);
   });
 
   const geoLocation: FileGeoLocation = {

--- a/packages/stable/src/__tests__/api/files.int.spec.ts
+++ b/packages/stable/src/__tests__/api/files.int.spec.ts
@@ -134,39 +134,51 @@ describe('Files integration test', () => {
     expect(retrievedFile.directory).toEqual('/test/testing');
   });
 
-  test('retrieve by instance id', async () => {
-    // Syncing from instance to files API is eventually consistant
-    await runTestWithRetryWhenFailing(async () => {
-      const [retrievedFile] = await client.files.retrieve([
-        { instanceId: fileCdmInstanceId },
-      ]);
-      expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
-    });
-  });
+  test(
+    'retrieve by instance id',
+    async () => {
+      // Syncing from instance to files API is eventually consistant
+      await runTestWithRetryWhenFailing(async () => {
+        const [retrievedFile] = await client.files.retrieve([
+          { instanceId: fileCdmInstanceId },
+        ]);
+        expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
+      });
+    },
+    3 * 60 * 1000
+  );
 
-  test('update by instance id', async () => {
-    // Syncing from instance to files API is eventually consistant
-    await runTestWithRetryWhenFailing(async () => {
-      const testMetadata = { testKey: 'testVal' };
-      const [retrievedFile] = await client.files.update([
-        {
-          instanceId: fileCdmInstanceId,
-          update: { metadata: { set: testMetadata } },
-        },
-      ]);
-      expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
-      expect(retrievedFile.metadata).toEqual(testMetadata);
-    });
-  });
+  test(
+    'update by instance id',
+    async () => {
+      // Syncing from instance to files API is eventually consistant
+      await runTestWithRetryWhenFailing(async () => {
+        const testMetadata = { testKey: 'testVal' };
+        const [retrievedFile] = await client.files.update([
+          {
+            instanceId: fileCdmInstanceId,
+            update: { metadata: { set: testMetadata } },
+          },
+        ]);
+        expect(retrievedFile.instanceId).toEqual(fileCdmInstanceId);
+        expect(retrievedFile.metadata).toEqual(testMetadata);
+      });
+    },
+    3 * 60 * 1000
+  );
 
-  test('download by instance id', async () => {
-    // Syncing from instance to files API is eventually consistant
-    await runTestWithRetryWhenFailing(async () => {
-      expect(
-        client.files.getDownloadUrls([{ instanceId: fileCdmInstanceId }])
-      ).rejects.toThrow(/Files not uploaded/);
-    });
-  });
+  test(
+    'download by instance id',
+    async () => {
+      // Syncing from instance to files API is eventually consistant
+      await runTestWithRetryWhenFailing(async () => {
+        expect(
+          client.files.getDownloadUrls([{ instanceId: fileCdmInstanceId }])
+        ).rejects.toThrow(/Files not uploaded/);
+      });
+    },
+    3 * 60 * 1000
+  );
 
   test.skip('retrieve with non-existent id', async () => {
     const res = await client.files.retrieve([{ id: 1 }], {

--- a/packages/stable/src/__tests__/api/instances.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/instances.unit.spec.ts
@@ -1,0 +1,78 @@
+// Copyright 2024 Cognite AS
+
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import type CogniteClient from '../../cogniteClient';
+import { mockBaseUrl, setupMockableClient } from '../testUtils';
+
+const QUERY_PARAMS = {
+  with: { myNodes: { nodes: {} } },
+  select: {
+    myNodes: {
+      sources: [
+        {
+          source: {
+            type: 'view' as const,
+            space: 's',
+            externalId: 'V',
+            version: 'v1',
+          },
+          properties: ['name'],
+        },
+      ],
+    },
+  },
+};
+
+const QUERY_RESPONSE = {
+  items: {
+    myNodes: [
+      {
+        instanceType: 'node' as const,
+        space: 's',
+        externalId: 'n1',
+        version: 1,
+        lastUpdatedTime: 0,
+        createdTime: 0,
+        properties: { s: { 'V/v1': { name: 'hello' } } },
+      },
+    ],
+  },
+  nextCursor: undefined,
+};
+
+describe('InstancesAPI unit test', () => {
+  let client: CogniteClient;
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test('queryTyped posts to the instances/query endpoint and returns response data', async () => {
+    nock(mockBaseUrl)
+      .post(/\/models\/instances\/query/, QUERY_PARAMS)
+      .once()
+      .reply(200, QUERY_RESPONSE);
+
+    const result = await client.instances.queryTyped(QUERY_PARAMS);
+
+    expect(result).toEqual(QUERY_RESPONSE);
+  });
+
+  test('queryTyped passes through arbitrary query params unchanged', async () => {
+    const customQuery = {
+      with: { edges: { edges: {} } },
+      select: { edges: {} },
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/models\/instances\/query/, customQuery)
+      .once()
+      .reply(200, { items: { edges: [] } });
+
+    const result = await client.instances.queryTyped(customQuery);
+
+    expect(result).toEqual({ items: { edges: [] } });
+  });
+});

--- a/packages/stable/src/__tests__/api/timeseries.int.spec.ts
+++ b/packages/stable/src/__tests__/api/timeseries.int.spec.ts
@@ -289,23 +289,35 @@ describe('Timeseries integration test', () => {
     expect(items.length).toBeGreaterThan(0);
   });
 
-  test('list with assetExternalIds', async () => {
-    const { items } = await client.timeseries.list({
-      filter: { assetExternalIds: [asset.externalId || ''] },
-      limit: 1,
-    });
-    expect(items.length).toBe(1);
-    expect(items[0].id).toBe(createdTimeseries[0].id);
-  });
+  test(
+    'list with assetExternalIds',
+    async () => {
+      await runTestWithRetryWhenFailing(async () => {
+        const { items } = await client.timeseries.list({
+          filter: { assetExternalIds: [asset.externalId || ''] },
+          limit: 1,
+        });
+        expect(items.length).toBe(1);
+        expect(items[0].id).toBe(createdTimeseries[0].id);
+      });
+    },
+    3 * 60 * 1000
+  );
 
-  test('list with assetSubtreeIds', async () => {
-    const { items } = await client.timeseries.list({
-      filter: { assetSubtreeIds: [{ id: asset.id }] },
-      limit: 1,
-    });
-    expect(items.length).toBe(1);
-    expect(items[0].id).toBe(createdTimeseries[0].id);
-  });
+  test(
+    'list with assetSubtreeIds',
+    async () => {
+      await runTestWithRetryWhenFailing(async () => {
+        const { items } = await client.timeseries.list({
+          filter: { assetSubtreeIds: [{ id: asset.id }] },
+          limit: 1,
+        });
+        expect(items.length).toBe(1);
+        expect(items[0].id).toBe(createdTimeseries[0].id);
+      });
+    },
+    3 * 60 * 1000
+  );
 
   test('search', async () => {
     const name = 'timeserie6';

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -1,0 +1,236 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import type { QueryRequest, QueryResponse } from 'stable/src/types';
+import { describe, test } from 'vitest';
+import type CogniteClient from '../../../cogniteClient';
+
+type Expect<T extends true> = T;
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+  ? 1
+  : 2
+  ? true
+  : false;
+
+describe('queryNodesEdges type tests', () => {
+  test('query still returns the original QueryResponse (non-breaking)', () => {
+    type Result = Awaited<
+      ReturnType<typeof CogniteClient.prototype.instances.query>
+    >;
+    type Assert = Expect<Equal<Result, QueryResponse>>;
+
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('queryTyped result keys should match const query select keys', () => {
+    type QueryResultSelectKeys = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<typeof testQuery>
+      >
+    >['items'];
+    type Assert = Expect<
+      Equal<QueryResultSelectKeys, keyof typeof testQuery.select>
+    >;
+
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('Each source with unique space should map to a key in properties of result', () => {
+    type ResultSourceSpaces = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties'];
+
+    type QueryResultSpaces =
+      (typeof testQuery.select.resultExpressionA.sources)[number]['source']['space'];
+    type Assert = Expect<Equal<ResultSourceSpaces, QueryResultSpaces>>;
+
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('property keys of result should match property keys of sources', () => {
+    type ResultPropertiesA = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+    type QueryPropertiesA =
+      (typeof testQuery.select.resultExpressionA.sources)[0]['properties'][number];
+
+    type Assert0 = Expect<Equal<ResultPropertiesA, QueryPropertiesA>>;
+    // @ts-ignore
+    type _0 = Assert0;
+
+    type ResultPropertiesB = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdB/v1'];
+    type QueryPropertiesB =
+      (typeof testQuery.select.resultExpressionA.sources)[1]['properties'][number];
+
+    type Assert1 = Expect<Equal<ResultPropertiesB, QueryPropertiesB>>;
+    // @ts-ignore
+    type _1 = Assert1;
+
+    type ResultPropertiesC = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceB']['externalIdC/v1'];
+    type QueryPropertiesC =
+      (typeof testQuery.select.resultExpressionA.sources)[2]['properties'][number];
+
+    type Assert2 = Expect<Equal<ResultPropertiesC, QueryPropertiesC>>;
+    // @ts-ignore
+    type _2 = Assert2;
+  });
+
+  test('passing a typed Source generic should return a typed results for parameters', () => {
+    type SourceExternalIdAPropertyTypes = [
+      {
+        source: {
+          type: 'view';
+          space: 'spaceA';
+          externalId: 'externalIdA';
+          version: 'v1';
+        };
+        properties: {
+          aPropOne: string;
+          aPropTwo: number;
+          aPropThree: { externalId: string; space: string };
+        };
+      },
+    ];
+
+    type TypedResultProperties = Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<
+          typeof testQuery,
+          SourceExternalIdAPropertyTypes
+        >
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+
+    type Assert = Expect<
+      Equal<
+        TypedResultProperties,
+        SourceExternalIdAPropertyTypes[0]['properties']
+      >
+    >;
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('Passing a non-constant query to queryTyped should be valid', () => {
+    type QueryResult = Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<QueryRequest>
+      >
+    >;
+
+    type TestType = QueryResult extends {
+      items: Record<string, unknown>;
+      nextCursors?: Record<string, unknown>;
+    }
+      ? true
+      : false;
+
+    type Assert = Expect<Equal<TestType, true>>;
+    // @ts-ignore
+    type _ = Assert;
+  });
+
+  test('passing * as property should type properties as Record', () => {
+    type ResultSourceSpaces = Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.queryTyped<typeof testQuery>
+      >
+    >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
+
+    // @ts-expect-error - property key should not be the string '*'
+    type _ = Expect<Equal<ResultSourceSpaces, '*'>>;
+
+    type Assert = Expect<Equal<ResultSourceSpaces, Record<string, unknown>>>;
+    // @ts-ignore
+    type _1 = Assert;
+  });
+});
+
+const testQuery = {
+  with: {
+    resultExpressionA: {
+      nodes: {},
+    },
+    resultExpressionB: {
+      nodes: {},
+    },
+    resultExpressionC: {
+      edges: {},
+    },
+  },
+  select: {
+    resultExpressionA: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdA',
+            version: 'v1',
+          },
+          properties: ['aPropOne', 'aPropTwo', 'aPropThree'],
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdB',
+            version: 'v1',
+          },
+          properties: ['bPropOne', 'bPropTwo'],
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceB',
+            externalId: 'externalIdC',
+            version: 'v1',
+          },
+          properties: ['cPropOne'],
+        },
+      ],
+    },
+    resultExpressionB: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceD',
+            externalId: 'externalIdD',
+            version: 'v1',
+          },
+          properties: ['*'],
+        },
+      ],
+    },
+    resultExpressionC: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceE',
+            externalId: 'externalIdE',
+            version: 'v1',
+          },
+          properties: ['ePropOne', 'ePropTwo'],
+        },
+      ],
+    },
+  },
+} as const satisfies QueryRequest;

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -18,10 +18,7 @@ describe('queryNodesEdges type tests', () => {
     type Result = Awaited<
       ReturnType<typeof CogniteClient.prototype.instances.query>
     >;
-    type Assert = Expect<Equal<Result, QueryResponse>>;
-
-    // @ts-ignore
-    type _ = Assert;
+    true satisfies Expect<Equal<Result, QueryResponse>>;
   });
 
   test('queryTyped result keys should match const query select keys', () => {
@@ -30,12 +27,9 @@ describe('queryNodesEdges type tests', () => {
         typeof CogniteClient.prototype.instances.queryTyped<typeof testQuery>
       >
     >['items'];
-    type Assert = Expect<
+    true satisfies Expect<
       Equal<QueryResultSelectKeys, keyof typeof testQuery.select>
     >;
-
-    // @ts-ignore
-    type _ = Assert;
   });
 
   test('Each source with unique space should map to a key in properties of result', () => {
@@ -47,10 +41,7 @@ describe('queryNodesEdges type tests', () => {
 
     type QueryResultSpaces =
       (typeof testQuery.select.resultExpressionA.sources)[number]['source']['space'];
-    type Assert = Expect<Equal<ResultSourceSpaces, QueryResultSpaces>>;
-
-    // @ts-ignore
-    type _ = Assert;
+    true satisfies Expect<Equal<ResultSourceSpaces, QueryResultSpaces>>;
   });
 
   test('property keys of result should match property keys of sources', () => {
@@ -61,10 +52,7 @@ describe('queryNodesEdges type tests', () => {
     >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
     type QueryPropertiesA =
       (typeof testQuery.select.resultExpressionA.sources)[0]['properties'][number];
-
-    type Assert0 = Expect<Equal<ResultPropertiesA, QueryPropertiesA>>;
-    // @ts-ignore
-    type _0 = Assert0;
+    true satisfies Expect<Equal<ResultPropertiesA, QueryPropertiesA>>;
 
     type ResultPropertiesB = keyof Awaited<
       ReturnType<
@@ -73,10 +61,7 @@ describe('queryNodesEdges type tests', () => {
     >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdB/v1'];
     type QueryPropertiesB =
       (typeof testQuery.select.resultExpressionA.sources)[1]['properties'][number];
-
-    type Assert1 = Expect<Equal<ResultPropertiesB, QueryPropertiesB>>;
-    // @ts-ignore
-    type _1 = Assert1;
+    true satisfies Expect<Equal<ResultPropertiesB, QueryPropertiesB>>;
 
     type ResultPropertiesC = keyof Awaited<
       ReturnType<
@@ -85,10 +70,7 @@ describe('queryNodesEdges type tests', () => {
     >['items']['resultExpressionA'][number]['properties']['spaceB']['externalIdC/v1'];
     type QueryPropertiesC =
       (typeof testQuery.select.resultExpressionA.sources)[2]['properties'][number];
-
-    type Assert2 = Expect<Equal<ResultPropertiesC, QueryPropertiesC>>;
-    // @ts-ignore
-    type _2 = Assert2;
+    true satisfies Expect<Equal<ResultPropertiesC, QueryPropertiesC>>;
   });
 
   test('passing a typed Source generic should return a typed results for parameters', () => {
@@ -117,14 +99,9 @@ describe('queryNodesEdges type tests', () => {
       >
     >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
 
-    type Assert = Expect<
-      Equal<
-        TypedResultProperties,
-        SourceExternalIdAPropertyTypes[0]['properties']
-      >
+    true satisfies Expect<
+      Equal<TypedResultProperties, SourceExternalIdAPropertyTypes[0]['properties']>
     >;
-    // @ts-ignore
-    type _ = Assert;
   });
 
   test('Passing a non-constant query to queryTyped should be valid', () => {
@@ -141,9 +118,7 @@ describe('queryNodesEdges type tests', () => {
       ? true
       : false;
 
-    type Assert = Expect<Equal<TestType, true>>;
-    // @ts-ignore
-    type _ = Assert;
+    true satisfies Expect<Equal<TestType, true>>;
   });
 
   test('passing * as property should type properties as Record', () => {
@@ -154,11 +129,9 @@ describe('queryNodesEdges type tests', () => {
     >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
 
     // @ts-expect-error - property key should not be the string '*'
-    type _ = Expect<Equal<ResultSourceSpaces, '*'>>;
+    true satisfies Expect<Equal<ResultSourceSpaces, '*'>>;
 
-    type Assert = Expect<Equal<ResultSourceSpaces, Record<string, unknown>>>;
-    // @ts-ignore
-    type _1 = Assert;
+    true satisfies Expect<Equal<ResultSourceSpaces, Record<string, unknown>>>;
   });
 });
 

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -100,7 +100,10 @@ describe('queryNodesEdges type tests', () => {
     >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
 
     true satisfies Expect<
-      Equal<TypedResultProperties, SourceExternalIdAPropertyTypes[0]['properties']>
+      Equal<
+        TypedResultProperties,
+        SourceExternalIdAPropertyTypes[0]['properties']
+      >
     >;
   });
 

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -249,17 +249,21 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Declare params as const satisfies QueryRequest for fully typed results per select key, space and property name.
    *
    * ```js
-   *  const query = {
-   *    with: { myNodes: { nodes: {} } },
+   *  const typedResponse = await client.instances.queryTyped({
+   *    with: {
+   *      result_set_1: {
+   *        nodes: {},
+   *      },
+   *    },
    *    select: {
-   *      myNodes: {
+   *      result_set_1: {
    *        sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }],
    *      },
    *    },
-   *  } as const satisfies QueryRequest;
-   *
-   *  const result = await client.instances.queryTyped(query);
-   *  // result.items.myNodes[0].properties.mySpace['MyView/v1'].name  — fully typed
+   *  });
+   *  // For fully typed results, declare the query variable as:
+   *  // const query = { ... } as const satisfies QueryRequest;
+   *  // then: typedResponse.items.result_set_1[0].properties.mySpace['MyView/v1'].name
    * ```
    */
   public queryTyped = async <

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -246,24 +246,20 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
   };
 
   /**
-   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types.
-   *
-   * When `params` is declared `as const satisfies QueryRequest`, TypeScript infers the exact
-   * select keys, spaces and property names from the query, giving you fully typed results.
-   * Optionally pass `TypedSelectSources` to override property value types per source.
+   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Pass `params as const satisfies QueryRequest` to get fully typed results per select key, space and property name.
    *
    * ```js
    *  const query = {
    *    with: { myNodes: { nodes: {} } },
    *    select: {
    *      myNodes: {
-   *        sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }]
-   *      }
-   *    }
+   *        sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }],
+   *      },
+   *    },
    *  } as const satisfies QueryRequest;
    *
    *  const result = await client.instances.queryTyped(query);
-   *  // result.items.myNodes[0].properties.mySpace['MyView/v1'].name  ← fully typed
+   *  // result.items.myNodes[0].properties.mySpace['MyView/v1'].name  — fully typed
    * ```
    */
   public queryTyped = async <

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Cognite AS
 
 import { BaseResourceAPI } from '@cognite/sdk-core';
+import type { QueryResult, SelectSourceWithParams } from './query.types';
 import type {
   AggregationRequest,
   AggregationResponse,
@@ -241,6 +242,39 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
     const response = await this.post<QueryResponse>(this.url('query'), {
       data: params,
     });
+    return response.data;
+  };
+
+  /**
+   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types.
+   *
+   * When `params` is declared `as const satisfies QueryRequest`, TypeScript infers the exact
+   * select keys, spaces and property names from the query, giving you fully typed results.
+   * Optionally pass `TypedSelectSources` to override property value types per source.
+   *
+   * ```js
+   *  const query = {
+   *    with: { myNodes: { nodes: {} } },
+   *    select: {
+   *      myNodes: {
+   *        sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }]
+   *      }
+   *    }
+   *  } as const satisfies QueryRequest;
+   *
+   *  const result = await client.instances.queryTyped(query);
+   *  // result.items.myNodes[0].properties.mySpace['MyView/v1'].name  ← fully typed
+   * ```
+   */
+  public queryTyped = async <
+    TQueryRequest extends QueryRequest,
+    TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams,
+  >(
+    params: TQueryRequest
+  ): Promise<QueryResult<TQueryRequest, TypedSelectSources>> => {
+    const response = await this.post<
+      QueryResult<TQueryRequest, TypedSelectSources>
+    >(this.url('query'), { data: params });
     return response.data;
   };
 

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -246,7 +246,7 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
   };
 
   /**
-   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Pass `params as const satisfies QueryRequest` to get fully typed results per select key, space and property name.
+   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Declare params as const satisfies QueryRequest for fully typed results per select key, space and property name.
    *
    * ```js
    *  const query = {

--- a/packages/stable/src/api/instances/query.types.ts
+++ b/packages/stable/src/api/instances/query.types.ts
@@ -1,0 +1,84 @@
+import type {
+  EdgeDefinition,
+  NodeDefinition,
+  NodeOrEdge,
+  QueryRequest,
+} from './types.gen';
+
+type SELECT = 'select';
+type WITH = 'with';
+type LIMIT = 'limit';
+type NODES = 'nodes';
+type EDGES = 'edges';
+type PROPERTIES = 'properties';
+type SOURCES = 'sources';
+type SOURCE = 'source';
+type SPACE = 'space';
+type EXTERNALID = 'externalId';
+type VERSION = 'version';
+type ALLPROPERTIES = '*';
+
+type InstanceType<
+  TQueryRequest extends QueryRequest,
+  SelectKey extends keyof TQueryRequest[SELECT],
+> = Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends NODES
+  ? Omit<NodeDefinition, PROPERTIES>
+  : Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends EDGES
+    ? Omit<EdgeDefinition, PROPERTIES>
+    : Omit<NodeOrEdge, PROPERTIES>;
+
+type TypedSourceProperty<
+  SelectSource extends NonNullable<
+    QueryRequest[SELECT][keyof QueryRequest[SELECT]][SOURCES]
+  >[number],
+  TypedSelectSourcePropertyMap extends
+    SelectSourceWithParams = SelectSourceWithParams,
+> = Extract<
+  TypedSelectSourcePropertyMap[number],
+  Pick<SelectSource, SOURCE>
+>[PROPERTIES];
+
+export type SelectSourceWithParams = Array<{
+  source: {
+    type: string;
+    space: string;
+    externalId: string;
+    version: string;
+  };
+  properties: Record<string, unknown>;
+}>;
+
+export type QueryResult<
+  TQueryRequest extends QueryRequest,
+  TSelectSourceWithParams extends
+    SelectSourceWithParams = SelectSourceWithParams,
+> = {
+  items: {
+    [SELECT_KEY in keyof TQueryRequest[SELECT]]: Array<
+      InstanceType<TQueryRequest, SELECT_KEY> & {
+        properties: {
+          [SELECT_SOURCE in NonNullable<
+            TQueryRequest[SELECT][SELECT_KEY][SOURCES]
+          >[number] as SELECT_SOURCE[SOURCE][SPACE]]: {
+            [SELECT_SOURCE_VAR in SELECT_SOURCE as `${SELECT_SOURCE_VAR[SOURCE][EXTERNALID]}/${SELECT_SOURCE_VAR[SOURCE][VERSION]}`]: SELECT_SOURCE_VAR[PROPERTIES][0] extends ALLPROPERTIES
+              ? Record<string, unknown>
+              : {
+                  [SELECT_SOURCE_PROPERTY in SELECT_SOURCE_VAR[PROPERTIES][number]]: TypedSourceProperty<
+                    SELECT_SOURCE_VAR,
+                    TSelectSourceWithParams
+                  >[SELECT_SOURCE_PROPERTY] extends never
+                    ? unknown
+                    : TypedSourceProperty<
+                        SELECT_SOURCE_VAR,
+                        TSelectSourceWithParams
+                      >[SELECT_SOURCE_PROPERTY];
+                };
+          };
+        };
+      }
+    >;
+  };
+  nextCursor?: Partial<{
+    [SELECT_SOURCE_KEY in keyof TQueryRequest[SELECT]]: string;
+  }>;
+};

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -2929,6 +2929,11 @@ export type {
 } from './api/instances/types.gen';
 
 export type {
+  QueryResult,
+  SelectSourceWithParams,
+} from './api/instances/query.types';
+
+export type {
   AllVersionsQueryParameter,
   ByExternalIdsDataModelsRequest,
   ConnectionDefinition,


### PR DESCRIPTION
## Strategy A — Keep `query` + add `queryTyped`

This is a **non-breaking** alternative to #1442.

### What changes

| | Before | After |
|---|---|---|
| `instances.query(params)` | `Promise<QueryResponse>` | **unchanged** |
| `instances.queryTyped(params)` | _doesn't exist_ | `Promise<QueryResult<TQueryRequest, TypedSelectSources>>` |

The original `query` method is left completely untouched. A new `queryTyped` method is added alongside it, providing full type inference when the caller passes `params as const satisfies QueryRequest`.

### Usage

```ts
const query = {
  with: { myNodes: { nodes: {} } },
  select: {
    myNodes: {
      sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }]
    }
  }
} as const satisfies QueryRequest;

// Fully typed — result.items.myNodes[0].properties.mySpace['MyView/v1'].name
const result = await client.instances.queryTyped(query);

// Old call still works exactly as before
const untyped = await client.instances.query(query);  // QueryResponse
```

### Trade-off

Pro: zero risk of breaking existing consumers.
Con: two methods doing the same thing at runtime; callers must opt-in by switching to `queryTyped`.

---
Alternative approach: #1443 (smart conditional default on `query` itself)

Made with [Cursor](https://cursor.com)