### PR TITLE
feat(alpha): add support for workflows triggers

### DIFF
--- a/packages/alpha/package.json
+++ b/packages/alpha/package.json
@@ -11,7 +11,7 @@
     "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts"
   },
-  "version": "0.43.0",
+  "version": "0.42.0",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",

--- a/packages/alpha/package.json
+++ b/packages/alpha/package.json
@@ -11,7 +11,7 @@
     "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts"
   },
-  "version": "0.42.0",
+  "version": "0.43.0",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/ docs/ codeSnippets/",

--- a/packages/alpha/src/__tests__/api/workflowTriggers.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowTriggers.int.spec.ts
@@ -1,0 +1,182 @@
+// Copyright 2026 Cognite AS
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type CogniteClientAlpha from '../../cogniteClient';
+import type {
+  TaskDefinition,
+  Version,
+  Workflow,
+  WorkflowTrigger,
+} from '../../types';
+import { randomInt, setupLoggedInClient } from '../testUtils';
+
+const workflowTasks: TaskDefinition = {
+  externalId: 'int-trigger-task-1',
+  type: 'function',
+  parameters: {
+    function: { externalId: 'int-fn-external-id' },
+  },
+};
+
+describe('Workflow triggers integration test', () => {
+  let client: CogniteClientAlpha;
+  const workflowExternalId = `int-workflow-trigger-${randomInt()}`;
+  const versionExternalId = '1';
+  const triggerExternalId = `int-trigger-${randomInt()}`;
+  let createdWorkflow: Workflow | undefined;
+  let createdVersion: Version | undefined;
+  let createdTrigger: WorkflowTrigger | undefined;
+  let sessionNonce: string;
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+
+    const workflowItems = await client.workflows.upsert([
+      {
+        externalId: workflowExternalId,
+        description: 'integration test workflow for triggers',
+        maxConcurrentExecutions: 1,
+      },
+    ]);
+    createdWorkflow = workflowItems[0];
+
+    const versionItems = await client.workflowVersions.upsert([
+      {
+        workflowExternalId,
+        version: versionExternalId,
+        workflowDefinition: {
+          description: 'integration test workflow version for triggers',
+          tasks: [workflowTasks],
+        },
+      },
+    ]);
+    createdVersion = versionItems[0];
+
+    const clientSecret = process.env.COGNITE_CLIENT_SECRET || '';
+    const clientId = process.env.COGNITE_CLIENT_ID || '';
+    const [session] = await client.sessions.create([
+      {
+        clientId,
+        clientSecret,
+      },
+    ]);
+    sessionNonce = session.nonce;
+
+    const [trigger] = await client.workflowTriggers.upsert([
+      {
+        externalId: triggerExternalId,
+        triggerRule: {
+          triggerType: 'schedule',
+          cronExpression: '0 0 1 1 *',
+          timezone: 'UTC',
+        },
+        workflowExternalId,
+        workflowVersion: versionExternalId,
+        authentication: { nonce: sessionNonce },
+        metadata: { source: 'sdk-int-test' },
+      },
+    ]);
+    createdTrigger = trigger;
+  });
+
+  afterAll(async () => {
+    try {
+      if (createdTrigger) {
+        await client.workflowTriggers
+          .delete([{ externalId: triggerExternalId }])
+          .catch();
+      }
+
+      if (createdVersion) {
+        await client.workflowVersions
+          .delete([
+            {
+              workflowExternalId,
+              version: versionExternalId,
+            },
+          ])
+          .catch();
+      }
+
+      if (createdWorkflow) {
+        await client.workflows
+          .delete([{ externalId: workflowExternalId }])
+          .catch();
+      }
+    } catch (error) {
+      console.error(
+        'Workflow triggers integration test cleanup failed:',
+        error
+      );
+    }
+  });
+
+  test('list', async () => {
+    const response = await client.workflowTriggers.list({ limit: 10 });
+
+    expect(Array.isArray(response.items)).toBe(true);
+  });
+
+  test('upsert updates existing trigger', async () => {
+    const [trigger] = await client.workflowTriggers.upsert([
+      {
+        externalId: triggerExternalId,
+        triggerRule: {
+          triggerType: 'schedule',
+          cronExpression: '0 0 1 1 *',
+          timezone: 'UTC',
+        },
+        workflowExternalId,
+        workflowVersion: versionExternalId,
+        authentication: { nonce: sessionNonce },
+        metadata: { source: 'sdk-int-test-updated' },
+      },
+    ]);
+    createdTrigger = trigger;
+
+    expect(trigger.externalId).toBe(triggerExternalId);
+    expect(trigger.workflowExternalId).toBe(workflowExternalId);
+    expect(trigger.workflowVersion).toBe(versionExternalId);
+    expect(trigger.metadata).toEqual({ source: 'sdk-int-test-updated' });
+  });
+
+  test('pause and resume', async () => {
+    await expect(
+      client.workflowTriggers.pause(triggerExternalId)
+    ).resolves.toBe(undefined);
+    await expect(
+      client.workflowTriggers.resume(triggerExternalId)
+    ).resolves.toBe(undefined);
+  });
+
+  test('history', async () => {
+    const response = await client.workflowTriggers.history(triggerExternalId, {
+      limit: 10,
+    });
+
+    expect(Array.isArray(response.items)).toBe(true);
+  });
+
+  test('delete', async () => {
+    const deleteTriggerExternalId = `int-trigger-delete-${randomInt()}`;
+    const [triggerToDelete] = await client.workflowTriggers.upsert([
+      {
+        externalId: deleteTriggerExternalId,
+        triggerRule: {
+          triggerType: 'schedule',
+          cronExpression: '0 0 1 1 *',
+          timezone: 'UTC',
+        },
+        workflowExternalId,
+        workflowVersion: versionExternalId,
+        authentication: { nonce: sessionNonce },
+      },
+    ]);
+
+    expect(triggerToDelete.externalId).toBe(deleteTriggerExternalId);
+
+    await expect(
+      client.workflowTriggers.delete([{ externalId: deleteTriggerExternalId }])
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/alpha/src/__tests__/api/workflowTriggers.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowTriggers.int.spec.ts
@@ -113,9 +113,18 @@ describe('Workflow triggers integration test', () => {
   });
 
   test('list', async () => {
-    const response = await client.workflowTriggers.list({ limit: 10 });
+    const items = await client.workflowTriggers
+      .list({ limit: 100 })
+      .autoPagingToArray({ limit: 100 });
 
-    expect(Array.isArray(response.items)).toBe(true);
+    expect(Array.isArray(items)).toBe(true);
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        externalId: triggerExternalId,
+        workflowExternalId,
+        workflowVersion: versionExternalId,
+      })
+    );
   });
 
   test('upsert updates existing trigger', async () => {

--- a/packages/alpha/src/__tests__/api/workflowTriggers.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowTriggers.int.spec.ts
@@ -26,7 +26,18 @@ describe('Workflow triggers integration test', () => {
   let createdWorkflow: Workflow | undefined;
   let createdVersion: Version | undefined;
   let createdTrigger: WorkflowTrigger | undefined;
-  let sessionNonce: string;
+
+  const createSessionNonce = async () => {
+    const clientSecret = process.env.COGNITE_CLIENT_SECRET || '';
+    const clientId = process.env.COGNITE_CLIENT_ID || '';
+    const [session] = await client.sessions.create([
+      {
+        clientId,
+        clientSecret,
+      },
+    ]);
+    return session.nonce;
+  };
 
   beforeAll(async () => {
     client = setupLoggedInClient();
@@ -52,16 +63,6 @@ describe('Workflow triggers integration test', () => {
     ]);
     createdVersion = versionItems[0];
 
-    const clientSecret = process.env.COGNITE_CLIENT_SECRET || '';
-    const clientId = process.env.COGNITE_CLIENT_ID || '';
-    const [session] = await client.sessions.create([
-      {
-        clientId,
-        clientSecret,
-      },
-    ]);
-    sessionNonce = session.nonce;
-
     const [trigger] = await client.workflowTriggers.upsert([
       {
         externalId: triggerExternalId,
@@ -72,7 +73,7 @@ describe('Workflow triggers integration test', () => {
         },
         workflowExternalId,
         workflowVersion: versionExternalId,
-        authentication: { nonce: sessionNonce },
+        authentication: { nonce: await createSessionNonce() },
         metadata: { source: 'sdk-int-test' },
       },
     ]);
@@ -128,7 +129,7 @@ describe('Workflow triggers integration test', () => {
         },
         workflowExternalId,
         workflowVersion: versionExternalId,
-        authentication: { nonce: sessionNonce },
+        authentication: { nonce: await createSessionNonce() },
         metadata: { source: 'sdk-int-test-updated' },
       },
     ]);
@@ -169,7 +170,7 @@ describe('Workflow triggers integration test', () => {
         },
         workflowExternalId,
         workflowVersion: versionExternalId,
-        authentication: { nonce: sessionNonce },
+        authentication: { nonce: await createSessionNonce() },
       },
     ]);
 

--- a/packages/alpha/src/__tests__/api/workflowTriggers.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowTriggers.unit.spec.ts
@@ -1,0 +1,140 @@
+// Copyright 2026 Cognite AS
+
+import matches from 'lodash/matches';
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { mockBaseUrl } from '../../../../core/src/__tests__/testUtils';
+import type CogniteClientAlpha from '../../cogniteClient';
+import { setupMockableClient } from '../testUtils';
+
+describe('Workflow triggers unit test', () => {
+  let client: CogniteClientAlpha;
+
+  const triggerUpsertBody = {
+    externalId: 'trigger-1',
+    triggerRule: {
+      triggerType: 'schedule' as const,
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+    },
+    workflowExternalId: 'wf-1',
+    workflowVersion: '1',
+    authentication: { nonce: 'session-nonce' },
+    input: { key: 'value' },
+    metadata: { source: 'sdk-test' },
+  };
+
+  const mockTrigger = {
+    externalId: triggerUpsertBody.externalId,
+    triggerRule: triggerUpsertBody.triggerRule,
+    workflowExternalId: triggerUpsertBody.workflowExternalId,
+    workflowVersion: triggerUpsertBody.workflowVersion,
+    input: triggerUpsertBody.input,
+    metadata: triggerUpsertBody.metadata,
+    createdTime: 1716900000000,
+    lastUpdatedTime: 1716900001000,
+    isPaused: false,
+  };
+
+  const mockTriggerRun = {
+    fireTime: 1716900002000,
+    externalId: 'trigger-1',
+    workflowExternalId: 'wf-1',
+    workflowVersion: '1',
+    status: 'success' as const,
+    workflowExecutionId: '550e8400-e29b-41d4-a716-446655440000',
+    reasonForFailure: null,
+  };
+
+  beforeEach(() => {
+    client = setupMockableClient();
+    nock.cleanAll();
+  });
+
+  test('list', async () => {
+    nock(mockBaseUrl)
+      .get(/\/workflows\/triggers\/?$/)
+      .query({ limit: '10', cursor: 'abc' })
+      .once()
+      .reply(200, {
+        items: [mockTrigger],
+        nextCursor: 'next',
+      });
+
+    const response = await client.workflowTriggers.list({
+      limit: 10,
+      cursor: 'abc',
+    });
+
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].externalId).toBe('trigger-1');
+    expect(response.items[0].triggerRule.triggerType).toBe('schedule');
+    expect(response.nextCursor).toBe('next');
+  });
+
+  test('upsert', async () => {
+    nock(mockBaseUrl)
+      .post(/\/workflows\/triggers$/, matches({ items: [triggerUpsertBody] }))
+      .once()
+      .reply(200, {
+        items: [mockTrigger],
+      });
+
+    const items = await client.workflowTriggers.upsert([triggerUpsertBody]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].externalId).toEqual('trigger-1');
+    expect(items[0].workflowExternalId).toEqual('wf-1');
+    expect(items[0].isPaused).toEqual(false);
+  });
+
+  test('delete', async () => {
+    nock(mockBaseUrl)
+      .post(/\/workflows\/triggers\/delete/, {
+        items: [{ externalId: 'trigger-1' }],
+      })
+      .once()
+      .reply(200, {});
+
+    await client.workflowTriggers.delete([{ externalId: 'trigger-1' }]);
+  });
+
+  test('pause', async () => {
+    nock(mockBaseUrl)
+      .post(/\/workflows\/triggers\/trigger-1\/pause$/)
+      .once()
+      .reply(200, {});
+
+    await client.workflowTriggers.pause('trigger-1');
+  });
+
+  test('resume', async () => {
+    nock(mockBaseUrl)
+      .post(/\/workflows\/triggers\/trigger-1\/resume$/)
+      .once()
+      .reply(200, {});
+
+    await client.workflowTriggers.resume('trigger-1');
+  });
+
+  test('history', async () => {
+    nock(mockBaseUrl)
+      .get(/\/workflows\/triggers\/trigger-1\/history$/)
+      .query({ limit: '10', cursor: 'abc' })
+      .once()
+      .reply(200, {
+        items: [mockTriggerRun],
+        nextCursor: 'next',
+      });
+
+    const response = await client.workflowTriggers.history('trigger-1', {
+      limit: 10,
+      cursor: 'abc',
+    });
+
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].externalId).toBe('trigger-1');
+    expect(response.items[0].status).toBe('success');
+    expect(response.nextCursor).toBe('next');
+  });
+});

--- a/packages/alpha/src/__tests__/api/workflowTriggers.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowTriggers.unit.spec.ts
@@ -10,7 +10,7 @@ import { setupMockableClient } from '../testUtils';
 describe('Workflow triggers unit test', () => {
   let client: CogniteClientAlpha;
 
-  const triggerUpsertBody = {
+  const triggerBase = {
     externalId: 'trigger-1',
     triggerRule: {
       triggerType: 'schedule' as const,
@@ -19,16 +19,17 @@ describe('Workflow triggers unit test', () => {
     },
     workflowExternalId: 'wf-1',
     workflowVersion: '1',
-    authentication: { nonce: 'session-nonce' },
     input: { key: 'value' },
     metadata: { source: 'sdk-test' },
   };
 
-  const { authentication: _authentication, ...triggerResponseBody } =
-    triggerUpsertBody;
+  const triggerUpsertBody = {
+    ...triggerBase,
+    authentication: { nonce: 'session-nonce' },
+  };
 
   const mockTrigger = {
-    ...triggerResponseBody,
+    ...triggerBase,
     createdTime: 1716900000000,
     lastUpdatedTime: 1716900001000,
     isPaused: false,

--- a/packages/alpha/src/__tests__/api/workflowTriggers.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflowTriggers.unit.spec.ts
@@ -24,13 +24,11 @@ describe('Workflow triggers unit test', () => {
     metadata: { source: 'sdk-test' },
   };
 
+  const { authentication: _authentication, ...triggerResponseBody } =
+    triggerUpsertBody;
+
   const mockTrigger = {
-    externalId: triggerUpsertBody.externalId,
-    triggerRule: triggerUpsertBody.triggerRule,
-    workflowExternalId: triggerUpsertBody.workflowExternalId,
-    workflowVersion: triggerUpsertBody.workflowVersion,
-    input: triggerUpsertBody.input,
-    metadata: triggerUpsertBody.metadata,
+    ...triggerResponseBody,
     createdTime: 1716900000000,
     lastUpdatedTime: 1716900001000,
     isPaused: false,

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -312,3 +312,107 @@ export interface WorkflowExecutionRetryRequest {
 export interface WorkflowExecutionCancelRequest {
   reason?: string;
 }
+
+export interface WorkflowTriggerExternalId {
+  externalId: CogniteExternalId;
+}
+
+export interface WorkflowTriggerAuthentication {
+  nonce: string;
+}
+
+export interface ManualWorkflowTriggerRule {
+  triggerType: 'manual';
+}
+
+export interface ScheduleWorkflowTriggerRule {
+  triggerType: 'schedule';
+  cronExpression: string;
+  timezone?: string;
+}
+
+export interface DataModelingWorkflowTriggerRule {
+  triggerType: 'dataModeling';
+  dataModelingQuery: {
+    with: Record<string, unknown>;
+    select: Record<string, unknown>;
+  };
+  batchSize: number;
+  batchTimeout: number;
+}
+
+export interface RecordStreamWorkflowTriggerRule {
+  triggerType: 'recordStream';
+  streamExternalId: string;
+  batchSize: number;
+  batchTimeout: number;
+  filter?: JsonValue;
+  sources?: JsonValue;
+  initializeCursor?: string | null;
+}
+
+export type WorkflowTriggerRule =
+  | ManualWorkflowTriggerRule
+  | ScheduleWorkflowTriggerRule
+  | DataModelingWorkflowTriggerRule
+  | RecordStreamWorkflowTriggerRule;
+
+export type WorkflowTriggerUpsertRule = Exclude<
+  WorkflowTriggerRule,
+  ManualWorkflowTriggerRule
+>;
+
+interface WorkflowTriggerRequestBase<Rule extends WorkflowTriggerRule> {
+  externalId: CogniteExternalId;
+  triggerRule: Rule;
+  workflowExternalId: CogniteExternalId;
+  workflowVersion: string;
+  authentication: WorkflowTriggerAuthentication;
+  input?: Record<string, JsonValue>;
+  metadata?: Record<string, string>;
+}
+
+interface WorkflowTriggerBase<Rule extends WorkflowTriggerRule> {
+  externalId: CogniteExternalId;
+  triggerRule: Rule;
+  workflowExternalId: CogniteExternalId;
+  workflowVersion: string;
+  input?: Record<string, JsonValue>;
+  metadata?: Record<string, string>;
+  createdTime?: number;
+  lastUpdatedTime?: number;
+  isPaused?: boolean;
+}
+
+export type ManualWorkflowTrigger =
+  WorkflowTriggerBase<ManualWorkflowTriggerRule>;
+
+export type ScheduleWorkflowTrigger =
+  WorkflowTriggerBase<ScheduleWorkflowTriggerRule>;
+
+export type DataModelingWorkflowTrigger =
+  WorkflowTriggerBase<DataModelingWorkflowTriggerRule>;
+
+export type RecordStreamWorkflowTrigger =
+  WorkflowTriggerBase<RecordStreamWorkflowTriggerRule>;
+
+export type WorkflowTrigger =
+  | ManualWorkflowTrigger
+  | ScheduleWorkflowTrigger
+  | DataModelingWorkflowTrigger
+  | RecordStreamWorkflowTrigger;
+
+export type WorkflowTriggerUpsert =
+  WorkflowTriggerRequestBase<WorkflowTriggerUpsertRule>;
+
+export type WorkflowTriggerRunStatus = 'success' | 'failed';
+
+export interface WorkflowTriggerRun {
+  fireTime: number;
+  externalId: CogniteExternalId;
+  workflowExternalId: CogniteExternalId;
+  workflowVersion: string;
+  status: WorkflowTriggerRunStatus;
+  workflowExecutionId?: string | null;
+  reasonForFailure?: string | null;
+}

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -295,18 +295,18 @@ export interface WorkflowExecutionFilterQuery extends FilterQuery {
   filter?: WorkflowExecutionFilter;
 }
 
-export interface WorkflowExecutionAuthentication {
+export interface WorkflowAuthentication {
   nonce: string;
 }
 
 export interface WorkflowExecutionRunRequest {
-  authentication: WorkflowExecutionAuthentication;
+  authentication: WorkflowAuthentication;
   input?: Record<string, JsonValue>;
   metadata?: Record<string, string>;
 }
 
 export interface WorkflowExecutionRetryRequest {
-  authentication: WorkflowExecutionAuthentication;
+  authentication: WorkflowAuthentication;
 }
 
 export interface WorkflowExecutionCancelRequest {
@@ -315,10 +315,6 @@ export interface WorkflowExecutionCancelRequest {
 
 export interface WorkflowTriggerExternalId {
   externalId: CogniteExternalId;
-}
-
-export interface WorkflowTriggerAuthentication {
-  nonce: string;
 }
 
 export interface ManualWorkflowTriggerRule {
@@ -367,7 +363,7 @@ interface WorkflowTriggerRequestBase<Rule extends WorkflowTriggerRule> {
   triggerRule: Rule;
   workflowExternalId: CogniteExternalId;
   workflowVersion: string;
-  authentication: WorkflowTriggerAuthentication;
+  authentication: WorkflowAuthentication;
   input?: Record<string, JsonValue>;
   metadata?: Record<string, string>;
 }

--- a/packages/alpha/src/api/workflows/workflowTriggersApi.ts
+++ b/packages/alpha/src/api/workflows/workflowTriggersApi.ts
@@ -1,0 +1,105 @@
+// Copyright 2026 Cognite AS
+
+import { BaseResourceAPI } from '@cognite/sdk-core';
+import type {
+  CogniteExternalId,
+  CursorAndAsyncIterator,
+  CursorResponse,
+  FilterQuery,
+} from '@cognite/sdk-core';
+import type {
+  WorkflowTrigger,
+  WorkflowTriggerExternalId,
+  WorkflowTriggerRun,
+  WorkflowTriggerUpsert,
+} from './types';
+
+export class WorkflowTriggersAPI extends BaseResourceAPI<WorkflowTrigger> {
+  /**
+   * [List workflow triggers](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-triggers/operation/ListTriggers)
+   *
+   * ```js
+   * const triggers = await client.workflowTriggers.list({ limit: 10 });
+   * ```
+   */
+  public list = (
+    query?: FilterQuery
+  ): CursorAndAsyncIterator<WorkflowTrigger> => {
+    return this.listEndpoint(this.callListEndpointWithGet, query);
+  };
+
+  /**
+   * [Create or update workflow triggers](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-triggers/operation/CreateOrUpdateTriggers)
+   *
+   * ```js
+   * const triggers = await client.workflowTriggers.upsert([
+   *   {
+   *     externalId: 'my-trigger',
+   *     triggerRule: { triggerType: 'schedule', cronExpression: '0 * * * *' },
+   *     workflowExternalId: 'my-workflow',
+   *     workflowVersion: '1',
+   *     authentication: { nonce: 'session-nonce' },
+   *   },
+   * ]);
+   * ```
+   */
+  public upsert = (
+    items: WorkflowTriggerUpsert[]
+  ): Promise<WorkflowTrigger[]> => {
+    return this.createEndpoint(items, this.url());
+  };
+
+  /**
+   * [Delete workflow triggers](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-triggers/operation/DeleteTriggers)
+   *
+   * ```js
+   * await client.workflowTriggers.delete([{ externalId: 'my-trigger' }]);
+   * ```
+   */
+  public delete = (ids: WorkflowTriggerExternalId[]) => {
+    return this.deleteEndpoint(ids);
+  };
+
+  /**
+   * [Pause a workflow trigger](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-triggers/operation/PauseTrigger)
+   *
+   * ```js
+   * await client.workflowTriggers.pause('my-trigger');
+   * ```
+   */
+  public pause = async (externalId: CogniteExternalId): Promise<void> => {
+    await this.post(this.url(`${encodeURIComponent(externalId)}/pause`));
+  };
+
+  /**
+   * [Resume a workflow trigger](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-triggers/operation/ResumeTrigger)
+   *
+   * ```js
+   * await client.workflowTriggers.resume('my-trigger');
+   * ```
+   */
+  public resume = async (externalId: CogniteExternalId): Promise<void> => {
+    await this.post(this.url(`${encodeURIComponent(externalId)}/resume`));
+  };
+
+  /**
+   * [Get the run history of a workflow trigger](https://api-docs.cognite.com/20230101-alpha/tag/Workflow-triggers/operation/GetTriggerHistory)
+   *
+   * ```js
+   * const runs = await client.workflowTriggers.history('my-trigger', { limit: 10 });
+   * ```
+   */
+  public history = (
+    externalId: CogniteExternalId,
+    query?: FilterQuery
+  ): CursorAndAsyncIterator<WorkflowTriggerRun> => {
+    return this.cursorBasedEndpoint<FilterQuery, WorkflowTriggerRun>(
+      (scope?: FilterQuery) =>
+        this.get<CursorResponse<WorkflowTriggerRun[]>>(
+          this.url(`${encodeURIComponent(externalId)}/history`),
+          { params: scope }
+        ),
+      query
+    );
+  };
+}

--- a/packages/alpha/src/cogniteClient.ts
+++ b/packages/alpha/src/cogniteClient.ts
@@ -8,6 +8,7 @@ import { LimitsAPI } from './api/limits/limitsApi';
 import { MeteringAPI } from './api/metering/meteringApi';
 import { SimulatorsAPI } from './api/simulators/simulatorsApi';
 import { WorkflowExecutionsAPI } from './api/workflows/workflowExecutionsApi';
+import { WorkflowTriggersAPI } from './api/workflows/workflowTriggersApi';
 import { WorkflowVersionsAPI } from './api/workflows/workflowVersionsApi';
 import { WorkflowsAPI } from './api/workflows/workflowsApi';
 
@@ -18,6 +19,7 @@ export default class CogniteClientAlpha extends CogniteClientStable {
   private workflowsApi?: WorkflowsAPI;
   private workflowVersionsApi?: WorkflowVersionsAPI;
   private workflowExecutionsApi?: WorkflowExecutionsAPI;
+  private workflowTriggersApi?: WorkflowTriggersAPI;
   private dataProductsApi?: DataProductsAPI;
   private dataProductVersionsApi?: DataProductVersionsAPI;
 
@@ -45,6 +47,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     return accessApi(this.workflowExecutionsApi);
   }
 
+  public get workflowTriggers() {
+    return accessApi(this.workflowTriggersApi);
+  }
+
   public get dataProducts() {
     return accessApi(this.dataProductsApi);
   }
@@ -65,6 +71,10 @@ export default class CogniteClientAlpha extends CogniteClientStable {
     this.workflowVersionsApi = this.apiFactory(
       WorkflowVersionsAPI,
       'workflows/versions'
+    );
+    this.workflowTriggersApi = this.apiFactory(
+      WorkflowTriggersAPI,
+      'workflows/triggers'
     );
     this.dataProductsApi = this.apiFactory(DataProductsAPI, 'dataproducts');
     this.dataProductVersionsApi = this.apiFactory(


### PR DESCRIPTION
## Summary
- Add `client.workflowTriggers` to the alpha SDK.
- Support workflow trigger `list`, `upsert`, `delete`, `pause`, `resume`, and `history` endpoints.
- Export workflow trigger request/response types aligned with the API docs and Fusion usage.
- Add unit and integration tests for workflow trigger operations.

## Test plan
- [x] `yarn workspace @cognite/sdk-alpha test src/__tests__/api/workflowTriggers.unit.spec.ts`
- [x] `yarn workspace @cognite/sdk-alpha lint`
- [x] `yarn workspace @cognite/sdk-alpha build`
- [ ] `yarn workspace @cognite/sdk-alpha test src/__tests__/api/workflowTriggers.int.spec.ts` requires `COGNITE_PROJECT` and integration credentials