### PR TITLE
chore: add queryTyped API endpoint

### DIFF
--- a/packages/stable/src/__tests__/api/instances.int.spec.ts
+++ b/packages/stable/src/__tests__/api/instances.int.spec.ts
@@ -1,7 +1,15 @@
 // Copyright 2024 Cognite AS
 
-import type { ViewReference } from 'stable/src/types';
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import type { QueryRequest, ViewReference } from 'stable/src/types';
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+  vi,
+} from 'vitest';
 import type CogniteClient from '../../cogniteClient';
 import { randomInt, setupLoggedInClient } from '../testUtils';
 
@@ -58,12 +66,12 @@ describe('Instances integration test', () => {
     name: TEST_SPACE_EXT_ID,
     description: 'Instance space used for integration tests.',
   };
-  const view: ViewReference = {
+  const view = {
     externalId: 'Describable',
     space: 'cdf_core',
     type: 'view',
     version: 'v1',
-  };
+  } as const satisfies ViewReference;
 
   const describable1: Describable = {
     externalId: `describable_1_${timestamp}`,
@@ -318,7 +326,50 @@ describe('Instances integration test', () => {
         result_set_1: {},
       },
     });
+    expect(response.items.resuslt_set_1).toHaveLength(1);
+  }, 10_000);
+
+  test('queryTyped', async () => {
+    const query = {
+      with: {
+        result_set_1: {
+          nodes: {
+            filter: {
+              equals: {
+                property: ['node', 'externalId'],
+                value: describable1.externalId,
+              },
+            },
+          },
+        },
+      },
+      select: {
+        result_set_1: {
+          sources: [
+            { source: view, properties: ['title', 'description', 'labels'] },
+          ],
+        },
+      },
+    } as const satisfies QueryRequest;
+
+    const response = await client.instances.queryTyped<
+      typeof query,
+      [
+        {
+          source: typeof view;
+          properties: { title: string; description: string; labels: string[] };
+        },
+      ]
+    >(query);
+
     expect(response.items.result_set_1).toHaveLength(1);
+
+    const resultProperties =
+      response.items.result_set_1[0].properties.cdf_core['Describable/v1'];
+
+    expectTypeOf(resultProperties.title).toEqualTypeOf<string>();
+    expectTypeOf(resultProperties.description).toEqualTypeOf<string>();
+    expectTypeOf(resultProperties.labels).toEqualTypeOf<string[]>();
   }, 10_000);
 
   test('sync', async () => {

--- a/packages/stable/src/__tests__/api/instances.int.spec.ts
+++ b/packages/stable/src/__tests__/api/instances.int.spec.ts
@@ -326,7 +326,7 @@ describe('Instances integration test', () => {
         result_set_1: {},
       },
     });
-    expect(response.items.resuslt_set_1).toHaveLength(1);
+    expect(response.items.result_set_1).toHaveLength(1);
   }, 10_000);
 
   test('queryTyped', async () => {

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -1,0 +1,182 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import type { QueryRequest } from 'stable/src/types';
+import { describe, expectTypeOf, test } from 'vitest';
+import type { InstancesAPI } from '../../../api/instances/instancesApi';
+
+describe('queryNodesEdges type tests', () => {
+  test('query result keys should match const query select keys', () => {
+    type QueryResultSelectKeys = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
+    >['items'];
+
+    expectTypeOf<QueryResultSelectKeys>().toEqualTypeOf<
+      keyof typeof testQuery.select
+    >();
+  });
+
+  test('Each source with unique space should map to a key in properties of result', () => {
+    type ResultSourceSpaces = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
+    >['items']['resultExpressionA'][number]['properties'];
+
+    type QueryResultSpaces =
+      (typeof testQuery.select.resultExpressionA.sources)[number]['source']['space'];
+    expectTypeOf<ResultSourceSpaces>().toEqualTypeOf<QueryResultSpaces>();
+  });
+
+  test('property keys of result should match property keys of sources', () => {
+    type ResultPropertiesA = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+    type QueryPropertiesA =
+      (typeof testQuery.select.resultExpressionA.sources)[0]['properties'][number];
+
+    expectTypeOf<ResultPropertiesA>().toEqualTypeOf<QueryPropertiesA>();
+
+    type ResultPropertiesB = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdB/v1'];
+    type QueryPropertiesB =
+      (typeof testQuery.select.resultExpressionA.sources)[1]['properties'][number];
+
+    expectTypeOf<ResultPropertiesB>().toEqualTypeOf<QueryPropertiesB>();
+
+    type ResultPropertiesC = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
+    >['items']['resultExpressionA'][number]['properties']['spaceB']['externalIdC/v1'];
+    type QueryPropertiesC =
+      (typeof testQuery.select.resultExpressionA.sources)[2]['properties'][number];
+
+    expectTypeOf<ResultPropertiesC>().toEqualTypeOf<QueryPropertiesC>();
+  });
+
+  test('passing a typed Source generic should return a typed results for parameters', () => {
+    type SourceExternalIdAPropertyTypes = [
+      {
+        source: {
+          type: 'view';
+          space: 'spaceA';
+          externalId: 'externalIdA';
+          version: 'v1';
+        };
+        properties: {
+          aPropOne: string;
+          aPropTwo: number;
+          aPropThree: { externalId: string; space: string };
+        };
+      },
+    ];
+
+    type TypedResultProperties = Awaited<
+      ReturnType<
+        typeof InstancesAPI.prototype.queryTyped<
+          typeof testQuery,
+          SourceExternalIdAPropertyTypes
+        >
+      >
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+
+    expectTypeOf<TypedResultProperties>().toEqualTypeOf<
+      SourceExternalIdAPropertyTypes[0]['properties']
+    >();
+  });
+
+  test('Passing a non-constant query should be valid', () => {
+    type QueryResult = Awaited<
+      ReturnType<typeof InstancesAPI.prototype.queryTyped<QueryRequest>>
+    >;
+
+    type TestType = QueryResult extends {
+      items: Record<string, unknown>;
+      nextCursors?: Record<string, unknown>;
+    }
+      ? true
+      : false;
+
+    expectTypeOf<TestType>().toEqualTypeOf<true>();
+  });
+
+  test('passing * as property should type properties as Record', () => {
+    type ResultSourceSpaces = Awaited<
+      ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
+    >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
+
+    expectTypeOf<ResultSourceSpaces>().toEqualTypeOf<Record<string, unknown>>();
+  });
+});
+
+const testQuery = {
+  with: {
+    resultExpressionA: {
+      nodes: {},
+    },
+    resultExpressionB: {
+      nodes: {},
+    },
+    resultExpressionC: {
+      edges: {},
+    },
+  },
+  select: {
+    resultExpressionA: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdA',
+            version: 'v1',
+          },
+          properties: ['aPropOne', 'aPropTwo', 'aPropThree'],
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceA',
+            externalId: 'externalIdB',
+            version: 'v1',
+          },
+          properties: ['bPropOne', 'bPropTwo'],
+        },
+        {
+          source: {
+            type: 'view',
+            space: 'spaceB',
+            externalId: 'externalIdC',
+            version: 'v1',
+          },
+          properties: ['cPropOne'],
+        },
+      ],
+    },
+    resultExpressionB: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceD',
+            externalId: 'externalIdD',
+            version: 'v1',
+          },
+          properties: ['*'],
+        },
+      ],
+    },
+    resultExpressionC: {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: 'spaceE',
+            externalId: 'externalIdE',
+            version: 'v1',
+          },
+          properties: ['ePropOne', 'ePropTwo'],
+        },
+      ],
+    },
+  },
+} as const satisfies QueryRequest;

--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -2,9 +2,13 @@
  * Copyright 2024 Cognite AS
  */
 
-import type { QueryRequest } from 'stable/src/types';
 import { describe, expectTypeOf, test } from 'vitest';
 import type { InstancesAPI } from '../../../api/instances/instancesApi';
+import type {
+  QueryRequest,
+  QueryResponse,
+  RawPropertyValueV3,
+} from '../../../types';
 
 describe('queryNodesEdges type tests', () => {
   test('query result keys should match const query select keys', () => {
@@ -89,12 +93,7 @@ describe('queryNodesEdges type tests', () => {
       ReturnType<typeof InstancesAPI.prototype.queryTyped<QueryRequest>>
     >;
 
-    type TestType = QueryResult extends {
-      items: Record<string, unknown>;
-      nextCursors?: Record<string, unknown>;
-    }
-      ? true
-      : false;
+    type TestType = QueryResult extends QueryResponse ? true : false;
 
     expectTypeOf<TestType>().toEqualTypeOf<true>();
   });
@@ -104,7 +103,9 @@ describe('queryNodesEdges type tests', () => {
       ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
     >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
 
-    expectTypeOf<ResultSourceSpaces>().toEqualTypeOf<Record<string, unknown>>();
+    expectTypeOf<ResultSourceSpaces>().toEqualTypeOf<
+      Record<string, RawPropertyValueV3>
+    >();
   });
 });
 

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -249,7 +249,7 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Declare params as const satisfies QueryRequest for fully typed results per select key, space and property name.
    *
    * ```js
-   * 
+   *
    *  const query = {
    *    with: {
    *      result_set_1: {

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -249,7 +249,8 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Declare params as const satisfies QueryRequest for fully typed results per select key, space and property name.
    *
    * ```js
-   *  const typedResponse = await client.instances.queryTyped({
+   * 
+   *  const query = {
    *    with: {
    *      result_set_1: {
    *        nodes: {},
@@ -260,7 +261,8 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    *        sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }],
    *      },
    *    },
-   *  });
+   *  } as const satisfies QueryRequest
+   *  const typedResponse = await client.instances.queryTyped(query);
    *  // For fully typed results, declare the query variable as:
    *  // const query = { ... } as const satisfies QueryRequest;
    *  // then: typedResponse.items.result_set_1[0].properties.mySpace['MyView/v1'].name

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Cognite AS
 
 import { BaseResourceAPI } from '@cognite/sdk-core';
+import type { QueryResult, SelectSourceWithParams } from './query.types';
 import type {
   AggregationRequest,
   AggregationResponse,
@@ -241,6 +242,39 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
     const response = await this.post<QueryResponse>(this.url('query'), {
       data: params,
     });
+    return response.data;
+  };
+
+  /**
+   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Declare params as const satisfies QueryRequest for fully typed results per select key, space and property name.
+   *
+   * ```js
+   *  const typedResponse = await client.instances.queryTyped({
+   *    with: {
+   *      result_set_1: {
+   *        nodes: {},
+   *      },
+   *    },
+   *    select: {
+   *      result_set_1: {
+   *        sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }],
+   *      },
+   *    },
+   *  });
+   *  // For fully typed results, declare the query variable as:
+   *  // const query = { ... } as const satisfies QueryRequest;
+   *  // then: typedResponse.items.result_set_1[0].properties.mySpace['MyView/v1'].name
+   * ```
+   */
+  public queryTyped = async <
+    TQueryRequest extends QueryRequest,
+    TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams,
+  >(
+    params: TQueryRequest
+  ): Promise<QueryResult<TQueryRequest, TypedSelectSources>> => {
+    const response = await this.post<
+      QueryResult<TQueryRequest, TypedSelectSources>
+    >(this.url('query'), { data: params });
     return response.data;
   };
 

--- a/packages/stable/src/api/instances/query.types.ts
+++ b/packages/stable/src/api/instances/query.types.ts
@@ -26,11 +26,34 @@ type EXTERNALID = 'externalId';
 type VERSION = 'version';
 type ALLPROPERTIES = '*';
 
+/**
+ * Typed result of a DMS instances query, derived from the query request shape.
+ *
+ * `items` is keyed by the result-set names defined in the `select` clause of
+ * `TQueryRequest`. Each result set is an array of node or edge objects whose
+ * `properties` are nested first by space, then by `externalId/version` of the
+ * view. Property value types are inferred from `TSelectSourceWithParams` when
+ * provided, falling back to the raw `RawPropertyValueV3` union otherwise.
+ *
+ * @typeParam TQueryRequest - The query request object whose `select` and `with`
+ *   clauses drive the shape of the returned items and cursors.
+ * @typeParam TSelectSourceWithParams - An optional mapping of view references to
+ *   typed property records. When supplied, properties listed in the `select`
+ *   clause are narrowed to their concrete types instead of `RawPropertyValueV3`.
+ *   Defaults to the untyped `SelectSourceWithParams`.
+ *
+ * @example
+ * ```ts
+ * const result: QueryResult<typeof myQuery> = await client.instances.queryTyped(myQuery);
+ * // result.items.<resultSetName>[0].properties.<space>.<externalId/version>.<propertyName>
+ * ```
+ */
 export type QueryResult<
   TQueryRequest extends QueryRequest,
   TSelectSourceWithParams extends
     SelectSourceWithParams = SelectSourceWithParams,
 > = {
+  /** Result sets keyed by the names defined in the query's `select` clause. */
   items: {
     [SelectKey in keyof TQueryRequest[SELECT]]: Array<
       Prettify<
@@ -58,11 +81,16 @@ export type QueryResult<
       >
     >;
   };
+  /**
+   * Pagination cursors, one per result set. Pass these back in a subsequent
+   * request to retrieve the next page for any result set that has more items.
+   */
   nextCursor: Prettify<
     ConcreteValues<{
       [SelectKey in keyof TQueryRequest[SELECT]]?: string;
     }>
   >;
+  /** Optional type information for property values, keyed by view identifier. */
   typing?: Record<string, TypeInformationOuter>;
 };
 
@@ -73,7 +101,7 @@ type DmsInstanceType<
   ? Omit<NodeDefinition, PROPERTIES>
   : Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends EDGES
     ? Omit<EdgeDefinition, PROPERTIES>
-  : Omit<NodeOrEdge, PROPERTIES>;
+    : Omit<NodeOrEdge, PROPERTIES>;
 
 type TypedSourceProperty<
   SelectSource extends NonNullable<

--- a/packages/stable/src/api/instances/query.types.ts
+++ b/packages/stable/src/api/instances/query.types.ts
@@ -3,12 +3,14 @@ import type {
   NodeDefinition,
   NodeOrEdge,
   QueryRequest,
+  RawPropertyValueV3,
+  TypeInformationOuter,
   ViewReference,
 } from './types.gen';
 
 export type SelectSourceWithParams = Array<{
   source: ViewReference;
-  properties: Record<string, unknown>;
+  properties: Record<string, RawPropertyValueV3>;
 }>;
 
 type SELECT = 'select';
@@ -24,14 +26,54 @@ type EXTERNALID = 'externalId';
 type VERSION = 'version';
 type ALLPROPERTIES = '*';
 
-type InstanceType<
+export type QueryResult<
+  TQueryRequest extends QueryRequest,
+  TSelectSourceWithParams extends
+    SelectSourceWithParams = SelectSourceWithParams,
+> = {
+  items: {
+    [SelectKey in keyof TQueryRequest[SELECT]]: Array<
+      Prettify<
+        DmsInstanceType<TQueryRequest, SelectKey> & {
+          properties: {
+            [SelectSource in NonNullable<
+              NonNullable<TQueryRequest[SELECT][SelectKey]>[SOURCES]
+            >[number] as SelectSource[SOURCE][SPACE]]: {
+              [SelectSourceVar in SelectSource as `${SelectSourceVar[SOURCE][EXTERNALID]}/${SelectSourceVar[SOURCE][VERSION]}`]: SelectSourceVar[PROPERTIES][0] extends ALLPROPERTIES
+                ? Record<string, RawPropertyValueV3>
+                : {
+                    [SELECT_SOURCE_PROPERTY in SelectSourceVar[PROPERTIES][number]]: TypedSourceProperty<
+                      SelectSourceVar,
+                      TSelectSourceWithParams
+                    >[SELECT_SOURCE_PROPERTY] extends never
+                      ? RawPropertyValueV3
+                      : TypedSourceProperty<
+                          SelectSourceVar,
+                          TSelectSourceWithParams
+                        >[SELECT_SOURCE_PROPERTY];
+                  };
+            };
+          };
+        }
+      >
+    >;
+  };
+  nextCursor: Prettify<
+    ConcreteValues<{
+      [SelectKey in keyof TQueryRequest[SELECT]]?: string;
+    }>
+  >;
+  typing?: Record<string, TypeInformationOuter>;
+};
+
+type DmsInstanceType<
   TQueryRequest extends QueryRequest,
   SelectKey extends keyof TQueryRequest[SELECT],
 > = Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends NODES
   ? Omit<NodeDefinition, PROPERTIES>
   : Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends EDGES
     ? Omit<EdgeDefinition, PROPERTIES>
-    : Omit<NodeOrEdge, PROPERTIES>;
+  : Omit<NodeOrEdge, PROPERTIES>;
 
 type TypedSourceProperty<
   SelectSource extends NonNullable<
@@ -44,37 +86,10 @@ type TypedSourceProperty<
   Pick<SelectSource, SOURCE>
 >[PROPERTIES];
 
-export type QueryResult<
-  TQueryRequest extends QueryRequest,
-  TSelectSourceWithParams extends
-    SelectSourceWithParams = SelectSourceWithParams,
-> = {
-  items: {
-    [SELECT_KEY in keyof TQueryRequest[SELECT]]: Array<
-      InstanceType<TQueryRequest, SELECT_KEY> & {
-        properties: {
-          [SELECT_SOURCE in NonNullable<
-            NonNullable<TQueryRequest[SELECT][SELECT_KEY]>[SOURCES]
-          >[number] as SELECT_SOURCE[SOURCE][SPACE]]: {
-            [SELECT_SOURCE_VAR in SELECT_SOURCE as `${SELECT_SOURCE_VAR[SOURCE][EXTERNALID]}/${SELECT_SOURCE_VAR[SOURCE][VERSION]}`]: SELECT_SOURCE_VAR[PROPERTIES][0] extends ALLPROPERTIES
-              ? Record<string, unknown>
-              : {
-                  [SELECT_SOURCE_PROPERTY in SELECT_SOURCE_VAR[PROPERTIES][number]]: TypedSourceProperty<
-                    SELECT_SOURCE_VAR,
-                    TSelectSourceWithParams
-                  >[SELECT_SOURCE_PROPERTY] extends never
-                    ? unknown
-                    : TypedSourceProperty<
-                        SELECT_SOURCE_VAR,
-                        TSelectSourceWithParams
-                      >[SELECT_SOURCE_PROPERTY];
-                };
-          };
-        };
-      }
-    >;
-  };
-  nextCursor?: Partial<{
-    [SELECT_SOURCE_KEY in keyof TQueryRequest[SELECT]]: string;
-  }>;
+type ConcreteValues<T> = {
+  [K in keyof T]: NonNullable<T[K]>;
 };
+
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};

--- a/packages/stable/src/api/instances/query.types.ts
+++ b/packages/stable/src/api/instances/query.types.ts
@@ -1,0 +1,80 @@
+import type {
+  EdgeDefinition,
+  NodeDefinition,
+  NodeOrEdge,
+  QueryRequest,
+  ViewReference,
+} from './types.gen';
+
+export type SelectSourceWithParams = Array<{
+  source: ViewReference;
+  properties: Record<string, unknown>;
+}>;
+
+type SELECT = 'select';
+type WITH = 'with';
+type LIMIT = 'limit';
+type NODES = 'nodes';
+type EDGES = 'edges';
+type PROPERTIES = 'properties';
+type SOURCES = 'sources';
+type SOURCE = 'source';
+type SPACE = 'space';
+type EXTERNALID = 'externalId';
+type VERSION = 'version';
+type ALLPROPERTIES = '*';
+
+type InstanceType<
+  TQueryRequest extends QueryRequest,
+  SelectKey extends keyof TQueryRequest[SELECT],
+> = Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends NODES
+  ? Omit<NodeDefinition, PROPERTIES>
+  : Exclude<keyof TQueryRequest[WITH][SelectKey], LIMIT> extends EDGES
+    ? Omit<EdgeDefinition, PROPERTIES>
+    : Omit<NodeOrEdge, PROPERTIES>;
+
+type TypedSourceProperty<
+  SelectSource extends NonNullable<
+    QueryRequest[SELECT][keyof QueryRequest[SELECT]][SOURCES]
+  >[number],
+  TypedSelectSourcePropertyMap extends
+    SelectSourceWithParams = SelectSourceWithParams,
+> = Extract<
+  TypedSelectSourcePropertyMap[number],
+  Pick<SelectSource, SOURCE>
+>[PROPERTIES];
+
+export type QueryResult<
+  TQueryRequest extends QueryRequest,
+  TSelectSourceWithParams extends
+    SelectSourceWithParams = SelectSourceWithParams,
+> = {
+  items: {
+    [SELECT_KEY in keyof TQueryRequest[SELECT]]: Array<
+      InstanceType<TQueryRequest, SELECT_KEY> & {
+        properties: {
+          [SELECT_SOURCE in NonNullable<
+            NonNullable<TQueryRequest[SELECT][SELECT_KEY]>[SOURCES]
+          >[number] as SELECT_SOURCE[SOURCE][SPACE]]: {
+            [SELECT_SOURCE_VAR in SELECT_SOURCE as `${SELECT_SOURCE_VAR[SOURCE][EXTERNALID]}/${SELECT_SOURCE_VAR[SOURCE][VERSION]}`]: SELECT_SOURCE_VAR[PROPERTIES][0] extends ALLPROPERTIES
+              ? Record<string, unknown>
+              : {
+                  [SELECT_SOURCE_PROPERTY in SELECT_SOURCE_VAR[PROPERTIES][number]]: TypedSourceProperty<
+                    SELECT_SOURCE_VAR,
+                    TSelectSourceWithParams
+                  >[SELECT_SOURCE_PROPERTY] extends never
+                    ? unknown
+                    : TypedSourceProperty<
+                        SELECT_SOURCE_VAR,
+                        TSelectSourceWithParams
+                      >[SELECT_SOURCE_PROPERTY];
+                };
+          };
+        };
+      }
+    >;
+  };
+  nextCursor?: Partial<{
+    [SELECT_SOURCE_KEY in keyof TQueryRequest[SELECT]]: string;
+  }>;
+};

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -2929,6 +2929,11 @@ export type {
 } from './api/instances/types.gen';
 
 export type {
+  QueryResult,
+  SelectSourceWithParams,
+} from './api/instances/query.types';
+
+export type {
   AllVersionsQueryParameter,
   ByExternalIdsDataModelsRequest,
   ConnectionDefinition,

--- a/scripts/extractCodeSnippets.js
+++ b/scripts/extractCodeSnippets.js
@@ -85,7 +85,7 @@ codeSnippets.forEach((snippets, operationId) => {
     return;
   }
   const codeToTest = `
-    import { CogniteClient, SequenceValueType } from '${packageName}';
+    import { CogniteClient, SequenceValueType, QueryRequest } from '${packageName}';
     const client = new CogniteClient({
       appId: '[APP NAME]',
       project: '[PROJECT]',


### PR DESCRIPTION
## Description
Adds a queryTyped method to InstancesAPI that infers return types from a const query declaration, providing full TypeScript type safety on query results.

- New method instances.queryTyped<TQueryRequest>(params) — wraps the existing /instances/query endpoint with generic type inference. When the query is declared as const query = { ... } as const satisfies QueryRequest, the return type is fully inferred: result expression keys, source spaces, view external IDs, and individual property names are all typed.
- New query.types.ts — contains the QueryResult<TQueryRequest, TSelectSourceWithParams> and SelectSourceWithParams utility types that power the inference. Supports a second generic TSelectSourceWithParams for passing explicit property value types when richer typing is needed.
- Type-level feature highlights:
  - Result keys match select keys from the query
  - Source spaces and externalId/version view identifiers are inferred per result expression
  - Property names are inferred per source; * (wildcard) falls back to Record<string, unknown>
  - Falls back gracefully to Record<string, unknown> for non-const / runtime queries
- Exports QueryResult and SelectSourceWithParams from packages/stable/src/types.ts
- Type tests added in query.spec.ts covering all inference scenarios using vitest's expectTypeOf

## Example usage:
 ```ts
const query = {
  with: {
    result_set_1: {
      nodes: {},
    },
  },
  select: {
    result_set_1: {
      sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }],
    },
  },
} as const satisfies QueryRequest;

const typedResponse = await client.instances.queryTyped(query);
// For fully typed results, declare the query variable as:
// const query = { ... } as const satisfies QueryRequest;
// then: typedResponse.items.result_set_1[0].properties.mySpace['MyView/v1'].name
```

## Visual Aids

https://github.com/user-attachments/assets/671b519e-3fe8-4c76-baf8-2bcbbecc1953


