### PR TITLE
feat(stable): add Extractors source systems and solutions APIs (2/3)

### DIFF
--- a/packages/stable/src/__tests__/api/extractors.int.spec.ts
+++ b/packages/stable/src/__tests__/api/extractors.int.spec.ts
@@ -15,6 +15,20 @@ describe('extractors api', () => {
     expect(response.items[0].type).toBeDefined();
   });
 
+  it('list source systems', async () => {
+    const response = await client.extractors.sourceSystems.list();
+    expect(response.items.length).toBeGreaterThan(0);
+    expect(response.items[0].externalId).toBeDefined();
+    expect(response.items[0].name).toBeDefined();
+  });
+
+  it('list solutions', async () => {
+    const response = await client.extractors.solutions.list();
+    expect(response.items.length).toBeGreaterThan(0);
+    expect(response.items[0].externalId).toBeDefined();
+    expect(response.items[0].sourceSystemExternalId).toBeDefined();
+  });
+
   it('retrieve extractor by external id', async () => {
     const listResponse = await client.extractors.list();
     const extractor = listResponse.items[0];

--- a/packages/stable/src/__tests__/api/extractors.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/extractors.unit.spec.ts
@@ -2,7 +2,14 @@
 
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
-import type { CogniteClient, Extractor, ExtractorSchema, Link } from '../..';
+import type {
+  CogniteClient,
+  Extractor,
+  ExtractorSchema,
+  Link,
+  Solution,
+  SourceSystem,
+} from '../..';
 import { mockBaseUrl, setupMockableClient } from '../testUtils';
 
 type ItemsResponseWire<T> = {
@@ -32,8 +39,30 @@ const mockSchema: ExtractorSchema = {
   },
 };
 
+const mockSourceSystem: SourceSystem = {
+  externalId: 'cognite-pi',
+  name: 'OSIsoft PI',
+  description: 'PI System',
+  type: 'global',
+};
+
+const mockSolution: Solution = {
+  externalId: 'cognite-pi-pi',
+  name: 'PI to CDF',
+  sourceSystemExternalId: 'cognite-pi',
+  extractorExternalId: 'cognite-pi',
+};
+
 const mockExtractorItemsResponse: ItemsResponseWire<Extractor> = {
   items: [mockExtractor],
+};
+
+const mockSourceSystemItemsResponse: ItemsResponseWire<SourceSystem> = {
+  items: [mockSourceSystem],
+};
+
+const mockSolutionItemsResponse: ItemsResponseWire<Solution> = {
+  items: [mockSolution],
 };
 
 describe('Extractors unit test', () => {
@@ -102,6 +131,58 @@ describe('Extractors unit test', () => {
       { ignoreUnknownIds: true }
     );
     expect(result).toHaveLength(1);
+  });
+
+  test('list source systems', async () => {
+    nock(mockBaseUrl)
+      .get(/\/extractors\/sources\/?$/)
+      .once()
+      .reply(200, mockSourceSystemItemsResponse);
+
+    const response = await client.extractors.sourceSystems.list();
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0]).toEqual(mockSourceSystem);
+  });
+
+  test('retrieve source systems', async () => {
+    nock(mockBaseUrl)
+      .post(/\/extractors\/sources\/byids$/, {
+        items: [{ externalId: 'cognite-pi' }],
+      })
+      .once()
+      .reply(200, mockSourceSystemItemsResponse);
+
+    const result = await client.extractors.sourceSystems.retrieve([
+      { externalId: 'cognite-pi' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(mockSourceSystem);
+  });
+
+  test('list solutions', async () => {
+    nock(mockBaseUrl)
+      .get(/\/extractors\/solutions\/?$/)
+      .once()
+      .reply(200, mockSolutionItemsResponse);
+
+    const response = await client.extractors.solutions.list();
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0]).toEqual(mockSolution);
+  });
+
+  test('retrieve solutions', async () => {
+    nock(mockBaseUrl)
+      .post(/\/extractors\/solutions\/byids$/, {
+        items: [{ externalId: 'cognite-pi-pi' }],
+      })
+      .once()
+      .reply(200, mockSolutionItemsResponse);
+
+    const result = await client.extractors.solutions.retrieve([
+      { externalId: 'cognite-pi-pi' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(mockSolution);
   });
 
   test('getSchema encodes path segments', async () => {

--- a/packages/stable/src/api/extractors/codegen.json
+++ b/packages/stable/src/api/extractors/codegen.json
@@ -2,7 +2,15 @@
   "service": "extractors",
   "filter": {
     "serviceName": "extractors",
-    "relevantReferenceNames": ["Extractor", "ExtractorId", "Link", "LinkType"]
+    "relevantReferenceNames": [
+      "Extractor",
+      "ExtractorId",
+      "Link",
+      "LinkType",
+      "SourceSystem",
+      "Solution",
+      "ItemType"
+    ]
   },
   "inlinedSchemas": {
     "autoNameRequest": true

--- a/packages/stable/src/api/extractors/extractorSolutionsApi.ts
+++ b/packages/stable/src/api/extractors/extractorSolutionsApi.ts
@@ -5,8 +5,7 @@ import {
   type CursorAndAsyncIterator,
   type ExternalId,
 } from '@cognite/sdk-core';
-import type { IgnoreUnknownIds } from '../../types';
-import type { Solution } from './types.gen';
+import type { IgnoreUnknownIds, Solution } from '../../types';
 
 export class ExtractorSolutionsAPI extends BaseResourceAPI<Solution> {
   /**

--- a/packages/stable/src/api/extractors/extractorSolutionsApi.ts
+++ b/packages/stable/src/api/extractors/extractorSolutionsApi.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Cognite AS
+
+import {
+  BaseResourceAPI,
+  type CursorAndAsyncIterator,
+  type ExternalId,
+} from '@cognite/sdk-core';
+import type { IgnoreUnknownIds } from '../../types';
+import type { Solution } from './types.gen';
+
+export class ExtractorSolutionsAPI extends BaseResourceAPI<Solution> {
+  /**
+   * [List solutions](https://docs.cognite.com/20230101/extractors/list-solutions)
+   *
+   * ```js
+   * const solutions = await client.extractors.solutions.list();
+   * ```
+   */
+  public list = (): CursorAndAsyncIterator<Solution> => {
+    return super.listEndpoint(this.callListEndpointWithGet);
+  };
+
+  /**
+   * [Retrieve solutions](https://docs.cognite.com/20230101/extractors/retrieve-solutions)
+   *
+   * ```js
+   * const solutions = await client.extractors.solutions.retrieve([
+   *   { externalId: 'cognite-pi-pi' },
+   * ]);
+   * ```
+   */
+  public retrieve = (
+    ids: ExternalId[],
+    params: IgnoreUnknownIds = {}
+  ): Promise<Solution[]> => {
+    return super.retrieveEndpoint(ids, params);
+  };
+}

--- a/packages/stable/src/api/extractors/extractorSourceSystemsApi.ts
+++ b/packages/stable/src/api/extractors/extractorSourceSystemsApi.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Cognite AS
+
+import {
+  BaseResourceAPI,
+  type CursorAndAsyncIterator,
+  type ExternalId,
+} from '@cognite/sdk-core';
+import type { IgnoreUnknownIds } from '../../types';
+import type { SourceSystem } from './types.gen';
+
+export class ExtractorSourceSystemsAPI extends BaseResourceAPI<SourceSystem> {
+  /**
+   * [List source systems](https://docs.cognite.com/20230101/extractors/list-source-systems)
+   *
+   * ```js
+   * const sourceSystems = await client.extractors.sourceSystems.list();
+   * ```
+   */
+  public list = (): CursorAndAsyncIterator<SourceSystem> => {
+    return super.listEndpoint(this.callListEndpointWithGet);
+  };
+
+  /**
+   * [Retrieve source systems](https://docs.cognite.com/20230101/extractors/retrieve-source-systems)
+   *
+   * ```js
+   * const sourceSystems = await client.extractors.sourceSystems.retrieve([
+   *   { externalId: 'cognite-pi' },
+   * ]);
+   * ```
+   */
+  public retrieve = (
+    ids: ExternalId[],
+    params: IgnoreUnknownIds = {}
+  ): Promise<SourceSystem[]> => {
+    return super.retrieveEndpoint(ids, params);
+  };
+}

--- a/packages/stable/src/api/extractors/extractorSourceSystemsApi.ts
+++ b/packages/stable/src/api/extractors/extractorSourceSystemsApi.ts
@@ -5,8 +5,7 @@ import {
   type CursorAndAsyncIterator,
   type ExternalId,
 } from '@cognite/sdk-core';
-import type { IgnoreUnknownIds } from '../../types';
-import type { SourceSystem } from './types.gen';
+import type { IgnoreUnknownIds, SourceSystem } from '../../types';
 
 export class ExtractorSourceSystemsAPI extends BaseResourceAPI<SourceSystem> {
   /**

--- a/packages/stable/src/api/extractors/extractorsApi.ts
+++ b/packages/stable/src/api/extractors/extractorsApi.ts
@@ -2,12 +2,46 @@
 
 import {
   BaseResourceAPI,
+  type CDFHttpClient,
   type CursorAndAsyncIterator,
   type ExternalId,
+  type MetadataMap,
 } from '@cognite/sdk-core';
 import type { Extractor, ExtractorSchema, IgnoreUnknownIds } from '../../types';
+import { ExtractorSolutionsAPI } from './extractorSolutionsApi';
+import { ExtractorSourceSystemsAPI } from './extractorSourceSystemsApi';
 
 export class ExtractorsAPI extends BaseResourceAPI<Extractor> {
+  private readonly sourceSystemsApi: ExtractorSourceSystemsAPI;
+  private readonly solutionsApi: ExtractorSolutionsAPI;
+
+  /** @hidden */
+  constructor(resourcePath: string, ...args: [CDFHttpClient, MetadataMap]) {
+    super(resourcePath, ...args);
+    this.sourceSystemsApi = new ExtractorSourceSystemsAPI(
+      this.url('sources'),
+      ...args
+    );
+    this.solutionsApi = new ExtractorSolutionsAPI(
+      this.url('solutions'),
+      ...args
+    );
+  }
+
+  /**
+   * [Extractor source systems](https://docs.cognite.com/20230101/extractors/list-source-systems)
+   */
+  public get sourceSystems() {
+    return this.sourceSystemsApi;
+  }
+
+  /**
+   * [Extractor solutions](https://docs.cognite.com/20230101/extractors/list-solutions)
+   */
+  public get solutions() {
+    return this.solutionsApi;
+  }
+
   /**
    * [List extractors](https://docs.cognite.com/20230101/extractors/list-extractors)
    *

--- a/packages/stable/src/api/extractors/types.gen.ts
+++ b/packages/stable/src/api/extractors/types.gen.ts
@@ -62,6 +62,10 @@ export interface ExtractorId {
   externalId: CogniteExternalId;
 }
 /**
+ * Status of this item. "Global" means that it is maintained by Cognite and considered official. "Community" means that it is community made and maintained. "Unreleased" means that it is not yet released and it is visible only as a preview or closed beta.
+ */
+export type ItemType = 'global' | 'community' | 'unreleased';
+/**
  * Link to an external resource for an extractor
  */
 export interface Link {
@@ -82,3 +86,42 @@ export interface Link {
  * Enumeration of link types.
  */
 export type LinkType = 'generic' | 'externalDocumentation';
+/**
+ * A solution represents a connection between an extractor and a source system it can be configured to read from.
+ */
+export interface Solution {
+  /** Long-form documentation of the solution, describing how to use the referenced extractor to connect to the referenced source. */
+  documentation?: string;
+  /** The external ID provided by the client. Must be unique for the resource type. */
+  externalId: CogniteExternalId;
+  /** External ID of the extractor of this solution. */
+  extractorExternalId?: string;
+  /** Solution name. */
+  name: string;
+  /** External ID of the source system of this solution. */
+  sourceSystemExternalId: string;
+  /** Status of this item. "Global" means that it is maintained by Cognite and considered official. "Community" means that it is community made and maintained. "Unreleased" means that it is not yet released and it is visible only as a preview or closed beta. */
+  type?: ItemType;
+}
+/**
+ * A source system representing a source extractors may read from.
+ */
+export interface SourceSystem {
+  /** Short description of the source system. */
+  description: string;
+  /** Long-form description of the source system. */
+  documentation?: string;
+  /** The external ID provided by the client. Must be unique for the resource type. */
+  externalId: CogniteExternalId;
+  /** URL of a publicly hosted logo for the source system. */
+  imageUrl?: string;
+  /** Source system name. */
+  name: string;
+  /**
+   * Tags
+   * A list of tags, used for searching and filtering.
+   */
+  tags?: string[];
+  /** Status of this item. "Global" means that it is maintained by Cognite and considered official. "Community" means that it is community made and maintained. "Unreleased" means that it is not yet released and it is visible only as a preview or closed beta. */
+  type: ItemType;
+}

--- a/packages/stable/src/exports.gen.ts
+++ b/packages/stable/src/exports.gen.ts
@@ -136,8 +136,11 @@ export type {
 export type {
   Extractor,
   ExtractorId,
+  ItemType,
   Link,
   LinkType,
+  Solution,
+  SourceSystem,
 } from './api/extractors/types.gen';
 export type {
   CursorQueryParameter,


### PR DESCRIPTION
## Summary

Part of https://cognitedata.atlassian.net/browse/EDG-862

Stack **2/3**. Adds catalog sub-APIs on top of #1480:

- `client.extractors.sourceSystems.list()` / `retrieve()`
- `client.extractors.solutions.list()` / `retrieve()`
- Expands codegen `relevantReferenceNames` with `SourceSystem`, `Solution`, `ItemType`

**Stack:** #1480 → current PR → #1483