### PR TITLE
fix(auth): prevent retries on `401` responses when a custom authorization header is present

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -28,9 +28,11 @@ const client = new CogniteClient({
 
 The first invocation of `oidcTokenProvider` will happen after one of these actions:
 1. `client.authenticate()` is called.
-2. The SDK gets a [HTTP 401 status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) response from the Cognite Data Fusion API.
+2. A request using SDK-managed authentication gets a [HTTP 401 status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) response from the Cognite Data Fusion API.
 
-`oidcTokenProvider` may be invoked several times as the access token is short-lived. Whenever the SDK receives a 401, the SDK will call `oidcTokenProvider` to get an updated token. If the new token differs from the token used in the 401 request, then the request will be retried with the new token.
+`oidcTokenProvider` may be invoked several times as the access token is short-lived. Whenever the SDK receives a 401 for a request using SDK-managed authentication, the SDK will call `oidcTokenProvider` to get an updated token. If the new token differs from the token used in the 401 request, then the request will be retried with the new token.
+
+An `Authorization` header supplied in the options for an individual request is caller-owned. If that request receives a 401, the SDK returns the error without calling `oidcTokenProvider` or retrying the request.
 
 ## Accessing different clusters
 

--- a/packages/core/src/__tests__/cogniteClient.unit.spec.ts
+++ b/packages/core/src/__tests__/cogniteClient.unit.spec.ts
@@ -108,6 +108,98 @@ describe('CogniteClient', () => {
         expect(oidcTokenProvider).toHaveBeenCalledTimes(1);
       });
 
+      test('return 401 for a caller-owned per-request token', async () => {
+        nock(mockBaseUrl, {
+          reqheaders: {
+            authorization: 'Bearer expired-token',
+          },
+        })
+          .post('/test')
+          .reply(401, { error: { message: 'unauthorized' } });
+
+        const oidcTokenProvider = vi.fn().mockResolvedValue('refreshed-token');
+        const client = new BaseCogniteClient({
+          project,
+          appId: 'unit-test',
+          baseUrl: mockBaseUrl,
+          oidcTokenProvider,
+        });
+
+        await expect(
+          client.post('/test', {
+            headers: {
+              authorization: 'Bearer expired-token',
+            },
+          })
+        ).rejects.toMatchObject({ status: 401 });
+
+        expect(oidcTokenProvider).not.toHaveBeenCalled();
+      });
+
+      test('do not retry a caller-owned token when already authenticated', async () => {
+        nock(mockBaseUrl, {
+          reqheaders: {
+            [AUTHORIZATION_HEADER]: 'Bearer expired-token',
+          },
+        })
+          .post('/test')
+          .reply(401, { error: { message: 'unauthorized' } });
+
+        const oidcTokenProvider = vi.fn().mockResolvedValue('cached-token');
+        const client = new BaseCogniteClient({
+          project,
+          appId: 'unit-test',
+          baseUrl: mockBaseUrl,
+          oidcTokenProvider,
+        });
+        await client.authenticate();
+
+        await expect(
+          client.post('/test', {
+            headers: {
+              [AUTHORIZATION_HEADER]: 'Bearer expired-token',
+            },
+          })
+        ).rejects.toMatchObject({ status: 401 });
+
+        expect(oidcTokenProvider).toHaveBeenCalledTimes(1);
+      });
+
+      test('refresh an SDK-managed token when already authenticated', async () => {
+        nock(mockBaseUrl, {
+          reqheaders: {
+            [AUTHORIZATION_HEADER]: 'Bearer cached-token',
+          },
+        })
+          .post('/test')
+          .reply(401, { error: { message: 'unauthorized' } });
+        nock(mockBaseUrl, {
+          reqheaders: {
+            [AUTHORIZATION_HEADER]: 'Bearer refreshed-token',
+          },
+        })
+          .post('/test')
+          .reply(200, { body: 'request ok' });
+
+        const oidcTokenProvider = vi
+          .fn()
+          .mockResolvedValueOnce('cached-token')
+          .mockResolvedValueOnce('refreshed-token');
+        const client = new BaseCogniteClient({
+          project,
+          appId: 'unit-test',
+          baseUrl: mockBaseUrl,
+          oidcTokenProvider,
+        });
+        await client.authenticate();
+
+        const result = await client.post('/test');
+
+        expect(result.status).toEqual(200);
+        expect(result.data).toEqual({ body: 'request ok' });
+        expect(oidcTokenProvider).toHaveBeenCalledTimes(2);
+      });
+
       test('ensure deprecated getToken still works', async () => {
         nock(mockBaseUrl)
           .get('/test')

--- a/packages/core/src/httpClient/cdfHttpClient.ts
+++ b/packages/core/src/httpClient/cdfHttpClient.ts
@@ -52,6 +52,13 @@ export class CDFHttpClient extends RetryableHttpClient {
     return filteredHeaders;
   }
 
+  private static hasHeader(headers: HttpHeaders | undefined, name: string) {
+    const lowerCaseName = name.toLowerCase();
+    return Object.keys(headers ?? {}).some(
+      (headerName) => headerName.toLowerCase() === lowerCaseName
+    );
+  }
+
   private oneTimeHeaders: HttpHeaders = {};
 
   public addOneTimeHeader(name: string, value: string) {
@@ -102,7 +109,11 @@ export class CDFHttpClient extends RetryableHttpClient {
       if (!(err instanceof HttpError)) {
         throw err;
       }
-      if (err.status === 401 && !this.isTokenInspect(request.path)) {
+      if (
+        err.status === 401 &&
+        !this.isTokenInspect(request.path) &&
+        !CDFHttpClient.hasHeader(request.headers, AUTHORIZATION_HEADER)
+      ) {
         return new Promise((resolvePromise, rejectPromise) => {
           const retry = () => resolvePromise(this.request(request));
           const reject = () => rejectPromise(err);


### PR DESCRIPTION
## Problem
When a consumer of the `CogniteClient` provide a stale access token in the `Authorization` header of a request, the clien refreshs the token but fails to use it when retrying the request. Since retries on `401` responses are unbounded, this leads to a flood of requests that all fail with `401` (e.g. Infield generating millions of requests to CogIdp over the course of a week as described [here](https://cognitedata.slack.com/archives/C8E1D2NR1/p1783948203102669)).

## Proposed solution
When a consumer specifies a custom, non-SDK managed `Authorization` header, the SDK should refrain from refreshing the access token and retrying the request on its own. Instead, it should transparently pass the `401` response back to the caller as they are the one managing the token.

We should probably also consider limiting the amount of consecutive retries on `401` to avoid hammering the token issuer and downstream service with requests if the retrieved token is invalid for some reason, but that probably warrants its own PR.

## Changes
- Update `CDFHttpClient`'s `postRequest` handler to short-circuit on `401` responses where a caller supplied `Authorization` header is present.
- Reflect the behavior change in the `authenication.md` guide.
- Add tests that assert that
   - `401` responses with custom `Authorization` header are surfaced to the caller.
   - No token refresh is attempted when a custom `Authorization` header is present.
   - SDK-managed token refreshes still work as expected.