### PR TITLE
feat(instances): Strategy B – make query() conditionally typed (non-breaking alternative to queryTyped)

### DIFF
--- a/packages/stable/src/__tests__/types/instances/query.spec.ts
+++ b/packages/stable/src/__tests__/types/instances/query.spec.ts
@@ -10,7 +10,7 @@ import type {
   RawPropertyValueV3,
 } from '../../../types';
 
-describe('queryNodesEdges type tests', () => {
+describe('queryNodesEdges type tests (queryTyped – kept for back-compat)', () => {
   test('query result keys should match const query select keys', () => {
     type QueryResultSelectKeys = keyof Awaited<
       ReturnType<typeof InstancesAPI.prototype.queryTyped<typeof testQuery>>
@@ -104,6 +104,56 @@ describe('queryNodesEdges type tests', () => {
     >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
 
     expectTypeOf<ResultSourceSpaces>().toEqualTypeOf<
+      Record<string, RawPropertyValueV3>
+    >();
+  });
+});
+
+describe('query() Strategy B – conditional return type', () => {
+  test('plain QueryRequest call returns QueryResponse (backward-compatible)', () => {
+    type Result = Awaited<
+      ReturnType<typeof InstancesAPI.prototype.query<QueryRequest>>
+    >;
+
+    expectTypeOf<Result>().toEqualTypeOf<QueryResponse>();
+  });
+
+  test('const query select keys are preserved in result items', () => {
+    type QueryResultSelectKeys = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.query<typeof testQuery>>
+    >['items'];
+
+    expectTypeOf<QueryResultSelectKeys>().toEqualTypeOf<
+      keyof typeof testQuery.select
+    >();
+  });
+
+  test('source spaces are inferred from const query', () => {
+    type ResultSourceSpaces = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.query<typeof testQuery>>
+    >['items']['resultExpressionA'][number]['properties'];
+
+    type QueryResultSpaces =
+      (typeof testQuery.select.resultExpressionA.sources)[number]['source']['space'];
+    expectTypeOf<ResultSourceSpaces>().toEqualTypeOf<QueryResultSpaces>();
+  });
+
+  test('property keys of result match property keys of const sources', () => {
+    type ResultPropertiesA = keyof Awaited<
+      ReturnType<typeof InstancesAPI.prototype.query<typeof testQuery>>
+    >['items']['resultExpressionA'][number]['properties']['spaceA']['externalIdA/v1'];
+
+    expectTypeOf<ResultPropertiesA>().toEqualTypeOf<
+      (typeof testQuery.select.resultExpressionA.sources)[0]['properties'][number]
+    >();
+  });
+
+  test('wildcard property (*) falls back to Record<string, RawPropertyValueV3>', () => {
+    type ResultWildcard = Awaited<
+      ReturnType<typeof InstancesAPI.prototype.query<typeof testQuery>>
+    >['items']['resultExpressionB'][number]['properties']['spaceD']['externalIdD/v1'];
+
+    expectTypeOf<ResultWildcard>().toEqualTypeOf<
       Record<string, RawPropertyValueV3>
     >();
   });

--- a/packages/stable/src/api/instances/instancesApi.ts
+++ b/packages/stable/src/api/instances/instancesApi.ts
@@ -218,7 +218,14 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
   /**
    * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent)
    *
+   * When called with a plain `QueryRequest` the return type is `QueryResponse`
+   * (fully backward-compatible). When the query is declared with
+   * `as const satisfies QueryRequest` the return type is automatically narrowed
+   * to `QueryResult<typeof query>`, giving full TypeScript inference for result
+   * keys, source spaces, view identifiers and individual property names.
+   *
    * ```js
+   *  // Untyped – same as before
    *  const response = await client.instances.query({
    *     with: {
    *       result_set_1: {
@@ -236,37 +243,46 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
    *       result_set_1: {},
    *     },
    *   });
-   * ```
-   */
-  public query = async (params: QueryRequest): Promise<QueryResponse> => {
-    const response = await this.post<QueryResponse>(this.url('query'), {
-      data: params,
-    });
-    return response.data;
-  };
-
-  /**
-   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types. Declare params as const satisfies QueryRequest for fully typed results per select key, space and property name.
    *
-   * ```js
-   *
+   *  // Typed – declare the query as const satisfies QueryRequest
    *  const query = {
    *    with: {
-   *      result_set_1: {
-   *        nodes: {},
-   *      },
+   *      result_set_1: { nodes: {} },
    *    },
    *    select: {
    *      result_set_1: {
    *        sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }],
    *      },
    *    },
-   *  } as const satisfies QueryRequest
-   *  const typedResponse = await client.instances.queryTyped(query);
-   *  // For fully typed results, declare the query variable as:
-   *  // const query = { ... } as const satisfies QueryRequest;
-   *  // then: typedResponse.items.result_set_1[0].properties.mySpace['MyView/v1'].name
+   *  } as const satisfies QueryRequest;
+   *  const typedResponse = await client.instances.query(query);
+   *  // typedResponse.items.result_set_1[0].properties.mySpace['MyView/v1'].name
    * ```
+   */
+  public query = async <
+    TQueryRequest extends QueryRequest = QueryRequest,
+    TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams,
+  >(
+    params: TQueryRequest
+  ): Promise<
+    QueryRequest extends TQueryRequest
+      ? QueryResponse
+      : QueryResult<TQueryRequest, TypedSelectSources>
+  > => {
+    const response = await this.post<
+      QueryRequest extends TQueryRequest
+        ? QueryResponse
+        : QueryResult<TQueryRequest, TypedSelectSources>
+    >(this.url('query'), { data: params });
+    return response.data;
+  };
+
+  /**
+   * @deprecated Use `query` instead. When the query is declared as
+   * `as const satisfies QueryRequest`, `query` automatically returns a fully
+   * typed `QueryResult` — no separate method needed.
+   *
+   * [Query instances](https://developer.cognite.com/api#tag/Instances/operation/queryContent) with inferred return types.
    */
   public queryTyped = async <
     TQueryRequest extends QueryRequest,
@@ -274,10 +290,9 @@ export class InstancesAPI extends BaseResourceAPI<NodeOrEdge> {
   >(
     params: TQueryRequest
   ): Promise<QueryResult<TQueryRequest, TypedSelectSources>> => {
-    const response = await this.post<
+    return this.query<TQueryRequest, TypedSelectSources>(params) as Promise<
       QueryResult<TQueryRequest, TypedSelectSources>
-    >(this.url('query'), { data: params });
-    return response.data;
+    >;
   };
 
   /**


### PR DESCRIPTION
## Context

This is a draft proposal in response to the review comment on #1445 ([discussion_r3639230433](https://github.com/cognitedata/cognite-sdk-js/pull/1445#discussion_r3639230433)), which pointed back to the non-breaking **Strategy B** originally described in #1444.

The question: *can we avoid having two separate methods (`query` + `queryTyped`)?*

## What this PR does

Adopts **Strategy B**: the existing `instances.query()` method is upgraded with a conditional generic return type so it works for both the typed and untyped cases — no rename, no extra method needed.

### Conditional return type

```ts
public query = async <
  TQueryRequest extends QueryRequest = QueryRequest,
  TypedSelectSources extends SelectSourceWithParams = SelectSourceWithParams,
>(
  params: TQueryRequest
): Promise<
  QueryRequest extends TQueryRequest          // plain / untyped call?
    ? QueryResponse                           //  → same as today ✅
    : QueryResult<TQueryRequest, TypedSelectSources>  // → fully inferred ✅
>
```

### Usage

```ts
// ① Backward-compatible — returns QueryResponse, same as before
const response = await client.instances.query(looseParams);

// ② Typed — declare query as const satisfies QueryRequest
const query = {
  with: { result_set_1: { nodes: {} } },
  select: {
    result_set_1: {
      sources: [{ source: { type: 'view', space: 'mySpace', externalId: 'MyView', version: 'v1' }, properties: ['name', 'age'] }],
    },
  },
} as const satisfies QueryRequest;

const typedResponse = await client.instances.query(query);
// typedResponse.items.result_set_1[0].properties.mySpace['MyView/v1'].name  ← fully typed
```

## Changes

| File | Change |
|---|---|
| `instancesApi.ts` | `query()` becomes generic with conditional return type; `queryTyped` marked `@deprecated` (delegates to `query`) |
| `query.spec.ts` | Existing `queryTyped` tests unchanged; new `query()` Strategy-B test suite added |

## Trade-offs (same as #1444)

**Pro:** Single method, no rename, callers get types automatically with `as const`; `queryTyped` remains available for gradual migration.

**Con:** Conditional return types can sometimes confuse editor tooltips or less common type-checkers — worth validating in the team's typical tooling.

## Tests

All 22 type-level tests pass (`vitest run`).

Made with [Cursor](https://cursor.com)