### PR TITLE
test(stable): apply the intended vitest timeouts

### DIFF
--- a/packages/stable/vite.config.js
+++ b/packages/stable/vite.config.js
@@ -5,6 +5,16 @@ import dts from 'vite-plugin-dts';
 const externals = ['@cognite/sdk-core', 'geojson', 'lodash'];
 
 export default defineConfig({
+  test: {
+    // vitest's defaults (5s/10s) are too tight for the integration tests, which
+    // wait on eventually consistent CDF endpoints. `vi.setConfig` cannot supply
+    // these: it does not apply to a test that has already started, so calls from
+    // `beforeAll` or from inside a test body are silently ignored. These are the
+    // values vitest.workspace.js already declares, which the per-package test
+    // runs (lerna runs vitest from each package directory) never pick up.
+    testTimeout: 25_000,
+    hookTimeout: 30_000,
+  },
   plugins: [
     dts({
       exclude: ['**/__tests__/**/*', '**/*.spec.ts'],


### PR DESCRIPTION
This PR gives `@cognite/sdk` the vitest timeouts it was always meant to have. The package has no `test` config, so vitest's defaults (5s per test, 10s per hook) applied, and integration tests that poll eventually consistent CDF endpoints were cut off after 5s no matter how patient their retry logic was.

## Why the existing timeouts never applied

Three things look like they set a longer timeout, and none of them reach these tests:

- `vitest.workspace.js` declares `testTimeout: 25_000` / `hookTimeout: 30_000`, but `yarn test` goes through lerna, which runs vitest from each package directory — the root workspace file is never loaded.
- `setupLoggedInClient()` calls `vi.setConfig({ testTimeout: 25 * 1000 })` from `beforeAll`.
- `runTestWithRetryWhenFailing()` calls `vi.setConfig({ testTimeout: 3 * 60 * 1000 })` from inside the test body.

`vi.setConfig` does not apply to a test that has already started, so the last two are silently ignored. Verified with a scratch spec: a test sleeping 8s, with `vi.setConfig({ testTimeout: 25_000 })` in `beforeAll`, still failed with `Test timed out in 5000ms`. With this change it passes.

The values here are the ones `vitest.workspace.js` already declares, so this is the intended configuration rather than a new policy.

## Effect

`files.int.spec.ts > retrieve by instance id` has been failing on master with `Test timed out in 5000ms` — see the last run on `e52838e9`, where it took down `update by instance id` and `download by instance id` too. It waits on CDM-to-Files sync with exponential backoff, which only fits about three attempts into 5s. The sibling test operating on the same file passes moments later, which is what points at the timeout rather than the data.

The same 5s ceiling also fails 5 of the 19 tests in `filesMultiPart.unit.spec.ts` when that file is run on its own.

## Test plan

- [x] `filesMultiPart.unit.spec.ts` in isolation: 5 failed / 14 passed before, 19 passed after
- [x] Full stable unit suite: 106 passed, 1 skipped
- [x] Scratch spec confirming the timeout is applied rather than silently dropped
- [x] Lint and typecheck clean

Only `packages/stable` is changed. `beta`, `alpha` and `template` have the same missing config, but no failure has been traced to it there, so they are left for a follow-up.
