### PR TITLE
feat(records): support record views as sources in the records API

### DIFF
--- a/packages/stable/src/__tests__/api/records.int.spec.ts
+++ b/packages/stable/src/__tests__/api/records.int.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2025 Cognite AS
 
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import type { ViewCreateDefinition } from '../../api/views/types.gen';
 import type CogniteClient from '../../cogniteClient';
 import type { RecordDelete, SyncRecordItem } from '../../types';
 import {
@@ -1176,4 +1177,178 @@ describe('mutable records integration test', () => {
       .sort((a, b) => (a as number) - (b as number));
     expect(values).toEqual([10, 20, 30]);
   });
+});
+
+describe('record views integration test', () => {
+  let client: CogniteClient;
+
+  const immutableStreamId = 'sdk_test_immutable_stream';
+  const testSpaceId = RECORDS_TEST_SPACE;
+  const testContainerId = 'sdk_test_records_container';
+  const viewVersion = 'v1';
+  const recordsViewId = 'sdk_test_records_view';
+
+  const recordsViewRef = {
+    type: 'view' as const,
+    space: testSpaceId,
+    externalId: recordsViewId,
+    version: viewVersion,
+  };
+  const recordsViewKey = `${recordsViewId}/${viewVersion}`;
+
+  const lastDay = () => ({
+    gte: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+  });
+
+  beforeAll(async () => {
+    client = setupLoggedInClient();
+
+    try {
+      await client.streams.retrieve({ externalId: immutableStreamId });
+    } catch {
+      await client.streams.create({
+        externalId: immutableStreamId,
+        settings: { template: { name: 'ImmutableTestStream' } },
+      });
+    }
+
+    await client.spaces.upsert([
+      {
+        space: testSpaceId,
+        name: testSpaceId,
+        description: 'Space used for records integration tests.',
+      },
+    ]);
+
+    await client.containers.upsert([
+      {
+        externalId: testContainerId,
+        space: testSpaceId,
+        name: 'Test Records Container',
+        description: 'Container used for records integration tests.',
+        usedFor: 'record',
+        properties: {
+          name: { type: { type: 'text' } },
+          value: { type: { type: 'float64' } },
+          timestamp: { type: { type: 'timestamp' } },
+        },
+      },
+    ]);
+
+    const containerRef = {
+      type: 'container' as const,
+      space: testSpaceId,
+      externalId: testContainerId,
+    };
+
+    const recordViewDefinition: ViewCreateDefinition = {
+      externalId: recordsViewId,
+      space: testSpaceId,
+      version: viewVersion,
+      name: 'Records view',
+      description: 'Record view used for records integration tests.',
+      streamId: [immutableStreamId],
+      properties: {
+        recordName: {
+          container: containerRef,
+          containerPropertyIdentifier: 'name',
+        },
+        recordValue: {
+          container: containerRef,
+          containerPropertyIdentifier: 'value',
+        },
+      },
+    };
+    await client.views.upsert([recordViewDefinition]);
+
+    // Wait until the records API refreshes the schema cache
+    await vi.waitFor(
+      async () => {
+        await client.records.filter(immutableStreamId, {
+          lastUpdatedTime: lastDay(),
+          sources: [{ source: recordsViewRef, properties: ['*'] }],
+          limit: 1,
+        });
+      },
+      { timeout: 30_000, interval: 1_000 }
+    );
+  }, 90_000);
+
+  test('ingest, filter, and aggregate through a record view', async () => {
+    const testName = `view_roundtrip_${randomInt()}`;
+
+    await client.records.ingest(immutableStreamId, [
+      {
+        space: testSpaceId,
+        externalId: `view_roundtrip_1_${randomInt()}`,
+        sources: [
+          {
+            source: recordsViewRef,
+            properties: { recordName: testName, recordValue: 100 },
+          },
+        ],
+      },
+      {
+        space: testSpaceId,
+        externalId: `view_roundtrip_2_${randomInt()}`,
+        sources: [
+          {
+            source: recordsViewRef,
+            properties: { recordName: testName, recordValue: 200 },
+          },
+        ],
+      },
+    ]);
+
+    const { items, typing } = await vi.waitFor(
+      async () => {
+        const response = await client.records.filter(immutableStreamId, {
+          lastUpdatedTime: lastDay(),
+          sources: [{ source: recordsViewRef, properties: ['*'] }],
+          filter: {
+            equals: {
+              property: [testSpaceId, recordsViewKey, 'recordName'],
+              value: testName,
+            },
+          },
+          includeTyping: true,
+          limit: 10,
+        });
+        expect(response.items.length).toBe(2);
+        return response;
+      },
+      { timeout: 10_000, interval: 200 }
+    );
+
+    const values = items
+      .map((r) => r.properties[testSpaceId][recordsViewKey].recordValue)
+      .sort();
+    expect(values).toEqual([100, 200]);
+    expect(items[0].createdTime).toBeInstanceOf(Date);
+    expect(
+      typing?.[testSpaceId]?.[recordsViewKey]?.recordValue?.type
+    ).toBeDefined();
+
+    // Aggregates accept view property paths.
+    const valueProp = [testSpaceId, recordsViewKey, 'recordValue'] satisfies [
+      string,
+      string,
+      string,
+    ];
+    const aggregates = await client.records.aggregate(immutableStreamId, {
+      lastUpdatedTime: lastDay(),
+      filter: {
+        equals: {
+          property: [testSpaceId, recordsViewKey, 'recordName'],
+          value: testName,
+        },
+      },
+      aggregates: {
+        totalCount: { count: {} },
+        totalSum: { sum: { property: valueProp } },
+      },
+    });
+    expect((aggregates.totalCount as { count: number }).count).toBe(2);
+    expect((aggregates.totalSum as { sum: number }).sum).toBe(300);
+  }, 30_000);
 });

--- a/packages/stable/src/__tests__/api/records.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/records.unit.spec.ts
@@ -1,0 +1,175 @@
+// Copyright 2026 Cognite AS
+
+import nock from 'nock';
+import { beforeEach, describe, expect, test } from 'vitest';
+import type CogniteClient from '../../cogniteClient';
+import { mockBaseUrl, setupMockableClient } from '../testUtils';
+
+const streamId = 'my_stream';
+const viewRef = {
+  type: 'view' as const,
+  space: 'mySpace',
+  externalId: 'myView',
+  version: 'v1',
+};
+
+/**
+ * Intercepts the next POST to the given records sub-path and captures the
+ * request body so the serialization can be asserted.
+ */
+const interceptRecordsPost = (
+  path: string,
+  reply: object,
+  captured: { body?: unknown }
+) =>
+  nock(mockBaseUrl)
+    .post(
+      (uri) => uri.includes(`/streams/${streamId}/records${path}`),
+      (body) => {
+        captured.body = body;
+        return true;
+      }
+    )
+    .reply(200, reply);
+
+describe('Records unit test', () => {
+  let client: CogniteClient;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    client = setupMockableClient();
+  });
+
+  test('ingest posts view source bodies verbatim', async () => {
+    const captured: { body?: unknown } = {};
+    interceptRecordsPost('', {}, captured);
+
+    await client.records.ingest(streamId, [
+      {
+        space: 'mySpace',
+        externalId: 'record1',
+        sources: [
+          {
+            source: viewRef,
+            properties: { recordName: 'a', recordValue: 1 },
+          },
+        ],
+      },
+    ]);
+
+    expect(captured.body).toEqual({
+      items: [
+        {
+          space: 'mySpace',
+          externalId: 'record1',
+          sources: [
+            {
+              source: {
+                type: 'view',
+                space: 'mySpace',
+                externalId: 'myView',
+                version: 'v1',
+              },
+              properties: { recordName: 'a', recordValue: 1 },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('filter sends view sources, hasData, and view property paths untouched', async () => {
+    const captured: { body?: unknown } = {};
+    interceptRecordsPost('/filter', { items: [] }, captured);
+
+    // Both source kinds type-check, though the API rejects mixing them in a
+    // single request.
+    const request = {
+      sources: [{ source: viewRef, properties: ['*'] }],
+      filter: {
+        and: [
+          { hasData: [viewRef] },
+          {
+            equals: {
+              property: ['mySpace', 'myView/v1', 'recordName'] as [
+                string,
+                string,
+                string,
+              ],
+              value: 'a',
+            },
+          },
+        ],
+      },
+      targetUnits: {
+        properties: [
+          {
+            property: ['mySpace', 'myView/v1', 'temp'] as [
+              string,
+              string,
+              string,
+            ],
+            unit: { externalId: 'temperature:k' },
+          },
+        ],
+      },
+    };
+    await client.records.filter(streamId, request);
+
+    expect(captured.body).toEqual(request);
+  });
+
+  test('filter response keyed by viewExternalId/version survives the date transform', async () => {
+    const captured: { body?: unknown } = {};
+    interceptRecordsPost(
+      '/filter',
+      {
+        items: [
+          {
+            space: 'mySpace',
+            externalId: 'record1',
+            createdTime: 1700000000000,
+            lastUpdatedTime: 1700000001000,
+            properties: {
+              mySpace: {
+                'myView/v1': { recordName: 'a', recordValue: 1 },
+              },
+            },
+          },
+        ],
+        typing: {
+          mySpace: {
+            'myView/v1': {
+              recordValue: {
+                nullable: true,
+                defaultValue: null,
+                type: { type: 'float64', list: false },
+              },
+            },
+          },
+        },
+      },
+      captured
+    );
+
+    const { items, typing } = await client.records.filter(streamId, {
+      sources: [{ source: viewRef, properties: ['*'] }],
+      includeTyping: true,
+    });
+
+    expect(items).toHaveLength(1);
+    const record = items[0];
+    expect(record.createdTime).toBeInstanceOf(Date);
+    expect(record.createdTime.getTime()).toBe(1700000000000);
+    expect(record.lastUpdatedTime).toBeInstanceOf(Date);
+    // The slash-keyed nesting must pass through the transform unmangled.
+    expect(record.properties.mySpace['myView/v1']).toEqual({
+      recordName: 'a',
+      recordValue: 1,
+    });
+    expect(typing?.mySpace['myView/v1'].recordValue.type).toEqual({
+      type: 'float64',
+      list: false,
+    });
+  });
+});

--- a/packages/stable/src/api/records/recordsApi.ts
+++ b/packages/stable/src/api/records/recordsApi.ts
@@ -41,6 +41,8 @@ export class RecordsAPI extends BaseResourceAPI<RecordItem> {
    *     externalId: 'record1',
    *     sources: [
    *       {
+   *         // A source may also reference a record view:
+   *         // { type: 'view', space: 'mySpace', externalId: 'myView', version: 'v1' }
    *         source: { type: 'container', space: 'mySpace', externalId: 'myContainer' },
    *         properties: { temperature: 25.5, timestamp: '2025-01-01T00:00:00Z' }
    *       }
@@ -131,13 +133,13 @@ export class RecordsAPI extends BaseResourceAPI<RecordItem> {
    * const records = await client.records.filter('my_stream', {
    *   sources: [
    *     {
-   *       source: { type: 'container', space: 'mySpace', externalId: 'myContainer' },
+   *       source: { type: 'view', space: 'mySpace', externalId: 'myView', version: 'v1' },
    *       properties: ['*']
    *     }
    *   ],
    *   filter: {
    *     equals: {
-   *       property: ['mySpace', 'myContainer', 'status'],
+   *       property: ['mySpace', 'myView/v1', 'status'],
    *       value: 'active'
    *     }
    *   },

--- a/packages/stable/src/api/records/types.ts
+++ b/packages/stable/src/api/records/types.ts
@@ -47,6 +47,31 @@ export interface ContainerReference {
 }
 
 /**
+ * Reference to a record view.
+ *
+ * A view can be used as a record source when its `usedFor` is `'record'` and its
+ * `streamId` targets the stream being read from or written to. View properties map
+ * (and may rename) container properties, and a view may embed a filter which is
+ * applied (in addition to the request filter) on every read through the view.
+ * Record views are managed with the Data Modeling views API (`client.views`).
+ */
+export interface ViewReference {
+  /** External-id of the view */
+  externalId: RecordExternalId;
+  /** Id of the space that the view belongs to */
+  space: RecordSpaceId;
+  type: 'view';
+  /** Version of the view */
+  version: string;
+}
+
+/**
+ * Reference to the source of record data: either a view or a container,
+ * distinguished by the `type` attribute.
+ */
+export type SourceReference = ViewReference | ContainerReference;
+
+/**
  * Sort direction for record queries
  */
 export type RecordSortDirection = 'ascending' | 'descending';
@@ -57,15 +82,17 @@ export type RecordSortDirection = 'ascending' | 'descending';
 export type LastUpdatedTimeRangeBound = string | number;
 
 /**
- * Property values for a container source
+ * Property values for the identified view or container
  */
 export interface RecordData {
   /**
-   * Reference to the container
+   * Reference to the view or container
    */
-  source: ContainerReference;
+  source: SourceReference;
   /**
-   * Property values for the container
+   * Property values for the view or container. When writing through a view,
+   * the values are keyed by the view's property names, and a single view
+   * source writes to all containers mapped by the view.
    */
   properties: PropertyValueGroupV3;
 }
@@ -103,15 +130,21 @@ export interface RecordDelete {
 }
 
 /**
- * Source selector for specifying which container properties to return
+ * Source selector for specifying which view or container properties to return.
+ *
+ * Selecting through a view restricts the result to records that have data in
+ * all of the containers mapped by the view, and the view's embedded filter
+ * (if any) is applied in addition to the request filter.
+ * Container and view sources cannot be mixed in a single request.
  */
 export interface SourceSelector {
   /**
-   * Reference to the container
+   * Reference to the view or container
    */
-  source: ContainerReference;
+  source: SourceReference;
   /**
-   * Properties to return for the specified container
+   * Properties to return for the specified view or container.
+   * Use `'*'` to return all properties.
    */
   properties: string[];
 }
@@ -143,7 +176,9 @@ export interface LastUpdatedTimeFilter {
  */
 export interface RecordSort {
   /**
-   * Property to sort by
+   * Property to sort by. Sorting supports container property references only.
+   * To sort on a property exposed by a view, reference the underlying
+   * container property instead.
    */
   property: string[];
   /**
@@ -160,7 +195,10 @@ export interface RecordUnitReference {
 }
 
 /**
- * Container property path for unit conversion (exactly three segments: space, container, property).
+ * Property path for unit conversion (exactly three segments). The first segment
+ * is the space, the second is either the container external id or the view
+ * external id and version joined by a slash (`'viewExternalId/version'`), and
+ * the third is the property id. Top-level properties are not supported.
  */
 export type TargetUnitProperty = [string, string, string];
 
@@ -245,12 +283,14 @@ export interface RecordContainerPropertyDefinition {
 }
 
 /**
- * Nested typing map: space → container → property → definition.
+ * Nested typing map: space → view or container → property → definition.
  * Present when `includeTyping` is true in the request.
+ * For data selected through a view, the second-level key has the format
+ * `viewExternalId/version` and the property names are the view's.
  */
 export type RecordTypeInformation = {
   [space: string]: {
-    [containerExternalId: string]: {
+    [viewOrContainerExternalId: string]: {
       [property: string]: RecordContainerPropertyDefinition;
     };
   };
@@ -258,7 +298,9 @@ export type RecordTypeInformation = {
 
 /**
  * Property reference for filters. Either a top-level property (1 element) or
- * a container property [space, container, property] (3 elements).
+ * a view/container property (3 elements). For the 3-element form, the second
+ * segment is either the container external id, or the view external id and
+ * version joined by a slash, e.g. `['mySpace', 'myView/v1', 'myViewProperty']`.
  */
 export type FilterProperty = [string] | [string, string, string];
 
@@ -282,7 +324,12 @@ export type LeafFilter =
   | { matchAll: Record<string, never> }
   | { exists: { property: FilterProperty } }
   | { equals: { property: FilterProperty; value: RawPropertyValueV3 } }
-  | { hasData: ContainerReference[] }
+  /**
+   * Matches records where data is present in the referenced views or containers.
+   * A view reference matches records that have data in all of the containers
+   * mapped by the view and that match the view's embedded filter (if any).
+   */
+  | { hasData: SourceReference[] }
   | { prefix: { property: FilterProperty; value: string } }
   | {
       range: {
@@ -311,7 +358,7 @@ export interface RecordFilterRequest {
    */
   lastUpdatedTime?: LastUpdatedTimeFilter;
   /**
-   * List of containers and their properties to return
+   * List of views/containers and their properties to return
    */
   sources?: SourceSelector[];
   /**
@@ -366,18 +413,20 @@ export interface RecordItem {
    */
   lastUpdatedTime: Date;
   /**
-   * Properties organized by space -> container -> property
+   * Properties organized by space -> view or container -> property
    */
   properties: RecordProperties;
 }
 
 /**
  * Properties structure returned from the API
- * Organized as: { [spaceId]: { [containerId]: { [propertyId]: value } } }
+ * Organized as: { [spaceId]: { [viewOrContainerId]: { [propertyId]: value } } }
+ * For data selected through a view, the second-level key has the format
+ * `viewExternalId/version` and the property names are the view's.
  */
 export type RecordProperties = {
   [space: string]: {
-    [container: string]: PropertyValueGroupV3;
+    [viewOrContainer: string]: PropertyValueGroupV3;
   };
 };
 
@@ -415,7 +464,7 @@ export interface SyncRecordItem {
  * Request for syncing records from a stream
  */
 export interface RecordSyncRequest {
-  /** List of containers and their properties to return */
+  /** List of views/containers and their properties to return */
   sources?: SourceSelector[];
   /** Filter specification */
   filter?: RecordFilter;
@@ -477,7 +526,10 @@ export type RecordsSyncCursorAndAsyncIterator<T> = Promise<
 
 /**
  * Property reference for aggregates.
- * Either a top-level property (1 element) or a container property [space, container, property] (3 elements).
+ * Either a top-level property (1 element) or a view/container property (3 elements).
+ * For the 3-element form, the second segment is either the container external id,
+ * or the view external id and version joined by a slash, e.g.
+ * `['mySpace', 'myView/v1', 'myViewProperty']`.
  */
 export type AggregateProperty = [string] | [string, string, string];
 


### PR DESCRIPTION
This PR extends the Streams & Records API (`client.records`) to support **record views** everywhere a container reference was accepted, matching the ILA API spec. This is the client-side follow-up to #1464, which added record views to the DMS views API.

### Type changes (`packages/stable/src/api/records/types.ts`)

- New `ViewReference` and `SourceReference = ViewReference | ContainerReference` types.
- Widened the three container-only sites to the union:
  - `RecordData.source` (ingest/upsert)
  - `SourceSelector.source` (filter/sync)
  - the `hasData` filter leaf

Property path references (`FilterProperty`, `AggregateProperty`, `TargetUnitProperty`) were already structurally compatible with the view form, `['space', 'viewExternalId/version', 'property']`, so those got documentation updates only.

### Documentation

- View property-path form for filters, aggregates, and targetUnits.
- `'*'` wildcard in `SourceSelector.properties`.
- Response `properties`/`typing` maps keyed by `viewExternalId/version` when selecting through views.
- Sort supports container property references only.
- Aggregate requests can reference at most one property source when a view is involved.
- Container and view sources cannot be mixed in a single request (API-enforced; found via integration testing — not documented in the spec).
- `filter`/`ingest` doc snippets now show view sources.

### Tests

- New end-to-end integration test: ingest through a view (view property names), filter with a view source selector + view property path + `includeTyping`, and aggregate on a view property path. Uses a persistent record view over the existing persistent record container. Behavioral semantics (embedded view filters, unit conversion, aggregate math) are left to the API's own integration tests.
- New nock-based `records.unit.spec.ts` covering view-source request serialization and deserialization of view-keyed responses through the date transform.

### Breaking changes

None, widening the source types is source-compatible, and the new type names are shadowed at the package boundary by the structurally identical DMS instances re-exports (same precedent as the existing records `ContainerReference`).

## Test plan

- `yarn build`, `yarn lint`, `yarn test-snippets` all pass; `yarn codegen generate-types --package=stable` produces no drift.
- All records unit + integration tests pass locally against CDF (16 tests), plus the views suites that share the stream fixture.