### PR TITLE
test: stop concurrent data product test runs from deleting each other's fixtures

### DIFF
--- a/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
@@ -123,7 +123,7 @@ describe('Data product versions integration test', () => {
 
     await client.dataProductVersions
       .delete(dataProductExternalId, [{ version: createVersion }])
-      .catch();
+      .catch(() => {});
   });
 
   test('list', async () => {

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -81,7 +81,7 @@ describe('Data products integration test', () => {
     // Page through everything: concurrent runs and not-yet-cleaned orphans can
     // push this run's fixture off the first page.
     const items = await client.dataProducts
-      .list({ limit: 10 })
+      .list({ limit: 100 })
       .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
     expect(items.length).toBeGreaterThan(0);
     expect(

--- a/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProducts.int.spec.ts
@@ -74,14 +74,18 @@ describe('Data products integration test', () => {
     expect(created.name).toBe('data product create test');
     expect(created.isGoverned).toBe(true);
 
-    await client.dataProducts.delete([{ externalId }]).catch();
+    await client.dataProducts.delete([{ externalId }]).catch(() => {});
   });
 
   test('list', async () => {
-    const response = await client.dataProducts.list({ limit: 10 });
-    expect(response.items.length).toBeGreaterThan(0);
+    // Page through everything: concurrent runs and not-yet-cleaned orphans can
+    // push this run's fixture off the first page.
+    const items = await client.dataProducts
+      .list({ limit: 10 })
+      .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
+    expect(items.length).toBeGreaterThan(0);
     expect(
-      response.items.some((item) => item.externalId === dataProductExternalId)
+      items.some((item) => item.externalId === dataProductExternalId)
     ).toBe(true);
   });
 

--- a/packages/alpha/src/__tests__/testUtils.ts
+++ b/packages/alpha/src/__tests__/testUtils.ts
@@ -45,17 +45,22 @@ export async function cleanupDataProductSchemaSpaces(
     );
 
     for (const product of productsInSpace) {
-      const versions = await client.dataProductVersions
-        .list(product.externalId, { limit: 10 })
-        .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
+      // The product may already be gone: deleted by the test itself or by a
+      // concurrent run, while still present in the (eventually consistent)
+      // listing above. Cleanup must tolerate that rather than fail the suite.
+      try {
+        const versions = await client.dataProductVersions
+          .list(product.externalId, { limit: 10 })
+          .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
 
-      if (versions.length > 0) {
-        await client.dataProductVersions
-          .delete(
+        if (versions.length > 0) {
+          await client.dataProductVersions.delete(
             product.externalId,
             versions.map((version) => ({ version: version.version }))
-          )
-          .catch(() => {});
+          );
+        }
+      } catch {
+        // ignore - fall through to the product delete, which is also tolerant
       }
 
       await client.dataProducts
@@ -98,15 +103,31 @@ export async function cleanupDataProductSchemaSpaces(
   }
 }
 
+/**
+ * Only clean up test spaces that have been idle for at least this long.
+ * Both suites in this package (and the same suites in the parallel CI matrix
+ * job) run concurrently against the same project, and all of them create
+ * spaces under DATA_PRODUCT_TEST_SPACE_PREFIX. Deleting a space that another
+ * live run just created pulls its data products out from under it mid-test,
+ * so only spaces old enough to be orphans from a crashed run are removed.
+ * Mirrors deleteSpacesNotUpdatedSince in the stable package's testUtils.
+ */
+const ORPHAN_AGE_THRESHOLD_MS = 15 * 60 * 1000;
+
 export async function cleanupOrphanedDataProductTestResources(
   client: CogniteClientAlpha
 ) {
+  const cutoff = Date.now() - ORPHAN_AGE_THRESHOLD_MS;
   const spaces = (
     await client.spaces
       .list({ limit: 1000 })
       .autoPagingToArray({ limit: Number.POSITIVE_INFINITY })
   )
-    .filter((space) => space.space.startsWith(DATA_PRODUCT_TEST_SPACE_PREFIX))
+    .filter(
+      (space) =>
+        space.space.startsWith(DATA_PRODUCT_TEST_SPACE_PREFIX) &&
+        space.lastUpdatedTime < cutoff
+    )
     .map((space) => space.space);
 
   if (spaces.length > 0) {


### PR DESCRIPTION
Fixes the flaky `dataProducts.int.spec.ts` / `dataProductVersions.int.spec.ts` failures that have been intermittently failing CI on master and unrelated PRs (`Data product '...' not found`, `The API Failed to process some items`).

## Root cause

`cleanupOrphanedDataProductTestResources`, called in both suites' `beforeAll`, deleted every data product test space (`sdk_js_alpha_dp*` prefix) with **no age check**. But the suites' own live spaces match that prefix — and they run concurrently twice over: vitest runs the two spec files in parallel workers, and the CI matrix runs the whole suite simultaneously on node 20 and node 22 against the same project. Whichever run started later deleted the live fixtures of the others mid-test.

Two secondary bugs amplified it:

- In `cleanupDataProductSchemaSpaces`, every mutation is `.catch(() => {})`-guarded but the `dataProductVersions.list` read is not — a product deleted between the (eventually consistent) product listing and the versions call threw from `afterAll` and failed the whole suite.
- The `list` test asserted its fixture appears in the **first page of 10** products, which breaks as soon as concurrent runs or orphans push it off page one.

## Fix

- Orphan cleanup only touches spaces idle for 15+ minutes, mirroring `deleteSpacesNotUpdatedSince` in the stable package.
- Per-product version cleanup tolerates already-deleted products.
- The `list` test pages through the full listing.
- Two handler-less `.catch()` calls (which don't actually swallow the rejection) become `.catch(() => {})`.

## Verification (against a live project)

- Both suites green in a single run (parallel workers): 10/10.
- **Race reproduction**: two concurrent local test processes, staggered 3s — unfixed, one process fails 3 tests and the other fails at suite level with the exact error strings from CI; fixed, both processes pass 10/10.
- A further fixed run passes with the broken run's leftover debris still in the project.
