### PR TITLE
feat(workflows): add dataDomainExternalId to Workflow and WorkflowUpsert types

### DIFF
--- a/packages/alpha/src/__tests__/api/workflows.unit.spec.ts
+++ b/packages/alpha/src/__tests__/api/workflows.unit.spec.ts
@@ -57,12 +57,13 @@ describe('Workflows unit test', () => {
     expect(response.externalId).toEqual('wf-2');
   });
 
-  test('upsert forwards maxConcurrentExecutions and dataSetId', async () => {
+  test('upsert forwards maxConcurrentExecutions, dataSetId, and dataDomainExternalId', async () => {
     const upsertBody = {
       externalId: 'wf-1',
       description: 'd',
       dataSetId: 42,
       maxConcurrentExecutions: 5,
+      dataDomainExternalId: 'my-data-domain',
     };
     nock(mockBaseUrl)
       .post(/\/workflows$/, matches({ items: [upsertBody] }))
@@ -73,6 +74,7 @@ describe('Workflows unit test', () => {
             ...mockWorkflow,
             externalId: upsertBody.externalId,
             maxConcurrentExecutions: upsertBody.maxConcurrentExecutions,
+            dataDomainExternalId: upsertBody.dataDomainExternalId,
           },
         ],
       });
@@ -82,6 +84,7 @@ describe('Workflows unit test', () => {
     expect(items).toHaveLength(1);
     expect(items[0].externalId).toEqual('wf-1');
     expect(items[0].maxConcurrentExecutions).toEqual(5);
+    expect(items[0].dataDomainExternalId).toEqual('my-data-domain');
   });
 
   test('delete', async () => {

--- a/packages/alpha/src/api/workflows/types.ts
+++ b/packages/alpha/src/api/workflows/types.ts
@@ -11,6 +11,7 @@ export interface Workflow {
   description?: string;
   dataSetId?: CogniteInternalId;
   maxConcurrentExecutions?: number;
+  dataDomainExternalId?: CogniteExternalId;
   createdTime?: number;
   lastUpdatedTime: number;
 }
@@ -20,6 +21,7 @@ export interface WorkflowUpsert {
   description?: string;
   dataSetId?: CogniteInternalId;
   maxConcurrentExecutions?: number;
+  dataDomainExternalId?: CogniteExternalId;
 }
 
 export interface WorkflowExternalId {

--- a/packages/alpha/src/api/workflows/workflowsApi.ts
+++ b/packages/alpha/src/api/workflows/workflowsApi.ts
@@ -41,7 +41,12 @@ export class WorkflowsAPI extends BaseResourceAPI<Workflow> {
    *
    * ```js
    * const workflows = await client.workflows.upsert([
-   *   { externalId: 'my-workflow', description: 'Demo', maxConcurrentExecutions: 2 },
+   *   {
+   *     externalId: 'my-workflow',
+   *     description: 'Demo',
+   *     maxConcurrentExecutions: 2,
+   *     dataDomainExternalId: 'my-data-domain',
+   *   },
    * ]);
    * ```
    */


### PR DESCRIPTION
This PR extends the alpha Workflows API types so clients can associate workflows with a data domain when creating or updating them. The optional dataDomainExternalId field is added to both the Workflow response type and the WorkflowUpsert request type, aligning the SDK with the backend’s support for data domain linkage on workflow resources. The JSDoc example for upsert is updated to show how to pass dataDomainExternalId, and the unit tests are updated