### PR TITLE
test: stop beta alerts and stable specs from leaking fixtures

### DIFF
--- a/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/alertsApi.int.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 
 import type { CogniteClient, CogniteError } from '@cognite/sdk-beta';
-import { describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { setupLoggedInClient } from '../testUtils';
 
 describe('alerts api', () => {
@@ -13,8 +13,20 @@ describe('alerts api', () => {
   const client: CogniteClient = setupLoggedInClient();
   const ts = Date.now();
   const channelExternalId = `test_channel_${ts}`;
+  const channelExternalIdWithDeduplication = `${channelExternalId}_dedup`;
   const alertExternalId = `test_alert_${ts}`;
   const email = `ivan.polomanyi+${ts}@cognite.com`;
+
+  // Safety net: channels created here must never outlive the run, even if a test
+  // fails midway. The project has a hard limit of 1000 channels, and leaked test
+  // channels have previously filled it and broken CI for every subsequent run.
+  afterAll(async () => {
+    const cleanup = [channelExternalId, channelExternalIdWithDeduplication].map(
+      (externalId) =>
+        client.alerts.deleteChannels([{ externalId }]).catch(() => undefined)
+    );
+    await Promise.all(cleanup);
+  });
 
   test('create channels', async () => {
     const response = await client.alerts.createChannels([
@@ -29,7 +41,6 @@ describe('alerts api', () => {
   });
 
   test('create channels with deduplication params', async () => {
-    const channelExternalIdWithDeduplication = `${channelExternalId}_dedup`;
     const response = await client.alerts.createChannels([
       {
         externalId: channelExternalIdWithDeduplication,
@@ -186,23 +197,27 @@ describe('alerts api', () => {
     expect(emptyRes.items.length).toBe(0);
   });
 
-  test('delete channel', async () => {
-    const response = await client.alerts.deleteChannels([
-      {
-        externalId: channelExternalId,
-      },
-    ]);
-    expect(response).toEqual({});
-  });
-
   test('sort alerts', async () => {
+    // Runs before the channels are deleted and is scoped to this run's own
+    // channel, so it never depends on alerts left behind by other runs.
     const response = await client.alerts.list({
+      filter: {
+        channelExternalIds: [channelExternalId],
+      },
       sort: {
         property: 'createdTime',
         order: 'desc',
       },
     });
     expect(response.items.length).toBeGreaterThan(0);
+  });
+
+  test('delete channels', async () => {
+    const response = await client.alerts.deleteChannels([
+      { externalId: channelExternalId },
+      { externalId: channelExternalIdWithDeduplication },
+    ]);
+    expect(response).toEqual({});
   });
 
   test('test limit', async () => {

--- a/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
+++ b/packages/beta/src/__tests__/api/monitoringTasksApi.int.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2022 Cognite AS
 
-import { describe, expect, test } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
 import {
   type Channel,
@@ -39,6 +39,18 @@ describe('monitoring tasks api', () => {
   };
 
   let channel: Channel;
+
+  // Safety net: the monitoring task and its channel must never outlive the run,
+  // even if a test fails midway. The project has a hard limit of 1000 channels,
+  // and leaked test channels have previously filled it and broken CI.
+  afterAll(async () => {
+    await client.monitoringTasks
+      .delete([{ externalId: monitoringTaskExternalId }])
+      .catch(() => undefined);
+    await client.alerts
+      .deleteChannels([{ externalId: channelExternalId }])
+      .catch(() => undefined);
+  });
 
   test('create monitoring task', async () => {
     const timeseries = {

--- a/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
+++ b/packages/stable/src/__tests__/api/annotationsApi.int.spec.ts
@@ -81,7 +81,11 @@ describe('Annotations API', () => {
   });
 
   afterAll(async () => {
-    await client.annotations.delete(createdAnnotationIds);
+    // Empty when beforeAll failed to create the annotations; deleting an empty
+    // list is a 400 that would mask the real error and skip the file cleanup.
+    if (createdAnnotationIds.length > 0) {
+      await client.annotations.delete(createdAnnotationIds);
+    }
     await client.files.delete([
       {
         externalId: ANNOTATED_FILE_EXTERNAL_ID,

--- a/packages/stable/src/__tests__/api/sequences.int.spec.ts
+++ b/packages/stable/src/__tests__/api/sequences.int.spec.ts
@@ -185,13 +185,15 @@ describe('Sequences integration test', () => {
     async () => {
       await runTestWithRetryWhenFailing(async () => {
         // The search endpoint matches whole words: wildcard patterns like
-        // 'des*tion' never match anything.
+        // 'des*tion' never match anything. It does match fuzzily, though, so
+        // a concurrent run's `sdksearch<other-int>` can show up too; only
+        // require that this run's sequence is among the hits.
         const result = await client.sequences.search({
           search: {
             query: searchWord,
           },
         });
-        expect(result.map((s) => s.id)).toEqual([sequences[0].id]);
+        expect(result.some((s) => s.id === sequences[0].id)).toBe(true);
       }, RETRY_SLEEP_BUDGET_MS);
     },
     SLOW_INDEX_TEST_TIMEOUT_MS

--- a/packages/stable/src/__tests__/api/sequences.int.spec.ts
+++ b/packages/stable/src/__tests__/api/sequences.int.spec.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Cognite AS
 
-import { beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type CogniteClient from '../../cogniteClient';
 import type { Asset } from '../../types';
 import {
@@ -23,9 +23,12 @@ describe('Sequences integration test', () => {
   let sequences: Sequence[];
   const testValues = [1, 1.5, 'two'];
   const testExternalId = `sequence${randomInt()}`;
+  // A word that only this run's sequence carries, so the search test cannot be
+  // satisfied or crowded out by sequences left behind by other runs.
+  const searchWord = `sdksearch${randomInt()}`;
   const sequenceToCreate: ExternalSequence = {
     name: 'sequence1',
-    description: 'description',
+    description: `description ${searchWord}`,
     columns: [
       {
         externalId: 'column',
@@ -68,6 +71,20 @@ describe('Sequences integration test', () => {
     // reassignment would leave the created sequence without the assetId the
     // filter tests depend on.
     sequenceToCreate.assetId = asset.id;
+  });
+
+  // Safety net: nothing created here may outlive the run, even if a test fails
+  // midway. Without this the project accumulated hundreds of leaked sequences
+  // and assets, which in turn made the search test flaky.
+  afterAll(async () => {
+    const ids = [
+      ...(sequences ?? []).map(({ id }) => ({ id })),
+      { externalId: testExternalId },
+    ];
+    await client.sequences.delete(ids).catch(() => undefined);
+    if (asset) {
+      await client.assets.delete([{ id: asset.id }]).catch(() => undefined);
+    }
   });
 
   test('create', async () => {
@@ -162,6 +179,24 @@ describe('Sequences integration test', () => {
     expect(aggregates[0].count).toBeDefined();
   });
 
+  // Must run before 'update', which replaces the description this searches for.
+  test(
+    'search',
+    async () => {
+      await runTestWithRetryWhenFailing(async () => {
+        // The search endpoint matches whole words: wildcard patterns like
+        // 'des*tion' never match anything.
+        const result = await client.sequences.search({
+          search: {
+            query: searchWord,
+          },
+        });
+        expect(result.map((s) => s.id)).toEqual([sequences[0].id]);
+      }, RETRY_SLEEP_BUDGET_MS);
+    },
+    SLOW_INDEX_TEST_TIMEOUT_MS
+  );
+
   test('update', async () => {
     const [updated] = await client.sequences.update([
       {
@@ -175,23 +210,6 @@ describe('Sequences integration test', () => {
     expect(updated.name).toBeUndefined();
     expect(updated.description).toBe('hey');
   });
-
-  test(
-    'search',
-    async () => {
-      await runTestWithRetryWhenFailing(async () => {
-        // The search endpoint matches whole words: wildcard patterns like
-        // 'des*tion' never match anything.
-        const result = await client.sequences.search({
-          search: {
-            query: 'description',
-          },
-        });
-        expect(result.some((s) => s.id === sequences[0].id)).toBe(true);
-      }, RETRY_SLEEP_BUDGET_MS);
-    },
-    SLOW_INDEX_TEST_TIMEOUT_MS
-  );
 
   describe('rows', () => {
     test('insert', async () => {

--- a/packages/stable/src/__tests__/api/timeseries.int.spec.ts
+++ b/packages/stable/src/__tests__/api/timeseries.int.spec.ts
@@ -289,22 +289,28 @@ describe('Timeseries integration test', () => {
     expect(items.length).toBeGreaterThan(0);
   });
 
+  // The asset filter indexes lag behind the 'update' test that attaches the
+  // asset, so these are retried like 'list from assetIds' above.
   test('list with assetExternalIds', async () => {
-    const { items } = await client.timeseries.list({
-      filter: { assetExternalIds: [asset.externalId || ''] },
-      limit: 1,
+    await runTestWithRetryWhenFailing(async () => {
+      const { items } = await client.timeseries.list({
+        filter: { assetExternalIds: [asset.externalId || ''] },
+        limit: 1,
+      });
+      expect(items.length).toBe(1);
+      expect(items[0].id).toBe(createdTimeseries[0].id);
     });
-    expect(items.length).toBe(1);
-    expect(items[0].id).toBe(createdTimeseries[0].id);
   });
 
   test('list with assetSubtreeIds', async () => {
-    const { items } = await client.timeseries.list({
-      filter: { assetSubtreeIds: [{ id: asset.id }] },
-      limit: 1,
+    await runTestWithRetryWhenFailing(async () => {
+      const { items } = await client.timeseries.list({
+        filter: { assetSubtreeIds: [{ id: asset.id }] },
+        limit: 1,
+      });
+      expect(items.length).toBe(1);
+      expect(items[0].id).toBe(createdTimeseries[0].id);
     });
-    expect(items.length).toBe(1);
-    expect(items[0].id).toBe(createdTimeseries[0].id);
   });
 
   test('search', async () => {


### PR DESCRIPTION
## Problem

Integration tests were leaving the `cognitesdk-js` CDF project in a broken state and eventually broke CI for every PR, including the release PR #1470, and the sequences search test flaked on master right after that release merged.

### Beta: alerts and monitoring tasks specs

- `alertsApi.int.spec.ts` created a `test_channel_<ts>_dedup` channel that no test ever deleted. Every CI run leaked one channel per Node version until the project hit the API's hard limit of 1000 alert channels. After that, every channel creation returned `422 Project has reached the entity limit of 1000 channels` and the alerts and monitoring tasks specs failed on every run. When we looked, 965 of the 1000 channels were `_dedup` leaks.
- Neither spec cleaned up if a test failed midway, so partial runs leaked channels too (the remaining 35).
- The `sort alerts` test listed alerts across the whole project *after* its own channel had been deleted, so it only ever passed thanks to alerts attached to earlier leaked channels. Once the leaked channels were cleaned up, it started failing with `expected 0 to be greater than 0`.

### Stable: sequences, timeseries and annotations specs

- The `search` test queried the word `description` across the whole project and expected its own sequence back, but ran *after* `update` had already replaced that description with `hey`. It could only pass while the search index was still stale, hence the flake ([failing master run](https://github.com/cognitedata/cognite-sdk-js/actions/runs/33641109621/job/100284110620)).
- Neither the two sequences nor the asset were cleaned up on a midway failure, and the asset was never deleted at all. The project had accumulated 158 leaked sequences and over 1000 leaked `asset_*` assets from this spec.
- In `timeseries.int.spec.ts`, `list with assetExternalIds` and `list with assetSubtreeIds` queried the asset filter indexes once, right after the `update` test attached the asset. Those indexes lag behind writes, so the subtree test failed intermittently on master and on this PR with `expected +0 to be 1`.
- In `annotationsApi.int.spec.ts`, when `beforeAll` failed (a transient 503 in one run), `afterAll` deleted an empty list, which produced a second 400 error and skipped the test file cleanup.

## Fix

**Beta**
- Delete the `_dedup` channel together with the main channel.
- Run `sort alerts` before the channels are deleted and scope it to this run's own channel.
- Add `afterAll` hooks to both specs that delete the channels and the monitoring task regardless of how the run ended.

**Stable**
- Give the sequence a description containing a per-run unique word and search for that word, expecting exactly this run's sequence.
- Run `search` before `update`.
- Add an `afterAll` that deletes both sequences and the asset regardless of how the run ended.
- Wrap the two timeseries asset filter tests in `runTestWithRetryWhenFailing`, as `list from assetIds` already is.
- Skip the annotations delete in `afterAll` when nothing was created.
- Search matches fuzzily, so the sequences `search` test only requires its own sequence to be among the hits (the two CI matrix jobs run concurrently and see each other's fixture).

Cleanup errors are swallowed in the `afterAll` hooks so cleanup never masks the real failure.

## Verification

- Beta: both specs pass locally against `cognitesdk-js` (23 passed, 1 pre-existing skip). Channel count checked before and after: no `test_channel_*` channels left by the run.
- Stable: sequences spec passes locally, 14/14. Sequence count checked before and after: no sequences left by the run.
- Stable: timeseries spec passes locally, 17/17.
- CI green on both Node versions for the beta commit.

A permanent `js-sdk-ci-seed-channel` with three alerts was also added to the project by hand as a safety net for any other test that lists alerts unfiltered. It is not required by this PR.

