### PR TITLE
test: fix flaky integration tests

### DIFF
--- a/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
+++ b/packages/alpha/src/__tests__/api/dataProductVersions.int.spec.ts
@@ -127,15 +127,14 @@ describe('Data product versions integration test', () => {
   });
 
   test('list', async () => {
-    const response = await client.dataProductVersions.list(
-      dataProductExternalId,
-      { limit: 10 }
-    );
+    // Page through everything: concurrent runs can push this run's fixture off
+    // the first page.
+    const items = await client.dataProductVersions
+      .list(dataProductExternalId, { limit: 10 })
+      .autoPagingToArray({ limit: Number.POSITIVE_INFINITY });
 
-    expect(response.items.length).toBeGreaterThan(0);
-    expect(response.items.some((item) => item.version === versionNumber)).toBe(
-      true
-    );
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.some((item) => item.version === versionNumber)).toBe(true);
   });
 
   test('retrieve by version', async () => {

--- a/packages/alpha/vite.config.js
+++ b/packages/alpha/vite.config.js
@@ -5,6 +5,16 @@ import dts from 'vite-plugin-dts';
 const externals = ['@cognite/sdk', '@cognite/sdk-core'];
 
 export default defineConfig({
+  test: {
+    // vitest's defaults (5s/10s) are too tight for the integration tests, which
+    // wait on eventually consistent CDF endpoints. `vi.setConfig` cannot supply
+    // these: it does not apply to a test that has already started, so calls from
+    // `beforeAll` or from inside a test body are silently ignored. These are the
+    // values vitest.workspace.js already declares, which the per-package test
+    // runs (lerna runs vitest from each package directory) never pick up.
+    testTimeout: 25_000,
+    hookTimeout: 30_000,
+  },
   plugins: [
     dts({
       exclude: ['**/__tests__/**/*', '**/*.spec.ts'],

--- a/packages/beta/vite.config.js
+++ b/packages/beta/vite.config.js
@@ -5,6 +5,16 @@ import dts from 'vite-plugin-dts';
 const externals = ['@cognite/sdk', '@cognite/sdk-core'];
 
 export default defineConfig({
+  test: {
+    // vitest's defaults (5s/10s) are too tight for the integration tests, which
+    // wait on eventually consistent CDF endpoints. `vi.setConfig` cannot supply
+    // these: it does not apply to a test that has already started, so calls from
+    // `beforeAll` or from inside a test body are silently ignored. These are the
+    // values vitest.workspace.js already declares, which the per-package test
+    // runs (lerna runs vitest from each package directory) never pick up.
+    testTimeout: 25_000,
+    hookTimeout: 30_000,
+  },
   plugins: [
     dts({
       exclude: ['**/__tests__/**/*', '**/*.spec.ts'],

--- a/packages/core/src/__tests__/testUtils.ts
+++ b/packages/core/src/__tests__/testUtils.ts
@@ -68,15 +68,16 @@ export async function retryInSeconds<ResponseType>(
 }
 
 export async function runTestWithRetryWhenFailing(
-  testFunction: () => Promise<void>
+  testFunction: () => Promise<void>,
+  // Cumulative sleep budget. The default fits the 25s testTimeout; when
+  // raising it, pass a matching per-test timeout to vitest as well.
+  maxSleepMs = 20_000
 ) {
-  vi.setConfig({
-    testTimeout: 3 * 60 * 1000,
-  });
-  const maxNumberOfRetries = 15;
   const delayFactor = 2;
+  // Capped backoff: uncapped doubling would blow the budget after 5 retries.
+  const maxDelayInMs = 2_000;
   let delayInMs = 500;
-  let numberOfRetries = 0;
+  let sleptMs = 0;
   let error: unknown;
   do {
     try {
@@ -85,10 +86,10 @@ export async function runTestWithRetryWhenFailing(
     } catch (err) {
       error = err;
       await sleepPromise(delayInMs);
-      delayInMs *= delayFactor;
-      numberOfRetries++;
+      sleptMs += delayInMs;
+      delayInMs = Math.min(delayInMs * delayFactor, maxDelayInMs);
     }
-  } while (numberOfRetries < maxNumberOfRetries);
+  } while (sleptMs < maxSleepMs);
   throw error;
 }
 

--- a/packages/stable/src/__tests__/api/datapoints.int.spec.ts
+++ b/packages/stable/src/__tests__/api/datapoints.int.spec.ts
@@ -9,15 +9,15 @@ import type {
   NodeWrite,
   Timeseries,
 } from '../../types';
-import { randomInt, setupLoggedInClient } from '../testUtils';
+import { TEST_DATA_SPACE, randomInt, setupLoggedInClient } from '../testUtils';
 
 describe('Datapoints integration test', () => {
   let client: CogniteClient;
   let timeserie: Timeseries;
 
   const testSpace = {
-    space: 'test_data_space',
-    name: 'test_data_space',
+    space: TEST_DATA_SPACE,
+    name: TEST_DATA_SPACE,
     description: 'Instance space used for integration tests.',
   };
 

--- a/packages/stable/src/__tests__/api/files.int.spec.ts
+++ b/packages/stable/src/__tests__/api/files.int.spec.ts
@@ -13,6 +13,7 @@ import type {
   NodeWrite,
 } from '../../types';
 import {
+  TEST_DATA_SPACE,
   getFileCreateArgs,
   randomInt,
   runTestWithRetryWhenFailing,
@@ -27,8 +28,8 @@ describe('Files integration test', () => {
   let label: LabelDefinition;
 
   const testSpace = {
-    space: 'test_data_space',
-    name: 'test_data_space',
+    space: TEST_DATA_SPACE,
+    name: TEST_DATA_SPACE,
     description: 'Instance space used for integration tests.',
   };
 
@@ -162,7 +163,7 @@ describe('Files integration test', () => {
   test('download by instance id', async () => {
     // Syncing from instance to files API is eventually consistant
     await runTestWithRetryWhenFailing(async () => {
-      expect(
+      await expect(
         client.files.getDownloadUrls([{ instanceId: fileCdmInstanceId }])
       ).rejects.toThrow(/Files not uploaded/);
     });

--- a/packages/stable/src/__tests__/api/sequences.int.spec.ts
+++ b/packages/stable/src/__tests__/api/sequences.int.spec.ts
@@ -15,12 +15,15 @@ import {
   setupLoggedInClient,
 } from '../testUtils';
 
+const SLOW_INDEX_TEST_TIMEOUT_MS = 3 * 60 * 1000;
+const RETRY_SLEEP_BUDGET_MS = SLOW_INDEX_TEST_TIMEOUT_MS - 30 * 1000;
+
 describe('Sequences integration test', () => {
   let client: CogniteClient;
   let sequences: Sequence[];
   const testValues = [1, 1.5, 'two'];
   const testExternalId = `sequence${randomInt()}`;
-  let sequenceToCreate: ExternalSequence = {
+  const sequenceToCreate: ExternalSequence = {
     name: 'sequence1',
     description: 'description',
     columns: [
@@ -61,10 +64,10 @@ describe('Sequences integration test', () => {
         name: `asset_${randomInt()}`,
       },
     ]);
-    sequenceToCreate = {
-      ...sequenceToCreate,
-      assetId: asset.id,
-    };
+    // Mutate in place: sequencesToCreate[0] references this object, so a
+    // reassignment would leave the created sequence without the assetId the
+    // filter tests depend on.
+    sequenceToCreate.assetId = asset.id;
   });
 
   test('create', async () => {
@@ -87,35 +90,49 @@ describe('Sequences integration test', () => {
       expect(sequence.name).toBe(sequences[0].name);
     });
 
-    test('filter on assetIds', async () => {
-      runTestWithRetryWhenFailing(async () => {
-        const { items } = await client.sequences.list({
-          filter: { assetIds: [asset.id] },
-          limit: 1,
-        });
-        expect(items[0].name).toBe(sequences[0].name);
-      });
-    });
+    // The asset filter and search indexes lag far behind sequence creation,
+    // so these tests get a 3 minute budget instead of the default.
+    test(
+      'filter on assetIds',
+      async () => {
+        await runTestWithRetryWhenFailing(async () => {
+          const { items } = await client.sequences.list({
+            filter: { assetIds: [asset.id] },
+            limit: 1,
+          });
+          expect(items[0].name).toBe(sequences[0].name);
+        }, RETRY_SLEEP_BUDGET_MS);
+      },
+      SLOW_INDEX_TEST_TIMEOUT_MS
+    );
 
-    test('filter on rootAssetIds', async () => {
-      runTestWithRetryWhenFailing(async () => {
-        const { items } = await client.sequences.list({
-          filter: { rootAssetIds: [asset.id] },
-          limit: 1,
-        });
-        expect(items[0].name).toBe(sequences[0].name);
-      });
-    });
+    test(
+      'filter on rootAssetIds',
+      async () => {
+        await runTestWithRetryWhenFailing(async () => {
+          const { items } = await client.sequences.list({
+            filter: { rootAssetIds: [asset.id] },
+            limit: 1,
+          });
+          expect(items[0].name).toBe(sequences[0].name);
+        }, RETRY_SLEEP_BUDGET_MS);
+      },
+      SLOW_INDEX_TEST_TIMEOUT_MS
+    );
 
-    test('filter on assetSubtreeIds', async () => {
-      runTestWithRetryWhenFailing(async () => {
-        const { items } = await client.sequences.list({
-          filter: { assetSubtreeIds: [{ id: asset.id }] },
-          limit: 1,
-        });
-        expect(items[0].name).toBe(sequences[0].name);
-      });
-    });
+    test(
+      'filter on assetSubtreeIds',
+      async () => {
+        await runTestWithRetryWhenFailing(async () => {
+          const { items } = await client.sequences.list({
+            filter: { assetSubtreeIds: [{ id: asset.id }] },
+            limit: 1,
+          });
+          expect(items[0].name).toBe(sequences[0].name);
+        }, RETRY_SLEEP_BUDGET_MS);
+      },
+      SLOW_INDEX_TEST_TIMEOUT_MS
+    );
   });
 
   test('retrieve', async () => {
@@ -159,16 +176,22 @@ describe('Sequences integration test', () => {
     expect(updated.description).toBe('hey');
   });
 
-  test('search', async () => {
-    runTestWithRetryWhenFailing(async () => {
-      const result = await client.sequences.search({
-        search: {
-          query: 'n*m* des*tion',
-        },
-      });
-      expect(result.length).toBeGreaterThan(0);
-    });
-  });
+  test(
+    'search',
+    async () => {
+      await runTestWithRetryWhenFailing(async () => {
+        // The search endpoint matches whole words: wildcard patterns like
+        // 'des*tion' never match anything.
+        const result = await client.sequences.search({
+          search: {
+            query: 'description',
+          },
+        });
+        expect(result.some((s) => s.id === sequences[0].id)).toBe(true);
+      }, RETRY_SLEEP_BUDGET_MS);
+    },
+    SLOW_INDEX_TEST_TIMEOUT_MS
+  );
 
   describe('rows', () => {
     test('insert', async () => {

--- a/packages/stable/src/__tests__/testUtils.ts
+++ b/packages/stable/src/__tests__/testUtils.ts
@@ -44,6 +44,10 @@ function setupMockableClient() {
 
 const RECORDS_TEST_SPACE = 'sdk_test_records_space'; // Space reserved for records integration tests
 const DATA_PRODUCT_TEST_SPACE_PREFIX = 'sdk_js_alpha_dp';
+// Shared fixture space for the files and datapoints integration tests. Their
+// suites run in parallel with the suites that call deleteOldSpaces, so it must
+// never be garbage-collected mid-run.
+const TEST_DATA_SPACE = 'test_data_space';
 
 const deleteOldSpaces = async (client: CogniteClient) => {
   const fiveMinutesInMs = 5 * 60 * 1000;
@@ -61,6 +65,7 @@ const deleteSpacesNotUpdatedSince = async (
       (space) =>
         space.lastUpdatedTime < timestamp &&
         space.space !== RECORDS_TEST_SPACE &&
+        space.space !== TEST_DATA_SPACE &&
         !space.space.startsWith(DATA_PRODUCT_TEST_SPACE_PREFIX)
     );
 
@@ -305,4 +310,5 @@ export {
   deleteOldSpaces,
   getFileCreateArgs,
   RECORDS_TEST_SPACE,
+  TEST_DATA_SPACE,
 };

--- a/packages/template/vite.config.js
+++ b/packages/template/vite.config.js
@@ -5,6 +5,16 @@ import dts from 'vite-plugin-dts';
 const externals = ['@cognite/sdk', '@cognite/sdk-core'];
 
 export default defineConfig({
+  test: {
+    // vitest's defaults (5s/10s) are too tight for the integration tests, which
+    // wait on eventually consistent CDF endpoints. `vi.setConfig` cannot supply
+    // these: it does not apply to a test that has already started, so calls from
+    // `beforeAll` or from inside a test body are silently ignored. These are the
+    // values vitest.workspace.js already declares, which the per-package test
+    // runs (lerna runs vitest from each package directory) never pick up.
+    testTimeout: 25_000,
+    hookTimeout: 30_000,
+  },
   plugins: [
     dts({
       exclude: ['**/__tests__/**/*', '**/*.spec.ts'],


### PR DESCRIPTION
## Why

CI has been failing intermittently on master and on unrelated PRs (e.g. #1464) for weeks. Two consecutive runs of the same commit fail on *different* integration tests:

- `dataProductVersions.int.spec.ts` (alpha): `Hook timed out in 10000ms`
- `files.int.spec.ts` (stable): 408s / `File instance ids not found` on the *by instance id* tests

## What

**Timeouts (root cause of the alpha hook failure)**
- Apply the intended vitest timeouts (25s test / 30s hook) to the **alpha, beta and template** packages — the follow-up explicitly deferred in #1465. The data product suites' `beforeAll` (fixture setup + orphan cleanup) routinely exceeds vitest's default 10s hook timeout.

**Retry helper**
- `runTestWithRetryWhenFailing` now uses a capped backoff with a sleep budget (default 20s) that actually fits inside the 25s test timeout. Previously uncapped exponential backoff blew past the timeout after ~5 retries, and its `vi.setConfig(3 min)` call was a documented no-op.

**Missing `await`s — which exposed two real test bugs**
- `files.int.spec.ts` *download by instance id* and four `sequences.int.spec.ts` tests called the retry wrapper (or `expect().rejects`) without `await`, so they never retried or asserted anything and always passed. Awaiting them revealed:
  - the sequences `beforeAll` **reassigned** `sequenceToCreate` instead of mutating it, so the created sequence never carried the `assetId` the three asset-filter tests depend on — they could never pass;
  - the search test's wildcard query (`n*m* des*tion`) is never matched by the search endpoint (verified against the API: plain words match within seconds, wildcards never do).
  Both fixed; the asset-filter/search tests get a 3 minute budget since those indexes can lag.

**Cross-run fixture race (likely source of the files failures)**
- The shared `test_data_space` fixture space (files + datapoints suites) is now excluded from `deleteOldSpaces`, which the views/containers/spaces/datamodels suites run in parallel workers and in the node 20/22 matrix — the same race #1466 fixed for data products.
- The data product versions `list` test now pages through all results, like #1466 did for the products list test.

## Verification

Ran locally against the integration test project:
- `dataProductVersions.int.spec.ts`: 5/5 passed (suite takes ~12s — would have flaked on the old 10s hook timeout)
- `files.int.spec.ts`: 17/17 non-skipped passed
- `sequences.int.spec.ts`: 14/14 passed, twice
- `yarn lint` clean