### PR TITLE
feat(alpha): add data product versions API support

### DIFF
--- a/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
@@ -77,23 +77,20 @@ describe('Data product versions integration test', () => {
         tags: ['integration'],
       },
     ]);
-    await client.dataProductVersions.create(
-      dataProductExternalId,
-      [
-        {
-          version: versionNumber,
-          views: [
-            {
-              space: schemaSpace,
-              externalId: viewExternalId,
-              version: '1',
-            },
-          ],
-          description: 'integration test data product version',
-          terms: { usage: 'integration test' },
-        },
-      ]
-    );
+    await client.dataProductVersions.create(dataProductExternalId, [
+      {
+        version: versionNumber,
+        views: [
+          {
+            space: schemaSpace,
+            externalId: viewExternalId,
+            version: '1',
+          },
+        ],
+        description: 'integration test data product version',
+        terms: { usage: 'integration test' },
+      },
+    ]);
   });
 
   afterAll(async () => {

--- a/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
@@ -109,28 +109,42 @@ describe('Data product versions integration test', () => {
         .catch();
     }
 
+    await client.views
+      .delete([
+        {
+          space: schemaSpace,
+          externalId: viewExternalId,
+          version: '1',
+        },
+      ])
+      .catch();
+
     await client.containers
       .delete([{ externalId: containerExternalId, space: schemaSpace }])
       .catch();
+
     await client.spaces.delete([schemaSpace]).catch();
   });
 
   test('create', async () => {
     const createVersion = '2.0.0';
 
-    const items = await client.dataProductVersions.create(dataProductExternalId, [
-      {
-        version: createVersion,
-        views: [
-          {
-            space: schemaSpace,
-            externalId: viewExternalId,
-            version: '1',
-          },
-        ],
-        description: 'create test version',
-      },
-    ]);
+    const items = await client.dataProductVersions.create(
+      dataProductExternalId,
+      [
+        {
+          version: createVersion,
+          views: [
+            {
+              space: schemaSpace,
+              externalId: viewExternalId,
+              version: '1',
+            },
+          ],
+          description: 'create test version',
+        },
+      ]
+    );
     const created = items[0];
 
     expect(created.version).toBe(createVersion);
@@ -148,9 +162,9 @@ describe('Data product versions integration test', () => {
     );
 
     expect(response.items.length).toBeGreaterThan(0);
-    expect(
-      response.items.some((item) => item.version === versionNumber)
-    ).toBe(true);
+    expect(response.items.some((item) => item.version === versionNumber)).toBe(
+      true
+    );
   });
 
   test('retrieve by version', async () => {
@@ -162,20 +176,23 @@ describe('Data product versions integration test', () => {
   });
 
   test('update existing data product version', async () => {
-    const items = await client.dataProductVersions.update(dataProductExternalId, [
-      {
-        version: versionNumber,
-        update: {
-          description: { set: 'integration updated description' },
-          status: { set: 'published' },
-          terms: {
-            modify: {
-              usage: { set: 'updated usage terms' },
+    const items = await client.dataProductVersions.update(
+      dataProductExternalId,
+      [
+        {
+          version: versionNumber,
+          update: {
+            description: { set: 'integration updated description' },
+            status: { set: 'published' },
+            terms: {
+              modify: {
+                usage: { set: 'updated usage terms' },
+              },
             },
           },
         },
-      },
-    ]);
+      ]
+    );
     const updatedVersion = items[0];
 
     expect(updatedVersion.description).toBe('integration updated description');
@@ -184,20 +201,23 @@ describe('Data product versions integration test', () => {
   });
 
   test('delete', async () => {
-    const deleteVersion = `3.${dataProductRandom}.0`;
+    const deleteVersion = '3.0.0';
 
-    const items = await client.dataProductVersions.create(dataProductExternalId, [
-      {
-        version: deleteVersion,
-        views: [
-          {
-            space: schemaSpace,
-            externalId: viewExternalId,
-            version: '1',
-          },
-        ],
-      },
-    ]);
+    const items = await client.dataProductVersions.create(
+      dataProductExternalId,
+      [
+        {
+          version: deleteVersion,
+          views: [
+            {
+              space: schemaSpace,
+              externalId: viewExternalId,
+              version: '1',
+            },
+          ],
+        },
+      ]
+    );
     const versionToDelete = items[0];
 
     await expect(

--- a/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
@@ -1,0 +1,216 @@
+// Copyright 2026 Cognite AS
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
+import type { DataProduct, DataProductVersion } from '../../types';
+import { randomInt, setupLoggedInClient } from '../testUtils';
+
+function uniqueSchemaSpace(prefix: string): string {
+  return `${prefix}_${randomInt()}`;
+}
+
+describe('Data product versions integration test', () => {
+  let client: CogniteClientAlpha;
+  const dataProductRandom = randomInt();
+  const dataProductExternalId = `int-dp-version-${dataProductRandom}`;
+  const schemaSpace = uniqueSchemaSpace('sdk_js_alpha_dpv_int');
+  const containerExternalId = `int_dpv_container_${dataProductRandom}`;
+  const viewExternalId = `int_dpv_view_${dataProductRandom}`;
+  const versionNumber = '1.0.0';
+  let createdDataProduct: DataProduct | undefined;
+  let createdVersion: DataProductVersion | undefined;
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+
+    await client.spaces.upsert([
+      {
+        space: schemaSpace,
+        name: schemaSpace,
+        description: 'Space for Data Product Versions integration tests',
+      },
+    ]);
+
+    await client.containers.upsert([
+      {
+        externalId: containerExternalId,
+        space: schemaSpace,
+        name: containerExternalId,
+        description: 'Container for Data Product Versions integration tests',
+        properties: {
+          test: {
+            type: { type: 'text' },
+          },
+        },
+      },
+    ]);
+
+    await client.views.upsert([
+      {
+        externalId: viewExternalId,
+        space: schemaSpace,
+        name: viewExternalId,
+        description: 'View for Data Product Versions integration tests',
+        version: '1',
+        properties: {
+          test: {
+            container: {
+              type: 'container',
+              externalId: containerExternalId,
+              space: schemaSpace,
+            },
+            containerPropertyIdentifier: 'test',
+          },
+        },
+      },
+    ]);
+
+    const items = await client.dataProducts.create([
+      {
+        externalId: dataProductExternalId,
+        name: `integration test data product ${dataProductRandom}`,
+        schemaSpace,
+        isGoverned: true,
+        tags: ['integration'],
+      },
+    ]);
+    createdDataProduct = items[0];
+
+    const versionItems = await client.dataProductVersions.create(
+      dataProductExternalId,
+      [
+        {
+          version: versionNumber,
+          views: [
+            {
+              space: schemaSpace,
+              externalId: viewExternalId,
+              version: '1',
+            },
+          ],
+          description: 'integration test data product version',
+          terms: { usage: 'integration test' },
+        },
+      ]
+    );
+    createdVersion = versionItems[0];
+  });
+
+  afterAll(async () => {
+    if (createdVersion) {
+      await client.dataProductVersions
+        .delete(dataProductExternalId, [{ version: versionNumber }])
+        .catch();
+    }
+
+    if (createdDataProduct) {
+      await client.dataProducts
+        .delete([{ externalId: dataProductExternalId }])
+        .catch();
+    }
+
+    await client.containers
+      .delete([{ externalId: containerExternalId, space: schemaSpace }])
+      .catch();
+    await client.spaces.delete([schemaSpace]).catch();
+  });
+
+  test('create', async () => {
+    const createVersion = '2.0.0';
+
+    const items = await client.dataProductVersions.create(dataProductExternalId, [
+      {
+        version: createVersion,
+        views: [
+          {
+            space: schemaSpace,
+            externalId: viewExternalId,
+            version: '1',
+          },
+        ],
+        description: 'create test version',
+      },
+    ]);
+    const created = items[0];
+
+    expect(created.version).toBe(createVersion);
+    expect(created.views).toHaveLength(1);
+
+    await client.dataProductVersions
+      .delete(dataProductExternalId, [{ version: createVersion }])
+      .catch();
+  });
+
+  test('list', async () => {
+    const response = await client.dataProductVersions.list(
+      dataProductExternalId,
+      { limit: 10 }
+    );
+
+    expect(response.items.length).toBeGreaterThan(0);
+    expect(
+      response.items.some((item) => item.version === versionNumber)
+    ).toBe(true);
+  });
+
+  test('retrieve by version', async () => {
+    const version = await client.dataProductVersions.retrieve(
+      dataProductExternalId,
+      versionNumber
+    );
+    expect(version.version).toBe(versionNumber);
+  });
+
+  test('update existing data product version', async () => {
+    const items = await client.dataProductVersions.update(dataProductExternalId, [
+      {
+        version: versionNumber,
+        update: {
+          description: { set: 'integration updated description' },
+          status: { set: 'published' },
+          terms: {
+            modify: {
+              usage: { set: 'updated usage terms' },
+            },
+          },
+        },
+      },
+    ]);
+    const updatedVersion = items[0];
+
+    expect(updatedVersion.description).toBe('integration updated description');
+    expect(updatedVersion.status).toBe('published');
+    expect(updatedVersion.terms.usage).toBe('updated usage terms');
+  });
+
+  test('delete', async () => {
+    const deleteVersion = `3.${dataProductRandom}.0`;
+
+    const items = await client.dataProductVersions.create(dataProductExternalId, [
+      {
+        version: deleteVersion,
+        views: [
+          {
+            space: schemaSpace,
+            externalId: viewExternalId,
+            version: '1',
+          },
+        ],
+      },
+    ]);
+    const versionToDelete = items[0];
+
+    await expect(
+      client.dataProductVersions.delete(dataProductExternalId, [
+        { version: versionToDelete.version },
+      ])
+    ).resolves.toBeDefined();
+
+    const listAfterDelete = await client.dataProductVersions.list(
+      dataProductExternalId
+    );
+    expect(
+      listAfterDelete.items.some((item) => item.version === deleteVersion)
+    ).toBe(false);
+  });
+});

--- a/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
@@ -2,8 +2,12 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClientAlpha from '../../cogniteClient';
-import type { DataProduct, DataProductVersion } from '../../types';
-import { randomInt, setupLoggedInClient } from '../testUtils';
+import {
+  cleanupDataProductSchemaSpaces,
+  cleanupOrphanedDataProductTestResources,
+  randomInt,
+  setupLoggedInClient,
+} from '../testUtils';
 
 function uniqueSchemaSpace(prefix: string): string {
   return `${prefix}_${randomInt()}`;
@@ -17,11 +21,10 @@ describe('Data product versions integration test', () => {
   const containerExternalId = `int_dpv_container_${dataProductRandom}`;
   const viewExternalId = `int_dpv_view_${dataProductRandom}`;
   const versionNumber = '1.0.0';
-  let createdDataProduct: DataProduct | undefined;
-  let createdVersion: DataProductVersion | undefined;
 
   beforeAll(async () => {
     client = setupLoggedInClient();
+    await cleanupOrphanedDataProductTestResources(client);
 
     await client.spaces.upsert([
       {
@@ -65,7 +68,7 @@ describe('Data product versions integration test', () => {
       },
     ]);
 
-    const items = await client.dataProducts.create([
+    await client.dataProducts.create([
       {
         externalId: dataProductExternalId,
         name: `integration test data product ${dataProductRandom}`,
@@ -74,9 +77,7 @@ describe('Data product versions integration test', () => {
         tags: ['integration'],
       },
     ]);
-    createdDataProduct = items[0];
-
-    const versionItems = await client.dataProductVersions.create(
+    await client.dataProductVersions.create(
       dataProductExternalId,
       [
         {
@@ -93,37 +94,10 @@ describe('Data product versions integration test', () => {
         },
       ]
     );
-    createdVersion = versionItems[0];
   });
 
   afterAll(async () => {
-    if (createdVersion) {
-      await client.dataProductVersions
-        .delete(dataProductExternalId, [{ version: versionNumber }])
-        .catch();
-    }
-
-    if (createdDataProduct) {
-      await client.dataProducts
-        .delete([{ externalId: dataProductExternalId }])
-        .catch();
-    }
-
-    await client.views
-      .delete([
-        {
-          space: schemaSpace,
-          externalId: viewExternalId,
-          version: '1',
-        },
-      ])
-      .catch();
-
-    await client.containers
-      .delete([{ externalId: containerExternalId, space: schemaSpace }])
-      .catch();
-
-    await client.spaces.delete([schemaSpace]).catch();
+    await cleanupDataProductSchemaSpaces(client, [schemaSpace]);
   });
 
   test('create', async () => {

--- a/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
@@ -1,0 +1,129 @@
+// Copyright 2026 Cognite AS
+
+import matches from 'lodash/matches';
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+describe('Data product versions unit test', () => {
+  let client: CogniteClientAlpha;
+
+  const dataProductExternalId = 'dp-1';
+  const versionCreateBody = {
+    version: '1.0.0',
+    views: [{ space: 'dp_1_space', externalId: 'my-view', version: '1' }],
+    status: 'draft' as const,
+    description: 'Test version',
+    terms: { usage: 'Internal use only' },
+  };
+
+  const mockVersion = {
+    ...versionCreateBody,
+    createdTime: Date.now(),
+    lastUpdatedTime: Date.now() + 1000,
+  };
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test('create', async () => {
+    nock(mockBaseUrl)
+      .post(
+        /\/dataproducts\/dp-1\/versions$/,
+        matches({ items: [versionCreateBody] })
+      )
+      .once()
+      .reply(201, {
+        items: [mockVersion],
+      });
+
+    const items = await client.dataProductVersions.create(dataProductExternalId, [
+      versionCreateBody,
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0].version).toEqual('1.0.0');
+  });
+
+  test('list', async () => {
+    nock(mockBaseUrl)
+      .get(/\/dataproducts\/dp-1\/versions\/?$/)
+      .query({ limit: '10', cursor: 'abc' })
+      .once()
+      .reply(200, {
+        items: [mockVersion],
+        nextCursor: 'next',
+      });
+
+    const response = await client.dataProductVersions.list(dataProductExternalId, {
+      limit: 10,
+      cursor: 'abc',
+    });
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].version).toBe('1.0.0');
+    expect(response.nextCursor).toBe('next');
+  });
+
+  test('retrieve by version', async () => {
+    nock(mockBaseUrl)
+      .get(/\/dataproducts\/dp-1\/versions\/1\.0\.0$/)
+      .once()
+      .reply(200, mockVersion);
+
+    const response = await client.dataProductVersions.retrieve(
+      dataProductExternalId,
+      '1.0.0'
+    );
+    expect(response.version).toEqual('1.0.0');
+  });
+
+  test('update', async () => {
+    const updateBody = {
+      version: '1.0.0',
+      update: {
+        description: { set: 'updated description' },
+        status: { set: 'published' as const },
+      },
+    };
+
+    nock(mockBaseUrl)
+      .post(
+        /\/dataproducts\/dp-1\/versions\/update$/,
+        matches({ items: [updateBody] })
+      )
+      .once()
+      .reply(200, {
+        items: [
+          {
+            ...mockVersion,
+            description: 'updated description',
+            status: 'published',
+          },
+        ],
+      });
+
+    const items = await client.dataProductVersions.update(
+      dataProductExternalId,
+      [updateBody]
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].description).toEqual('updated description');
+    expect(items[0].status).toEqual('published');
+  });
+
+  test('delete', async () => {
+    nock(mockBaseUrl)
+      .post(/\/dataproducts\/dp-1\/versions\/delete$/, {
+        items: [{ version: '1.0.0' }],
+      })
+      .once()
+      .reply(200, {});
+
+    await client.dataProductVersions.delete(dataProductExternalId, [
+      { version: '1.0.0' },
+    ]);
+  });
+});

--- a/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
@@ -41,9 +41,10 @@ describe('Data product versions unit test', () => {
         items: [mockVersion],
       });
 
-    const items = await client.dataProductVersions.create(dataProductExternalId, [
-      versionCreateBody,
-    ]);
+    const items = await client.dataProductVersions.create(
+      dataProductExternalId,
+      [versionCreateBody]
+    );
     expect(items).toHaveLength(1);
     expect(items[0].version).toEqual('1.0.0');
   });
@@ -58,10 +59,13 @@ describe('Data product versions unit test', () => {
         nextCursor: 'next',
       });
 
-    const response = await client.dataProductVersions.list(dataProductExternalId, {
-      limit: 10,
-      cursor: 'abc',
-    });
+    const response = await client.dataProductVersions.list(
+      dataProductExternalId,
+      {
+        limit: 10,
+        cursor: 'abc',
+      }
+    );
     expect(response.items).toHaveLength(1);
     expect(response.items[0].version).toBe('1.0.0');
     expect(response.nextCursor).toBe('next');

--- a/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
@@ -89,7 +89,26 @@ describe('Data product versions unit test', () => {
       version: '1.0.0',
       update: {
         description: { set: 'updated description' },
+        terms: {
+          modify: {
+            usage: {
+              setNull: true
+            },
+            limitations: {
+              setNull: true
+            }
+          }
+        },
         status: { set: 'published' as const },
+        views: {
+          add: [
+            {
+              space: "test-space",
+              externalId: "testExternalId",
+              version: "v1"
+            }
+          ]
+        }
       },
     };
 
@@ -104,7 +123,18 @@ describe('Data product versions unit test', () => {
           {
             ...mockVersion,
             description: 'updated description',
+            terms: {
+              usage: null,
+              limitations: null,
+            },
             status: 'published',
+            views: [
+              {
+                space: "test-space",
+                externalId: "testExternalId",
+                version: "v1"
+              }
+            ]
           },
         ],
       });
@@ -117,6 +147,7 @@ describe('Data product versions unit test', () => {
     expect(items[0].description).toEqual('updated description');
     expect(items[0].status).toEqual('published');
   });
+  
 
   test('delete', async () => {
     nock(mockBaseUrl)

--- a/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.unit.spec.ts
@@ -92,23 +92,23 @@ describe('Data product versions unit test', () => {
         terms: {
           modify: {
             usage: {
-              setNull: true
+              setNull: true,
             },
             limitations: {
-              setNull: true
-            }
-          }
+              setNull: true,
+            },
+          },
         },
         status: { set: 'published' as const },
         views: {
           add: [
             {
-              space: "test-space",
-              externalId: "testExternalId",
-              version: "v1"
-            }
-          ]
-        }
+              space: 'test-space',
+              externalId: 'testExternalId',
+              version: 'v1',
+            },
+          ],
+        },
       },
     };
 
@@ -130,11 +130,11 @@ describe('Data product versions unit test', () => {
             status: 'published',
             views: [
               {
-                space: "test-space",
-                externalId: "testExternalId",
-                version: "v1"
-              }
-            ]
+                space: 'test-space',
+                externalId: 'testExternalId',
+                version: 'v1',
+              },
+            ],
           },
         ],
       });
@@ -147,7 +147,6 @@ describe('Data product versions unit test', () => {
     expect(items[0].description).toEqual('updated description');
     expect(items[0].status).toEqual('published');
   });
-  
 
   test('delete', async () => {
     nock(mockBaseUrl)

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -2,8 +2,12 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClientAlpha from '../../cogniteClient';
-import type { DataProduct } from '../../types';
-import { randomInt, setupLoggedInClient } from '../testUtils';
+import {
+  cleanupDataProductSchemaSpaces,
+  cleanupOrphanedDataProductTestResources,
+  randomInt,
+  setupLoggedInClient,
+} from '../testUtils';
 
 function uniqueSchemaSpace(prefix: string): string {
   return `${prefix}_${randomInt()}`;
@@ -15,10 +19,10 @@ describe('Data products integration test', () => {
   const dataProductExternalId = `int-dataproduct-${dataProductRandom}`;
   const setupSchemaSpace = uniqueSchemaSpace('sdk_js_alpha_dp_int_setup');
   const schemaSpacesToDelete: string[] = [setupSchemaSpace];
-  let createdDataProduct: DataProduct | undefined;
 
   beforeAll(async () => {
     client = setupLoggedInClient();
+    await cleanupOrphanedDataProductTestResources(client);
 
     await client.spaces.upsert([
       {
@@ -28,7 +32,7 @@ describe('Data products integration test', () => {
       },
     ]);
 
-    const items = await client.dataProducts.create([
+    await client.dataProducts.create([
       {
         externalId: dataProductExternalId,
         name: `integration test data product ${dataProductRandom}`,
@@ -37,17 +41,10 @@ describe('Data products integration test', () => {
         tags: ['integration'],
       },
     ]);
-    createdDataProduct = items[0];
   });
 
   afterAll(async () => {
-    if (createdDataProduct) {
-      await client.dataProducts
-        .delete([{ externalId: dataProductExternalId }])
-        .catch();
-    }
-
-    await client.spaces.delete(schemaSpacesToDelete).catch();
+    await cleanupDataProductSchemaSpaces(client, schemaSpacesToDelete);
   });
 
   test('create', async () => {

--- a/packages/alpha/src/__tests__/testUtils.ts
+++ b/packages/alpha/src/__tests__/testUtils.ts
@@ -29,6 +29,84 @@ export function randomInt() {
   return Math.floor(Math.random() * 10000000000);
 }
 
+export const DATA_PRODUCT_TEST_SPACE_PREFIX = 'sdk_js_alpha_dp';
+
+export async function cleanupDataProductSchemaSpaces(
+  client: CogniteClientAlpha,
+  spaces: string[]
+) {
+  const dataProducts = (await client.dataProducts.list({ limit: 100 })).items;
+
+  for (const space of spaces) {
+    const productsInSpace = dataProducts.filter(
+      (product) => product.schemaSpace === space
+    );
+
+    for (const product of productsInSpace) {
+      const versions = await client.dataProductVersions
+        .list(product.externalId, { limit: 10 })
+        .autoPagingToArray();
+
+      if (versions.length > 0) {
+        await client.dataProductVersions
+          .delete(
+            product.externalId,
+            versions.map((version) => ({ version: version.version }))
+          )
+          .catch(() => {});
+      }
+
+      await client.dataProducts
+        .delete([{ externalId: product.externalId }])
+        .catch(() => {});
+    }
+
+    const views = await client.views
+      .list({ limit: 1000, space, allVersions: true })
+      .autoPagingToArray();
+
+    if (views.length > 0) {
+      await client.views
+        .delete(
+          views.map((view) => ({
+            externalId: view.externalId,
+            space: view.space,
+            version: view.version,
+          }))
+        )
+        .catch(() => {});
+    }
+
+    const containers = (await client.containers.list({ limit: 100, space }))
+      .items;
+
+    if (containers.length > 0) {
+      await client.containers
+        .delete(
+          containers.map((container) => ({
+            externalId: container.externalId,
+            space: container.space,
+          }))
+        )
+        .catch(() => {});
+    }
+
+    await client.spaces.delete([space]).catch(() => {});
+  }
+}
+
+export async function cleanupOrphanedDataProductTestResources(
+  client: CogniteClientAlpha
+) {
+  const spaces = (await client.spaces.list({ limit: 100 })).items
+    .filter((space) => space.space.startsWith(DATA_PRODUCT_TEST_SPACE_PREFIX))
+    .map((space) => space.space);
+
+  if (spaces.length > 0) {
+    await cleanupDataProductSchemaSpaces(client, spaces);
+  }
+}
+
 export async function getOrCreateFile(
   client: CogniteClientAlpha,
   dataSetId: number,

--- a/packages/alpha/src/__tests__/testUtils.ts
+++ b/packages/alpha/src/__tests__/testUtils.ts
@@ -35,7 +35,9 @@ export async function cleanupDataProductSchemaSpaces(
   client: CogniteClientAlpha,
   spaces: string[]
 ) {
-  const dataProducts = (await client.dataProducts.list({ limit: 100 })).items;
+  const dataProducts = await client.dataProducts
+    .list({ limit: 100 })
+    .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
 
   for (const space of spaces) {
     const productsInSpace = dataProducts.filter(
@@ -45,7 +47,7 @@ export async function cleanupDataProductSchemaSpaces(
     for (const product of productsInSpace) {
       const versions = await client.dataProductVersions
         .list(product.externalId, { limit: 10 })
-        .autoPagingToArray();
+        .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
 
       if (versions.length > 0) {
         await client.dataProductVersions
@@ -63,7 +65,7 @@ export async function cleanupDataProductSchemaSpaces(
 
     const views = await client.views
       .list({ limit: 1000, space, allVersions: true })
-      .autoPagingToArray();
+      .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
 
     if (views.length > 0) {
       await client.views
@@ -77,8 +79,9 @@ export async function cleanupDataProductSchemaSpaces(
         .catch(() => {});
     }
 
-    const containers = (await client.containers.list({ limit: 100, space }))
-      .items;
+    const containers = await client.containers
+      .list({ limit: 100, space })
+      .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
 
     if (containers.length > 0) {
       await client.containers
@@ -98,7 +101,11 @@ export async function cleanupDataProductSchemaSpaces(
 export async function cleanupOrphanedDataProductTestResources(
   client: CogniteClientAlpha
 ) {
-  const spaces = (await client.spaces.list({ limit: 100 })).items
+  const spaces = (
+    await client.spaces
+      .list({ limit: 1000 })
+      .autoPagingToArray({ limit: Number.POSITIVE_INFINITY })
+  )
     .filter((space) => space.space.startsWith(DATA_PRODUCT_TEST_SPACE_PREFIX))
     .map((space) => space.space);
 

--- a/packages/alpha/src/api/dataProducts/dataProductVersionsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductVersionsApi.ts
@@ -60,10 +60,7 @@ export class DataProductVersionsAPI extends BaseResourceAPI<DataProductVersion> 
     query?: DataProductVersionListQuery
   ): CursorAndAsyncIterator<DataProductVersion> => {
     const path = this.versionsPath(dataProductExternalId);
-    return this.listEndpoint(
-      (params) => this.get(path, { params }),
-      query
-    );
+    return this.listEndpoint((params) => this.get(path, { params }), query);
   };
 
   /**

--- a/packages/alpha/src/api/dataProducts/dataProductVersionsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductVersionsApi.ts
@@ -1,0 +1,132 @@
+// Copyright 2026 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import type {
+  CogniteExternalId,
+  CursorAndAsyncIterator,
+} from '@cognite/sdk-core';
+import type {
+  DataProductVersion,
+  DataProductVersionChange,
+  DataProductVersionCreate,
+  DataProductVersionDelete,
+  DataProductVersionListQuery,
+} from './types';
+
+export class DataProductVersionsAPI extends BaseResourceAPI<DataProductVersion> {
+  /**
+   * @hidden
+   */
+  protected getDateProps() {
+    return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
+  }
+
+  private versionsPath(dataProductExternalId: CogniteExternalId) {
+    return this.url(`${encodeURIComponent(dataProductExternalId)}/versions`);
+  }
+
+  /**
+   * [Create a data product version](https://api-docs.cognite.com/20230101/tag/Data-products/operation/createDataProductVersion)
+   *
+   * ```js
+   * const versions = await client.dataProductVersions.create('my-data-product', [
+   *   {
+   *     version: '1.0.0',
+   *     views: [
+   *       { space: 'my-space', externalId: 'my-view', version: '1' },
+   *     ],
+   *   },
+   * ]);
+   * ```
+   */
+  public create = (
+    dataProductExternalId: CogniteExternalId,
+    items: [DataProductVersionCreate]
+  ): Promise<DataProductVersion[]> => {
+    return this.createEndpoint(items, this.versionsPath(dataProductExternalId));
+  };
+
+  /**
+   * [List data product versions](https://api-docs.cognite.com/20230101/tag/Data-products/operation/listDataProductVersions)
+   *
+   * ```js
+   * const versions = await client.dataProductVersions.list('my-data-product', {
+   *   limit: 10,
+   * });
+   * ```
+   */
+  public list = (
+    dataProductExternalId: CogniteExternalId,
+    query?: DataProductVersionListQuery
+  ): CursorAndAsyncIterator<DataProductVersion> => {
+    const path = this.versionsPath(dataProductExternalId);
+    return this.listEndpoint(
+      (params) => this.get(path, { params }),
+      query
+    );
+  };
+
+  /**
+   * [Get a data product version](https://api-docs.cognite.com/20230101/tag/Data-products/operation/getDataProductVersion)
+   *
+   * ```js
+   * const version = await client.dataProductVersions.retrieve(
+   *   'my-data-product',
+   *   '1.0.0'
+   * );
+   * ```
+   */
+  public retrieve = async (
+    dataProductExternalId: CogniteExternalId,
+    version: string
+  ): Promise<DataProductVersion> => {
+    const path = `${this.versionsPath(dataProductExternalId)}/${encodeURIComponent(version)}`;
+    const response = await this.get<DataProductVersion>(path);
+    return this.addToMapAndReturn(response.data, response);
+  };
+
+  /**
+   * [Update data product version](https://api-docs.cognite.com/20230101/tag/Data-products/operation/updateDataProductVersion)
+   *
+   * ```js
+   * const updated = await client.dataProductVersions.update('my-data-product', [
+   *   {
+   *     version: '1.0.0',
+   *     update: {
+   *       description: { set: 'Updated description' },
+   *       status: { set: 'published' },
+   *     },
+   *   },
+   * ]);
+   * ```
+   */
+  public update = (
+    dataProductExternalId: CogniteExternalId,
+    items: [DataProductVersionChange]
+  ): Promise<DataProductVersion[]> => {
+    return this.updateEndpoint(
+      items,
+      `${this.versionsPath(dataProductExternalId)}/update`
+    );
+  };
+
+  /**
+   * [Delete data product versions](https://api-docs.cognite.com/20230101/tag/Data-products/operation/deleteDataProductVersions)
+   *
+   * ```js
+   * await client.dataProductVersions.delete('my-data-product', [
+   *   { version: '1.0.0' },
+   * ]);
+   * ```
+   */
+  public delete = (
+    dataProductExternalId: CogniteExternalId,
+    ids: DataProductVersionDelete[]
+  ): Promise<object> => {
+    return this.deleteEndpoint(
+      ids,
+      undefined,
+      `${this.versionsPath(dataProductExternalId)}/delete`
+    );
+  };
+}

--- a/packages/alpha/src/api/dataProducts/dataProductVersionsApi.ts
+++ b/packages/alpha/src/api/dataProducts/dataProductVersionsApi.ts
@@ -21,10 +21,6 @@ export class DataProductVersionsAPI extends BaseResourceAPI<DataProductVersion> 
     return this.pickDateProps(['items'], ['createdTime', 'lastUpdatedTime']);
   }
 
-  private versionsPath(dataProductExternalId: CogniteExternalId) {
-    return this.url(`${encodeURIComponent(dataProductExternalId)}/versions`);
-  }
-
   /**
    * [Create a data product version](https://api-docs.cognite.com/20230101/tag/Data-products/operation/createDataProductVersion)
    *
@@ -126,4 +122,8 @@ export class DataProductVersionsAPI extends BaseResourceAPI<DataProductVersion> 
       `${this.versionsPath(dataProductExternalId)}/delete`
     );
   };
+
+  private versionsPath(dataProductExternalId: CogniteExternalId) {
+    return this.url(`${encodeURIComponent(dataProductExternalId)}/versions`);
+  }
 }

--- a/packages/alpha/src/api/dataProducts/types.ts
+++ b/packages/alpha/src/api/dataProducts/types.ts
@@ -47,3 +47,62 @@ export interface DataProductChange extends DataProductDelete {
 export interface DataProductListQuery extends FilterQuery {}
 
 export type DataProductListResponse = ListResponse<DataProduct[]>;
+
+export type DataProductVersionStatus =
+  | 'draft'
+  | 'published'
+  | 'deprecated';
+
+export interface DataProductViewReference {
+  space: string;
+  externalId: string;
+  version: string;
+}
+
+export interface DataProductVersionTerms {
+  usage?: string;
+  limitations?: string;
+}
+
+export interface DataProductVersion {
+  version: string;
+  views: DataProductViewReference[];
+  status: DataProductVersionStatus;
+  description?: string;
+  terms: DataProductVersionTerms;
+  createdTime: Date;
+  lastUpdatedTime: Date;
+}
+
+export interface DataProductVersionCreate {
+  version: string;
+  views: DataProductViewReference[];
+  status?: DataProductVersionStatus;
+  description?: string;
+  terms?: DataProductVersionTerms;
+}
+
+export interface DataProductVersionDelete {
+  version: string;
+}
+
+export interface DataProductVersionTermsPatch {
+  modify?: {
+    usage?: { set: string };
+    limitations?: { set: string };
+  };
+}
+
+export interface DataProductVersionPatch {
+  status?: { set: DataProductVersionStatus };
+  description?: { set: string } | { setNull: boolean };
+  terms?: DataProductVersionTermsPatch;
+  views?: { add: DataProductViewReference[] };
+}
+
+export interface DataProductVersionChange {
+  version: string;
+  update: DataProductVersionPatch;
+}
+
+export interface DataProductVersionListQuery extends FilterQuery {}

--- a/packages/alpha/src/api/dataProducts/types.ts
+++ b/packages/alpha/src/api/dataProducts/types.ts
@@ -48,10 +48,7 @@ export interface DataProductListQuery extends FilterQuery {}
 
 export type DataProductListResponse = ListResponse<DataProduct[]>;
 
-export type DataProductVersionStatus =
-  | 'draft'
-  | 'published'
-  | 'deprecated';
+export type DataProductVersionStatus = 'draft' | 'published' | 'deprecated';
 
 export interface DataProductViewReference {
   space: string;

--- a/packages/alpha/src/api/dataProducts/types.ts
+++ b/packages/alpha/src/api/dataProducts/types.ts
@@ -85,8 +85,8 @@ export interface DataProductVersionDelete {
 
 export interface DataProductVersionTermsPatch {
   modify?: {
-    usage?: { set: string };
-    limitations?: { set: string };
+    usage?: { set: string } | { setNull: boolean };
+    limitations?: { set: string } | { setNull: boolean };
   };
 }
 

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -2,8 +2,8 @@
 import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
 import { accessApi } from '@cognite/sdk-core';
 import { version } from '../package.json';
-import { DataProductsAPI } from './api/dataProducts/dataProductsApi';
 import { DataProductVersionsAPI } from './api/dataProducts/dataProductVersionsApi';
+import { DataProductsAPI } from './api/dataProducts/dataProductsApi';
 import { LimitsAPI } from './api/limits/limitsApi';
 import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -3,6 +3,7 @@ import { CogniteClient as CogniteClientStable } from '@cognite/sdk';
 import { accessApi } from '@cognite/sdk-core';
 import { version } from '../package.json';
 import { DataProductsAPI } from './api/dataProducts/dataProductsApi';
+import { DataProductVersionsAPI } from './api/dataProducts/dataProductVersionsApi';
 import { LimitsAPI } from './api/limits/limitsApi';
 import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
@@ -18,6 +19,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
   private workflowVersionsApi?: WorkflowVersionsAPI;
   private workflowExecutionsApi?: WorkflowExecutionsAPI;
   private dataProductsApi?: DataProductsAPI;
+  private dataProductVersionsApi?: DataProductVersionsAPI;
 
   public get limits() {
     return accessApi(this.limitsApi);
@@ -47,6 +49,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     return accessApi(this.dataProductsApi);
   }
 
+  public get dataProductVersions() {
+    return accessApi(this.dataProductVersionsApi);
+  }
+
   protected initAPIs() {
     super.initAPIs();
 
@@ -61,6 +67,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
       'workflows/versions'
     );
     this.dataProductsApi = this.apiFactory(DataProductsAPI, 'dataproducts');
+    this.dataProductVersionsApi = this.apiFactory(
+      DataProductVersionsAPI,
+      'dataproducts'
+    );
     this.workflowExecutionsApi = new WorkflowExecutionsAPI(
       `${this.projectUrl}/workflows/executions`,
       `${this.projectUrl}/workflows`,

--- a/packages/stable/src/__tests__/testUtils.ts
+++ b/packages/stable/src/__tests__/testUtils.ts
@@ -43,6 +43,7 @@ function setupMockableClient() {
 }
 
 const RECORDS_TEST_SPACE = 'sdk_test_records_space'; // Space reserved for records integration tests
+const DATA_PRODUCT_TEST_SPACE_PREFIX = 'sdk_js_alpha_dp';
 
 const deleteOldSpaces = async (client: CogniteClient) => {
   const fiveMinutesInMs = 5 * 60 * 1000;
@@ -58,7 +59,9 @@ const deleteSpacesNotUpdatedSince = async (
     const spaces = (await client.spaces.list({ limit: 100 })).items;
     const oldSpaces = spaces.filter(
       (space) =>
-        space.lastUpdatedTime < timestamp && space.space !== RECORDS_TEST_SPACE
+        space.lastUpdatedTime < timestamp &&
+        space.space !== RECORDS_TEST_SPACE &&
+        !space.space.startsWith(DATA_PRODUCT_TEST_SPACE_PREFIX)
     );
 
     const spacesList = oldSpaces.map((space) => space.space);

--- a/packages/stable/src/types.ts
+++ b/packages/stable/src/types.ts
@@ -84,6 +84,8 @@ export type AclActionDataSets = READ | WRITE | OWNER;
 
 export type AclActionDataModelInstances = READ | WRITE | WRITE_PROPERTIES;
 
+export type AclActionDataProducts = CREATE | DELETE | READ | UPDATE;
+
 export type AclActionDataModel = READ | WRITE;
 
 export type AclActionEvents = READ | WRITE;
@@ -122,6 +124,8 @@ export type AclDataModelInstances = Acl<
   AclActionDataModelInstances,
   AclScopeDataModelInstances
 >;
+
+export type AclDataProducts = Acl<AclActionDataProducts, AclScopeDataProducts>;
 
 export type AclEvents = Acl<AclActionEvents, AclScopeEvents>;
 
@@ -186,6 +190,14 @@ export interface AclScopeDatasetsIds {
 export type AclScopeDataModel = AclScopeAll | AclScopeSpaceIds;
 
 export type AclScopeDataModelInstances = AclScopeAll | AclScopeSpaceIds;
+
+export interface AclScopeDataProductExternalIds {
+  dataProductScope: {
+    externalIds: CogniteExternalId[];
+  };
+}
+
+export type AclScopeDataProducts = AclScopeAll | AclScopeDataProductExternalIds;
 
 export type AclScopeEvents = AclScopeAll | AclScopeDatasetsIds;
 
@@ -1910,6 +1922,7 @@ export type SingleCogniteCapability =
   | { templateInstancesAcl: AclTemplateInstances }
   | { dataModelAcl: AclDataModel }
   | { dataModelInstancesAcl: AclDataModelInstances }
+  | { dataProductsAcl: AclDataProducts }
   | { sessionsAcl: AclSessions };
 
 export type SinglePatch<T> = { set: T } | { setNull: boolean };


### PR DESCRIPTION
### Summary
Add Data Product Versions API support to @cognite/sdk-alpha

### What’s included

- New dataProductVersions API in alpha client: create, list, retrieve, update, delete
- Data Product Versions types added in alpha
- Unit tests for all CRUD operations
- Integration tests covering lifecycle flows