### PR TITLE
feat: instances.query infers typed results for const input, defaults to QueryResponse

### DIFF
--- a/packages/stable/src/__tests__/api/instances.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/instances.unit.spec.ts
@@ -1,0 +1,114 @@
+// Copyright 2024 Cognite AS
+
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import type CogniteClient from '../../cogniteClient';
+import type { QueryRequest } from '../../types';
+import { mockBaseUrl, setupMockableClient } from '../testUtils';
+
+const QUERY_PARAMS = {
+  with: { myNodes: { nodes: {} } },
+  select: {
+    myNodes: {
+      sources: [
+        {
+          source: {
+            type: 'view' as const,
+            space: 's',
+            externalId: 'V',
+            version: 'v1',
+          },
+          properties: ['name'],
+        },
+      ],
+    },
+  },
+};
+
+const QUERY_RESPONSE = {
+  items: {
+    myNodes: [
+      {
+        instanceType: 'node',
+        space: 's',
+        externalId: 'n1',
+        version: 1,
+        lastUpdatedTime: 0,
+        createdTime: 0,
+        properties: { s: { 'V/v1': { name: 'hello' } } },
+      },
+    ],
+  },
+};
+
+describe('InstancesAPI.query backward-compatibility unit tests', () => {
+  let client: CogniteClient;
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test('old-style call (no type param, plain QueryRequest) returns QueryResponse data', async () => {
+    nock(mockBaseUrl)
+      .post(/\/models\/instances\/query/)
+      .once()
+      .reply(200, QUERY_RESPONSE);
+
+    // This is the pre-existing API usage: no type parameters, plain QueryRequest.
+    // TypeScript should infer Promise<QueryResponse> (same as before the change).
+    const result = await client.instances.query(QUERY_PARAMS);
+
+    expect(result).toEqual(QUERY_RESPONSE);
+    expect(result.items.myNodes).toHaveLength(1);
+  });
+
+  test('typed call with const query hits the same endpoint and returns data', async () => {
+    const typedQuery = {
+      with: { myEdges: { edges: {} } },
+      select: {
+        myEdges: {
+          sources: [
+            {
+              source: {
+                type: 'view' as const,
+                space: 'sp',
+                externalId: 'E',
+                version: 'v1',
+              },
+              properties: ['label'],
+            },
+          ],
+        },
+      },
+    } as const satisfies QueryRequest;
+
+    const mockResponse = {
+      items: {
+        myEdges: [
+          {
+            instanceType: 'edge',
+            space: 'sp',
+            externalId: 'e1',
+            version: 1,
+            lastUpdatedTime: 0,
+            createdTime: 0,
+            properties: { sp: { 'E/v1': { label: 'an-edge' } } },
+          },
+        ],
+      },
+    };
+
+    nock(mockBaseUrl)
+      .post(/\/models\/instances\/query/)
+      .once()
+      .reply(200, mockResponse);
+
+    // With a const-narrowed query the return type is inferred, but the runtime
+    // behaviour is identical: same POST endpoint, same data is returned.
+    const result = await client.instances.query(typedQuery);
+
+    expect(result).toEqual(mockResponse);
+    expect(result.items.myEdges).toHaveLength(1);
+  });
+});

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -1,0 +1,206 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import type { QueryRequest, QueryResponse } from 'stable/src/types';
+import { describe, test } from 'vitest';
+import type CogniteClient from '../../../cogniteClient';
+
+type Expect<T extends true> = T;
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+  ? 1
+  : 2
+  ? true
+  : false;
+
+describe('queryNodesEdges type tests', () => {
+  test('calling query without type param returns QueryResponse (non-breaking default)', () => {
+    type Result = Awaited<
+      ReturnType<typeof CogniteClient.prototype.instances.query>
+    >;
+
+    true satisfies Expect<Equal<Result, QueryResponse>>;
+  });
+
+  test('calling query with plain QueryRequest also returns QueryResponse', () => {
+    type Result = Awaited<
+      ReturnType<typeof CogniteClient.prototype.instances.query<QueryRequest>>
+    >;
+
+    true satisfies Expect<Equal<Result, QueryResponse>>;
+  });
+
+  test('query result keys should match const query select keys', () => {
+    type QueryResultSelectKeys = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items'];
+
+    true satisfies Expect<
+      Equal<QueryResultSelectKeys, keyof typeof testQuery.select>
+    >;
+  });
+
+  test('Each source with unique space should map to a key in properties of result', () => {
+    type ResultSourceSpaces = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties'];
+
+    type QueryResultSpaces =
+      (typeof testQuery.select.resultExpressionA.sources)[number]['source']['space'];
+
+    true satisfies Expect<Equal<ResultSourceSpaces, QueryResultSpaces>>;
+  });
+
+  test('property keys of result should match property keys of sources', () => {
+    type ResultPropertiesA = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+    type QueryPropertiesA =
+      (typeof testQuery.select.resultExpressionA.sources)[0]['properties'][number];
+    true satisfies Expect<Equal<ResultPropertiesA, QueryPropertiesA>>;
+
+    type ResultPropertiesB = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdB/v1'];
+    type QueryPropertiesB =
+      (typeof testQuery.select.resultExpressionA.sources)[1]['properties'][number];
+    true satisfies Expect<Equal<ResultPropertiesB, QueryPropertiesB>>;
+
+    type ResultPropertiesC = keyof Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceB']['externalIdC/v1'];
+    type QueryPropertiesC =
+      (typeof testQuery.select.resultExpressionA.sources)[2]['properties'][number];
+    true satisfies Expect<Equal<ResultPropertiesC, QueryPropertiesC>>;
+  });
+
+  test('passing a typed Source generic should return typed property values', () => {
+    type SourceExternalIdAPropertyTypes = [
+      {
+        source: {
+          type: 'view';
+          space: 'spaceA';
+          externalId: 'externalIdA';
+          version: 'v1';
+        };
+        properties: {
+          aPropOne: string;
+          aPropTwo: number;
+          aPropThree: { externalId: string; space: string };
+        };
+      },
+    ];
+
+    type TypedResultProperties = Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<
+          typeof testQuery,
+          SourceExternalIdAPropertyTypes
+        >
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+
+    true satisfies Expect<
+      Equal<
+        TypedResultProperties,
+        SourceExternalIdAPropertyTypes[0]['properties']
+      >
+    >;
+  });
+
+  test('passing * as property should type properties as Record', () => {
+    type ResultSourceSpaces = Awaited<
+      ReturnType<
+        typeof CogniteClient.prototype.instances.query<typeof testQuery>
+      >
+    >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
+
+    // @ts-expect-error - property key should not be the string '*'
+    true satisfies Expect<Equal<ResultSourceSpaces, '*'>>;
+
+    true satisfies Expect<Equal<ResultSourceSpaces, Record<string, unknown>>>;
+  });
+});
+
+const testQuery = {
+  with: {
+    resultExpressionA: {
+      nodes: {},
+    },
+    resultExpressionB: {
+      nodes: {},
+    },
+    resultExpressionC: {
+      edges: {},
+    },
+  },
+  select: {
+    resultExpressionA: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdA',
+            version: 'v1',
+          },
+          properties: ['aPropOne', 'aPropTwo', 'aPropThree'],
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdB',
+            version: 'v1',
+          },
+          properties: ['bPropOne', 'bPropTwo'],
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceB',
+            externalId: 'externalIdC',
+            version: 'v1',
+          },
+          properties: ['cPropOne'],
+        },
+      ],
+    },
+    resultExpressionB: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceD',
+            externalId: 'externalIdD',
+            version: 'v1',
+          },
+          properties: ['*'],
+        },
+      ],
+    },
+    resultExpressionC: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceE',
+            externalId: 'externalIdE',
+            version: 'v1',
+          },
+          properties: ['ePropOne', 'ePropTwo'],
+        },
+      ],
+    },
+  },
+} as const satisfies QueryRequest;

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Cognite AS
 
 import { BaseResourceAPI } from '@cognite/sdk-core';
+import type { QueryResult, SelectSourceWithParams } from './query.types';
 import type {
   AggregationRequest,
   AggregationResponse,
@@ -237,8 +238,21 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    *   });
    * ```
    */
-  public query = async (params: QueryRequest): Promise<QueryResponse> => {
-    const response = await this.post<QueryResponse>(this.url('query'), {
+  public query = async <
+    TQueryRequest extends QueryRequest = QueryRequest,
+    TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams,
+  >(
+    params: TQueryRequest
+  ): Promise<
+    QueryRequest extends TQueryRequest
+      ? QueryResponse
+      : QueryResult<TQueryRequest, TypedSelectSources>
+  > => {
+    const response = await this.post<
+      QueryRequest extends TQueryRequest
+        ? QueryResponse
+        : QueryResult<TQueryRequest, TypedSelectSources>
+    >(this.url('query'), {
       data: params,
     });
     return response.data;

--- a/packages/stable/src/api/instances/query.types.ts
+++ b/packages/stable/src/api/instances/query.types.ts
@@ -1,0 +1,84 @@
+import type {
+  EdgeDefinition,
+  NodeDefinition,
+  NodeOrEdge,
+  QueryRequest,
+} from './types.gen';
+
+type SELECT = 'select';
+type WITH = 'with';
+type LIMIT = 'limit';
+type NODES = 'nodes';
+type EDGES = 'edges';
+type PROPERTIES = 'properties';
+type SOURCES = 'sources';
+type SOURCE = 'source';
+type SPACE = 'space';
+type EXTERNALID = 'externalId';
+type VERSION = 'version';
+type ALLPROPERTIES = '*';
+
+type InstanceType<
+  TQueryRequest extends QueryRequest,
+  SelectKey extends keyof TQueryRequest[SELECT],
+> = Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends NODES
+  ? Omit<NodeDefinition, PROPERTIES>
+  : Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends EDGES
+    ? Omit<EdgeDefinition, PROPERTIES>
+    : Omit<NodeOrEdge, PROPERTIES>;
+
+type TypedSourceProperty<
+  SelectSource extends NonNullable<
+    QueryRequest[SELECT][keyof QueryRequest[SELECT]][SOURCES]
+  >[number],
+  TypedSelectSourcePropertyMap extends
+    SelectSourceWithParams = SelectSourceWithParams,
+> = Extract<
+  TypedSelectSourcePropertyMap[number],
+  Pick<SelectSource, SOURCE>
+>[PROPERTIES];
+
+export type SelectSourceWithParams = Array<{
+  source: {
+    type: string;
+    space: string;
+    externalId: string;
+    version: string;
+  };
+  properties: Record<string, unknown>;
+}>;
+
+export type QueryResult<
+  TQueryRequest extends QueryRequest,
+  TSelectSourceWithParams extends
+    SelectSourceWithParams = SelectSourceWithParams,
+> = {
+  items: {
+    [SELECT_KEY in keyof TQueryRequest[SELECT]]: Array<
+      InstanceType<TQueryRequest, SELECT_KEY> & {
+        properties: {
+          [SELECT_SOURCE in NonNullable<
+            TQueryRequest[SELECT][SELECT_KEY][SOURCES]
+          >[number] as SELECT_SOURCE[SOURCE][SPACE]]: {
+            [SELECT_SOURCE_VAR in SELECT_SOURCE as `${SELECT_SOURCE_VAR[SOURCE][EXTERNALID]}/${SELECT_SOURCE_VAR[SOURCE][VERSION]}`]: SELECT_SOURCE_VAR[PROPERTIES][0] extends ALLPROPERTIES
+              ? Record<string, unknown>
+              : {
+                  [SELECT_SOURCE_PROPERTY in SELECT_SOURCE_VAR[PROPERTIES][number]]: TypedSourceProperty<
+                    SELECT_SOURCE_VAR,
+                    TSelectSourceWithParams
+                  >[SELECT_SOURCE_PROPERTY] extends never
+                    ? unknown
+                    : TypedSourceProperty<
+                        SELECT_SOURCE_VAR,
+                        TSelectSourceWithParams
+                      >[SELECT_SOURCE_PROPERTY];
+                };
+          };
+        };
+      }
+    >;
+  };
+  nextCursor?: Partial<{
+    [SELECT_SOURCE_KEY in keyof TQueryRequest[SELECT]]: string;
+  }>;
+};

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -2929,6 +2929,11 @@ export type {
 } from './api/instances/types.gen';
 
 export type {
+  QueryResult,
+  SelectSourceWithParams,
+} from './api/instances/query.types';
+
+export type {
   AllVersionsQueryParameter,
   ByExternalIdsDataModelsRequest,
   ConnectionDefinition,

--- a/packages/stable/vitest.config.ts
+++ b/packages/stable/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Integration tests use runTestWithRetryWhenFailing which retries up to
+    // 15 times with exponential backoff — give each test enough room.
+    testTimeout: 3 * 60 * 1000,
+    hookTimeout: 60 * 1000,
+  },
+});


### PR DESCRIPTION
## Strategy B — Smart conditional default on `query`

This is a **non-breaking** alternative to #1442.

### What changes

`instances.query` gains generic type parameters with a conditional return type:

```ts
// When called without a type param, or with the plain QueryRequest base type:
const result = await client.instances.query(params);
// → Promise<QueryResponse>   (same as today — fully backward-compatible)

// When called with a narrower const type:
const result = await client.instances.query(typedQuery);
// → Promise<QueryResult<typeof typedQuery>>  (fully inferred)
```

The conditional is `QueryRequest extends TQueryRequest ? QueryResponse : QueryResult<...>`:
- `TQueryRequest = QueryRequest` (default, or explicit `<QueryRequest>`) → `QueryResponse`
- `TQueryRequest = typeof myConst` (narrowed by `as const satisfies QueryRequest`) → `QueryResult<...>`

### Usage

```ts
const query = {
  with: { myNodes: { nodes: {} } },
  select: {
    myNodes: {
      sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }]
    }
  }
} as const satisfies QueryRequest;

// Fully typed — no method rename needed
const result = await client.instances.query(query);
// result.items.myNodes[0].properties.mySpace['MyView/v1'].name  ← typed

// Old-style call still returns QueryResponse
const untyped: QueryResponse = await client.instances.query(looseParams);
```

### Trade-off

Pro: single method, no rename needed, callers get types automatically with `as const`.
Con: slightly more complex signature; the conditional return type may confuse some editors/type-checkers in edge cases.

---
Alternative approach: #1443 (new `queryTyped` method)

Made with [Cursor](https://cursor.com)