### PR TITLE
feat(stable): add Extractors releases API (3/3)

### DIFF
--- a/packages/stable/src/__tests__/api/extractors.int.spec.ts
+++ b/packages/stable/src/__tests__/api/extractors.int.spec.ts
@@ -15,6 +15,14 @@ describe('extractors api', () => {
     expect(response.items[0].type).toBeDefined();
   });
 
+  it('list releases', async () => {
+    const response = await client.extractors.releases.list();
+    expect(response.items.length).toBeGreaterThan(0);
+    expect(response.items[0].externalId).toBeDefined();
+    expect(response.items[0].version).toBeDefined();
+    expect(response.items[0].artifacts).toBeDefined();
+  });
+
   it('list source systems', async () => {
     const response = await client.extractors.sourceSystems.list();
     expect(response.items.length).toBeGreaterThan(0);
@@ -38,5 +46,18 @@ describe('extractors api', () => {
     ]);
     expect(retrieved).toHaveLength(1);
     expect(retrieved[0].externalId).toBe(extractor.externalId);
+  });
+
+  it('retrieve release by external id and version', async () => {
+    const listResponse = await client.extractors.releases.list();
+    const release = listResponse.items[0];
+
+    const retrieved = await client.extractors.releases.retrieve([
+      { externalId: release.externalId, version: release.version },
+    ]);
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].externalId).toBe(release.externalId);
+    expect(retrieved[0].version).toBe(release.version);
+    expect(retrieved[0].artifacts.length).toBeGreaterThan(0);
   });
 });

--- a/packages/stable/src/__tests__/api/extractors.int.spec.ts
+++ b/packages/stable/src/__tests__/api/extractors.int.spec.ts
@@ -39,6 +39,7 @@ describe('extractors api', () => {
 
   it('retrieve extractor by external id', async () => {
     const listResponse = await client.extractors.list();
+    expect(listResponse.items.length).toBeGreaterThan(0);
     const extractor = listResponse.items[0];
 
     const retrieved = await client.extractors.retrieve([
@@ -50,6 +51,7 @@ describe('extractors api', () => {
 
   it('retrieve release by external id and version', async () => {
     const listResponse = await client.extractors.releases.list();
+    expect(listResponse.items.length).toBeGreaterThan(0);
     const release = listResponse.items[0];
 
     const retrieved = await client.extractors.releases.retrieve([

--- a/packages/stable/src/__tests__/api/extractors.unit.spec.ts
+++ b/packages/stable/src/__tests__/api/extractors.unit.spec.ts
@@ -3,10 +3,13 @@
 import nock from 'nock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import type {
+  Artifact,
+  Changelog,
   CogniteClient,
   Extractor,
   ExtractorSchema,
   Link,
+  Release,
   Solution,
   SourceSystem,
 } from '../..';
@@ -39,6 +42,27 @@ const mockSchema: ExtractorSchema = {
   },
 };
 
+const mockArtifact: Artifact = {
+  name: 'pi-extractor.zip',
+  displayName: 'PI Extractor for Windows',
+  link: '/extractors/artifacts/pi-extractor.zip',
+  platform: 'windows',
+};
+
+const mockChangelog: Changelog = {
+  added: ['PI connectivity'],
+  fixed: ['Connection timeout'],
+};
+
+const mockRelease: Release = {
+  externalId: 'cognite-pi',
+  version: '1.2.3',
+  createdTime: 1700000000000,
+  description: 'Initial release',
+  artifacts: [mockArtifact],
+  changelog: mockChangelog,
+};
+
 const mockSourceSystem: SourceSystem = {
   externalId: 'cognite-pi',
   name: 'OSIsoft PI',
@@ -55,6 +79,10 @@ const mockSolution: Solution = {
 
 const mockExtractorItemsResponse: ItemsResponseWire<Extractor> = {
   items: [mockExtractor],
+};
+
+const mockReleaseItemsResponse: ItemsResponseWire<Release> = {
+  items: [mockRelease],
 };
 
 const mockSourceSystemItemsResponse: ItemsResponseWire<SourceSystem> = {
@@ -128,6 +156,76 @@ describe('Extractors unit test', () => {
 
     const result = await client.extractors.retrieve(
       [{ externalId: 'cognite-pi' }],
+      { ignoreUnknownIds: true }
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  test('list releases', async () => {
+    nock(mockBaseUrl)
+      .get(/\/extractors\/releases\/?$/)
+      .once()
+      .reply(200, mockReleaseItemsResponse);
+
+    const response = await client.extractors.releases.list();
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].version).toBe('1.2.3');
+  });
+
+  test('list releases maps nested fields', async () => {
+    nock(mockBaseUrl)
+      .get(/\/extractors\/releases\/?$/)
+      .once()
+      .reply(200, mockReleaseItemsResponse);
+
+    const response = await client.extractors.releases.list();
+    expect(response.items[0]).toEqual(mockRelease);
+  });
+
+  test('list releases filtered by externalId', async () => {
+    nock(mockBaseUrl)
+      .get(/\/extractors\/releases\/?$/)
+      .query({ externalId: 'cognite-pi' })
+      .once()
+      .reply(200, mockReleaseItemsResponse);
+
+    const response = await client.extractors.releases.list({
+      externalId: 'cognite-pi',
+    });
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].externalId).toBe('cognite-pi');
+  });
+
+  test('retrieve releases', async () => {
+    nock(mockBaseUrl)
+      .post(/\/extractors\/releases\/byids$/, {
+        items: [{ externalId: 'cognite-pi', version: '1.2.3' }],
+      })
+      .once()
+      .reply(200, mockReleaseItemsResponse);
+
+    const result = await client.extractors.releases.retrieve([
+      { externalId: 'cognite-pi', version: '1.2.3' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(mockRelease);
+  });
+
+  test('retrieve releases with ignoreUnknownIds', async () => {
+    nock(mockBaseUrl)
+      .post(/\/extractors\/releases\/byids$/, (body) => {
+        return (
+          body.items?.length === 1 &&
+          body.items[0].externalId === 'cognite-pi' &&
+          body.items[0].version === '1.2.3' &&
+          body.ignoreUnknownIds === true
+        );
+      })
+      .once()
+      .reply(200, mockReleaseItemsResponse);
+
+    const result = await client.extractors.releases.retrieve(
+      [{ externalId: 'cognite-pi', version: '1.2.3' }],
       { ignoreUnknownIds: true }
     );
     expect(result).toHaveLength(1);

--- a/packages/stable/src/api/extractors/codegen.json
+++ b/packages/stable/src/api/extractors/codegen.json
@@ -4,12 +4,14 @@
     "serviceName": "extractors",
     "relevantReferenceNames": [
       "Extractor",
-      "ExtractorId",
-      "Link",
-      "LinkType",
+      "Release",
       "SourceSystem",
       "Solution",
-      "ItemType"
+      "ReleaseId",
+      "ExtractorId",
+      "Artifact",
+      "Link",
+      "Changelog"
     ]
   },
   "inlinedSchemas": {

--- a/packages/stable/src/api/extractors/extractorReleasesApi.ts
+++ b/packages/stable/src/api/extractors/extractorReleasesApi.ts
@@ -4,9 +4,8 @@ import {
   BaseResourceAPI,
   type CursorAndAsyncIterator,
 } from '@cognite/sdk-core';
-import type { IgnoreUnknownIds } from '../../types';
+import type { IgnoreUnknownIds, Release, ReleaseId } from '../../types';
 import type { ExtractorReleasesListQuery } from './types';
-import type { Release, ReleaseId } from './types.gen';
 
 export class ExtractorReleasesAPI extends BaseResourceAPI<Release> {
   /**

--- a/packages/stable/src/api/extractors/extractorReleasesApi.ts
+++ b/packages/stable/src/api/extractors/extractorReleasesApi.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Cognite AS
+
+import {
+  BaseResourceAPI,
+  type CursorAndAsyncIterator,
+} from '@cognite/sdk-core';
+import type { IgnoreUnknownIds } from '../../types';
+import type { ExtractorReleasesListQuery } from './types';
+import type { Release, ReleaseId } from './types.gen';
+
+export class ExtractorReleasesAPI extends BaseResourceAPI<Release> {
+  /**
+   * [List releases](https://docs.cognite.com/20230101/extractors/list-releases)
+   *
+   * ```js
+   * const releases = await client.extractors.releases.list({ externalId: 'cognite-pi' });
+   * ```
+   */
+  public list = (
+    query?: ExtractorReleasesListQuery
+  ): CursorAndAsyncIterator<Release> => {
+    return super.listEndpoint(this.callListEndpointWithGet, query);
+  };
+
+  /**
+   * [Retrieve releases](https://docs.cognite.com/20230101/extractors/retrieve-releases)
+   *
+   * ```js
+   * const releases = await client.extractors.releases.retrieve([
+   *   { externalId: 'cognite-pi', version: '1.2.3' },
+   * ]);
+   * ```
+   */
+  public retrieve = (
+    ids: ReleaseId[],
+    params: IgnoreUnknownIds = {}
+  ): Promise<Release[]> => {
+    return super.retrieveEndpoint(ids, params);
+  };
+}

--- a/packages/stable/src/api/extractors/extractorsApi.ts
+++ b/packages/stable/src/api/extractors/extractorsApi.ts
@@ -8,16 +8,19 @@ import {
   type MetadataMap,
 } from '@cognite/sdk-core';
 import type { Extractor, ExtractorSchema, IgnoreUnknownIds } from '../../types';
+import { ExtractorReleasesAPI } from './extractorReleasesApi';
 import { ExtractorSolutionsAPI } from './extractorSolutionsApi';
 import { ExtractorSourceSystemsAPI } from './extractorSourceSystemsApi';
 
 export class ExtractorsAPI extends BaseResourceAPI<Extractor> {
+  private readonly releasesApi: ExtractorReleasesAPI;
   private readonly sourceSystemsApi: ExtractorSourceSystemsAPI;
   private readonly solutionsApi: ExtractorSolutionsAPI;
 
   /** @hidden */
   constructor(resourcePath: string, ...args: [CDFHttpClient, MetadataMap]) {
     super(resourcePath, ...args);
+    this.releasesApi = new ExtractorReleasesAPI(this.url('releases'), ...args);
     this.sourceSystemsApi = new ExtractorSourceSystemsAPI(
       this.url('sources'),
       ...args
@@ -26,6 +29,13 @@ export class ExtractorsAPI extends BaseResourceAPI<Extractor> {
       this.url('solutions'),
       ...args
     );
+  }
+
+  /**
+   * [Extractor releases](https://docs.cognite.com/20230101/extractors/list-releases)
+   */
+  public get releases() {
+    return this.releasesApi;
   }
 
   /**

--- a/packages/stable/src/api/extractors/types.gen.ts
+++ b/packages/stable/src/api/extractors/types.gen.ts
@@ -3,10 +3,77 @@
 // Instead update the code generation logic or the OpenAPI document.
 
 /**
+ * An artifact for an extractor release.
+ */
+export interface Artifact {
+  /**
+   * Display Name
+   * Human readable name of the artifact.
+   */
+  displayName?: string;
+  /**
+   * Link
+   * Link to obtain a temporary download link for the artifact.
+   */
+  link: string;
+  /**
+   * Name
+   * Filename of the artifact.
+   */
+  name: string;
+  /**
+   * Platform
+   * Platform the extractor runs on. One of "windows", "linux", "macos", "docs", or "all".
+   */
+  platform: 'windows' | 'linux' | 'macos' | 'docs' | 'all';
+}
+/**
+ * Extractor changelog, uses the [keep-a-changelog](https://keepachangelog.com/en/1.1.0/) format
+ */
+export interface Changelog {
+  /**
+   * Added
+   * Features added to this release.
+   */
+  added?: string[];
+  /**
+   * Changed
+   * Changes made to the extractor in this release.
+   */
+  changed?: string[];
+  /**
+   * Deprecated
+   * Features that have been deprecated, but not yet removed.
+   */
+  deprecated?: string[];
+  /**
+   * Fixed
+   * Bugs fixed in this release.
+   */
+  fixed?: string[];
+  /**
+   * Removed
+   * Features that have been removed.
+   */
+  removed?: string[];
+  /**
+   * Security
+   * Changes that affect security.
+   */
+  security?: string[];
+}
+/**
  * The external ID provided by the client. Must be unique for the resource type.
  * @example my.known.id
  */
 export type CogniteExternalId = string;
+/**
+ * The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+ * @format int64
+ * @min 0
+ * @example 1730204346000
+ */
+export type EpochTimestamp = number;
 /**
  * An extractor instance
  */
@@ -86,6 +153,44 @@ export interface Link {
  * Enumeration of link types.
  */
 export type LinkType = 'generic' | 'externalDocumentation';
+/**
+ * A release of an extractor
+ */
+export interface Release {
+  /**
+   * Artifacts
+   * List of artifacts included in this release.
+   */
+  artifacts: Artifact[];
+  /** Extractor changelog, uses the [keep-a-changelog](https://keepachangelog.com/en/1.1.0/) format */
+  changelog?: Changelog;
+  /** The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds. */
+  createdTime?: EpochTimestamp;
+  /**
+   * Description
+   * Short description of this release. Details are found in the changelog.
+   */
+  description?: string;
+  /** The external ID provided by the client. Must be unique for the resource type. */
+  externalId: CogniteExternalId;
+  /**
+   * Version
+   * Release version number, uses semantic versioning.
+   */
+  version: string;
+}
+/**
+ * Identifier for a release
+ */
+export interface ReleaseId {
+  /** The external ID provided by the client. Must be unique for the resource type. */
+  externalId: CogniteExternalId;
+  /**
+   * Version
+   * Release version number, uses semantic versioning.
+   */
+  version: string;
+}
 /**
  * A solution represents a connection between an extractor and a source system it can be configured to read from.
  */

--- a/packages/stable/src/api/extractors/types.ts
+++ b/packages/stable/src/api/extractors/types.ts
@@ -1,3 +1,9 @@
 // Copyright 2026 Cognite AS
 
+import type { FilterQuery } from '@cognite/sdk-core';
+
+export interface ExtractorReleasesListQuery extends FilterQuery {
+  externalId?: string;
+}
+
 export type ExtractorSchema = Record<string, unknown>;

--- a/packages/stable/src/exports.gen.ts
+++ b/packages/stable/src/exports.gen.ts
@@ -134,11 +134,15 @@ export type {
   Space,
 } from './api/documents/types.gen';
 export type {
+  Artifact,
+  Changelog,
   Extractor,
   ExtractorId,
   ItemType,
   Link,
   LinkType,
+  Release,
+  ReleaseId,
   Solution,
   SourceSystem,
 } from './api/extractors/types.gen';


### PR DESCRIPTION
## Summary

Part of https://cognitedata.atlassian.net/browse/EDG-862

Stack **3/3**. Adds releases sub-API on top of #1482:

- `client.extractors.releases.list({ externalId? })` / `retrieve()`
- Full extractors codegen types (`Release`, `ReleaseId`, `Artifact`, `Changelog`, …)
- Manual `ExtractorReleasesListQuery` (extends `FilterQuery`)

 **Stack:** #1480 → #1482 → current PR